### PR TITLE
Implement autonomous editor evidence loop

### DIFF
--- a/.github/agents/godot-evidence-triage.agent.md
+++ b/.github/agents/godot-evidence-triage.agent.md
@@ -16,6 +16,7 @@ Interpret a Godot runtime evidence bundle from its manifest, explain the observe
 
 - Read `.github/copilot-instructions.md`, `AGENTS.md`, and any relevant `.github/instructions/*.instructions.md` file before acting.
 - Start from the evidence manifest and inspect raw artifacts only when the manifest points to them.
+- Stay in post-run diagnosis mode. If the user needs a fresh runtime proof, stop and route to `godot-runtime-verification.agent.md` instead of launching a new evidence run from this artifact.
 - Keep recommendations plugin-first and grounded in structured runtime evidence.
 - If asked to write machine-readable outputs, stay inside `tools/evals/001-agent-tooling-foundation/` and `tools/automation/run-records/` unless a different declared boundary explicitly permits more.
 

--- a/.github/agents/godot-runtime-verification.agent.md
+++ b/.github/agents/godot-runtime-verification.agent.md
@@ -1,0 +1,37 @@
+---
+description: Run Scenegraph Harness runtime verification for a Godot change, combine existing tests when needed, and report the result from manifest-centered evidence.
+---
+
+## Mission
+
+Interpret a Godot change request, choose between ordinary tests, Scenegraph Harness runtime verification, or combined validation, and prove any runtime-visible claim from persisted evidence without broad repo rediscovery.
+
+## Inputs
+
+- Change request or verification request
+- Project root when runtime verification is needed
+- Optional deterministic test command or existing test surface to include in combined validation
+- Optional expected runtime node, hierarchy, or gameplay symptom
+
+## Scope
+
+- Read `.github/copilot-instructions.md`, `AGENTS.md`, and any relevant `.github/instructions/*.instructions.md` file before acting.
+- Route runtime-visible requests to the Scenegraph Harness workflow.
+- If the user already provides an evidence manifest and only wants diagnosis, stop and route to `godot-evidence-triage.agent.md`.
+- For runtime verification from this repository checkout, prefer `tools/automation/get-editor-evidence-capability.ps1` and `tools/automation/request-editor-evidence-run.ps1` over hand-editing broker files.
+- Read the manifest first once a run has persisted evidence.
+- Keep recommendations plugin-first and grounded in structured runtime evidence.
+
+## Stop conditions
+
+- Capability is blocked, missing, or schema-invalid.
+- Final run result is blocked or failed before a persisted bundle is available.
+- The task requires fabricating a new ordinary test suite only to satisfy combined validation.
+- The requested work requires writes outside a declared boundary for any autonomous artifact involved.
+
+## Expected outputs
+
+- The selected validation mode with a short reason
+- The runtime verification outcome or explicit blocked reason
+- Whether existing ordinary tests were also run or should run
+- The next validation or debugging step grounded in the manifest or run result

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -17,6 +17,10 @@ This repository builds a plugin-first Godot harness that gives coding agents mac
 - Stay plugin-first: prefer addon, autoload, debugger, and GDExtension layers before considering engine changes.
 - Treat `../godot` as a read-only reference checkout when engine behavior needs confirmation.
 - When runtime evidence exists, read the manifest first and inspect raw artifacts only as needed.
+- Use three validation modes consistently: ordinary tests, Scenegraph Harness runtime verification, and combined validation.
+- Choose Scenegraph Harness runtime verification for requests about runtime-visible behavior, what appears in game, node presence, hierarchy, or other outcomes that must be proven from a running project.
+- Choose combined validation when a change affects runtime-visible behavior and there is already an existing deterministic test surface; run the existing tests plus the runtime harness flow, but do not invent new ordinary tests solely to satisfy the rule.
+- When routing to runtime verification from this repository checkout, prefer the workspace-side helper flow: check capability, request a brokered run, then read the persisted evidence manifest first. Treat blocked or missing capability and run-result artifacts as explicit unsupported states.
 - Keep repo-wide guidance concise. Put durable rules here, agent operating workflow in `AGENTS.md`, and subtree-specific constraints in `.github/instructions/`.
 - For the current agent-tooling foundation work, prefer changes in `.github/`, `docs/`, `tools/`, and `specs/001-agent-tooling-foundation/` unless the task explicitly requires addon or scenario edits.
 

--- a/.github/prompts/godot-evidence-triage.prompt.md
+++ b/.github/prompts/godot-evidence-triage.prompt.md
@@ -21,8 +21,9 @@ Summarize a manifest-centered evidence bundle, identify the most relevant failin
 
 1. Read the manifest first and summarize status, scenario, and key findings.
 2. Use invariant and artifact references to choose the next raw file to inspect.
-3. Keep recommendations plugin-first and scoped to addon, debugger, GDExtension, or tooling layers.
-4. If the requested follow-up would require writes outside the declared boundary, stop and say so.
+3. Stay in post-run diagnosis mode. If the user needs proof from a fresh run rather than diagnosis of an existing bundle, hand off to `godot-runtime-verification.prompt.md`.
+4. Keep recommendations plugin-first and scoped to addon, debugger, GDExtension, or tooling layers.
+5. If the requested follow-up would require writes outside the declared boundary, stop and say so.
 
 ## Output
 

--- a/.github/prompts/godot-runtime-verification.prompt.md
+++ b/.github/prompts/godot-runtime-verification.prompt.md
@@ -1,0 +1,36 @@
+---
+description: Verify a Godot runtime-visible change with the Scenegraph Harness, combine existing tests when needed, and prove the outcome from persisted evidence.
+---
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+## Goal
+
+Choose the correct validation mode for a Godot change, perform Scenegraph Harness runtime verification when the request is about running-game behavior, and keep ordinary tests in scope when the change also has an existing deterministic test surface.
+
+## Routing rules
+
+1. Use ordinary tests only for unit, contract, framework, or schema checks that do not ask about the running game.
+2. Use Scenegraph Harness runtime verification for requests such as "verify at runtime," "test the running code," "make sure the node appears in game," "confirm the node exists while playing," or other runtime-visible outcomes.
+3. Use combined validation when the change affects runtime-visible behavior and there is already a direct deterministic test surface. Run the existing tests plus the runtime harness flow, but do not invent new ordinary tests solely to satisfy the combined rule.
+4. If the user already provides an evidence manifest and only wants diagnosis, hand the task to `godot-evidence-triage.prompt.md` instead of starting a fresh run.
+
+## Runtime verification workflow
+
+1. Confirm harness availability and read the latest capability artifact first. From this repository checkout, prefer `pwsh ./tools/automation/get-editor-evidence-capability.ps1 -ProjectRoot <game-root>`.
+2. If capability is blocked, missing, or schema-invalid, report that blocked state explicitly instead of guessing around the editor.
+3. Submit a brokered run request through the workspace-side helper: `pwsh ./tools/automation/request-editor-evidence-run.ps1 -ProjectRoot <game-root> -RequestFixturePath <fixture-path>`.
+4. Wait for the final run result and persisted evidence bundle.
+5. Read the evidence manifest first, then the summary, then diagnostics or snapshot only if needed.
+6. Separate gameplay failures from harness wiring or automation failures such as missing autoload setup, blocked capability, or no persisted bundle.
+
+## Output
+
+- Selected validation mode
+- Runtime evidence result or blocked reason
+- Whether ordinary tests were also required
+- Next concrete validation or debugging step

--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/002-inspect-scene-tree"
+  "feature_directory": "specs/003-editor-evidence-loop"
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,6 +19,15 @@ Use this file as the agent-facing operating guide for work in this repository.
 - Do not duplicate large guidance blocks across files. Link or point to the canonical layer instead.
 - Treat `../godot` as reference-only unless the task explicitly asks for engine investigation.
 
+## Validation routing
+
+- Use **ordinary tests** for unit, contract, framework, and other non-runtime checks.
+- Use **Scenegraph Harness runtime verification** for requests such as "verify at runtime," "test the running code," "make sure the node appears in game," "confirm the node exists while playing," or other runtime-visible outcomes.
+- Use **combined validation** when a change affects runtime-visible behavior and there is already a deterministic direct test surface. Run the existing tests and the runtime harness flow together, but do not fabricate new ordinary tests only to satisfy the combined rule.
+- If the user already supplies an evidence manifest and wants diagnosis, stay in manifest-centered evidence triage instead of launching a fresh runtime-verification run.
+- For runtime verification in this repository, prefer `pwsh ./tools/automation/get-editor-evidence-capability.ps1` and `pwsh ./tools/automation/request-editor-evidence-run.ps1`, then inspect the persisted bundle manifest first.
+- Treat blocked capability artifacts, blocked run results, or missing persisted bundles as explicit stop conditions. Report them plainly instead of guessing around the editor.
+
 ## Validation expectations
 
 - Validate repository JSON outputs with `pwsh ./tools/validate-json.ps1` and the matching schema.

--- a/README.md
+++ b/README.md
@@ -82,7 +82,9 @@ That plugin action installs the project-level assets the agent needs:
 - `.github/copilot-instructions.md` managed runtime-harness block
 - `AGENTS.md` managed runtime-harness block
 - `.github/prompts/godot-evidence-triage.prompt.md`
+- `.github/prompts/godot-runtime-verification.prompt.md`
 - `.github/agents/godot-evidence-triage.agent.md`
+- `.github/agents/godot-runtime-verification.agent.md`
 - `harness/inspection-run-config.json`
 - `project.godot` wiring for the harness autoload and config path
 
@@ -114,6 +116,12 @@ For the autonomous editor evidence loop, the current workspace-side entry points
 - `pwsh ./tools/automation/request-editor-evidence-run.ps1 -ProjectRoot <game-root> -RequestFixturePath <fixture-path>`
 
 These helpers target the plugin-owned file broker under `harness/automation/requests/` and `harness/automation/results/`.
+
+Agent guidance now routes validation through three modes:
+
+- ordinary tests for unit, contract, or framework checks that do not ask about the running game
+- Scenegraph Harness runtime verification for runtime-visible outcomes such as what appears in game or whether a node exists while playing
+- combined validation when a change affects runtime-visible behavior and an existing deterministic test surface should also run
 
 ## Development discipline
 

--- a/README.md
+++ b/README.md
@@ -108,6 +108,13 @@ The repository uses a Copilot-first guidance stack for agent work:
 - `.github/prompts/` and `.github/agents/` for reusable Copilot-native workflows
 - `tools/evals/001-agent-tooling-foundation/` for seeded eval prompts and machine-readable result files
 
+For the autonomous editor evidence loop, the current workspace-side entry points are:
+
+- `pwsh ./tools/automation/get-editor-evidence-capability.ps1 -ProjectRoot <game-root>`
+- `pwsh ./tools/automation/request-editor-evidence-run.ps1 -ProjectRoot <game-root> -RequestFixturePath <fixture-path>`
+
+These helpers target the plugin-owned file broker under `harness/automation/requests/` and `harness/automation/results/`.
+
 ## Development discipline
 
 Feature work in this repository follows a plugin-first constitution:

--- a/addons/agent_runtime_harness/editor/agent_asset_deployer.gd
+++ b/addons/agent_runtime_harness/editor/agent_asset_deployer.gd
@@ -68,6 +68,8 @@ func deploy_into_project() -> Dictionary:
 		project_content = _set_ini_property(project_content, "autoload", "ScenegraphHarness", '"*res://addons/agent_runtime_harness/runtime/scenegraph_autoload.gd"')
 		project_content = _add_packed_string_array_value(project_content, "editor_plugins", "enabled", "res://addons/agent_runtime_harness/plugin.cfg")
 		project_content = _set_ini_property(project_content, "harness", "inspection_run_config", '"res://harness/inspection-run-config.json"')
+		project_content = _set_ini_property(project_content, "harness", "automation_request_path", '"res://harness/automation/requests/run-request.json"')
+		project_content = _set_ini_property(project_content, "harness", "automation_results_directory", '"res://harness/automation/results"')
 		var project_write_result := _write_text(PROJECT_FILE, project_content)
 		operations.append(_build_write_operation(PROJECT_FILE, project_write_result, "updated"))
 		if project_write_result != OK:

--- a/addons/agent_runtime_harness/editor/scenegraph_automation_artifact_store.gd
+++ b/addons/agent_runtime_harness/editor/scenegraph_automation_artifact_store.gd
@@ -1,0 +1,153 @@
+@tool
+extends RefCounted
+class_name ScenegraphAutomationArtifactStore
+
+const InspectionConstants = preload("res://addons/agent_runtime_harness/shared/inspection_constants.gd")
+
+
+func read_json(path: String) -> Variant:
+	if path.is_empty() or not FileAccess.file_exists(path):
+		return null
+
+	var handle := FileAccess.open(path, FileAccess.READ)
+	if handle == null:
+		return null
+
+	var parsed := JSON.parse_string(handle.get_as_text())
+	handle.close()
+	return parsed
+
+
+func ensure_automation_layout(config: Dictionary) -> void:
+	var automation: Dictionary = config.get("automation", {})
+	_ensure_directory(String(automation.get("requestsDirectory", "res://harness/automation/requests")))
+	_ensure_directory(String(automation.get("resultsDirectory", "res://harness/automation/results")))
+
+
+func read_request(config: Dictionary) -> Dictionary:
+	var request_path := get_request_path(config)
+	var parsed = read_json(request_path)
+	if typeof(parsed) != TYPE_DICTIONARY:
+		return {}
+	return parsed
+
+
+func clear_request(config: Dictionary) -> void:
+	var request_path := get_request_path(config)
+	if FileAccess.file_exists(request_path):
+		DirAccess.remove_absolute(ProjectSettings.globalize_path(request_path))
+
+
+func write_capability_result(config: Dictionary, payload: Dictionary) -> Dictionary:
+	var result_path := get_capability_result_path(config)
+	return _write_json_atomically(result_path, payload)
+
+
+func write_lifecycle_status(config: Dictionary, payload: Dictionary) -> Dictionary:
+	var result_path := get_lifecycle_status_path(config)
+	return _write_json_atomically(result_path, payload)
+
+
+func write_run_result(config: Dictionary, payload: Dictionary) -> Dictionary:
+	var result_path := get_run_result_path(config)
+	return _write_json_atomically(result_path, payload)
+
+
+func get_request_path(config: Dictionary) -> String:
+	var automation: Dictionary = config.get("automation", {})
+	return String(automation.get("requestPath", "res://harness/automation/requests/run-request.json"))
+
+
+func get_capability_result_path(config: Dictionary) -> String:
+	var automation: Dictionary = config.get("automation", {})
+	return String(automation.get("capabilityResultPath", "res://harness/automation/results/capability.json"))
+
+
+func get_lifecycle_status_path(config: Dictionary) -> String:
+	var automation: Dictionary = config.get("automation", {})
+	return String(automation.get("lifecycleStatusPath", "res://harness/automation/results/lifecycle-status.json"))
+
+
+func get_run_result_path(config: Dictionary) -> String:
+	var automation: Dictionary = config.get("automation", {})
+	return String(automation.get("runResultPath", "res://harness/automation/results/run-result.json"))
+
+
+func load_harness_config(config_path: String) -> Dictionary:
+	var parsed = read_json(config_path)
+	if typeof(parsed) != TYPE_DICTIONARY:
+		return {}
+	return parsed
+
+
+func build_status_payload(request_id: String, run_id: String, status: String, details: String, extras := {}) -> Dictionary:
+	var payload := {
+		"requestId": request_id,
+		"runId": run_id,
+		"status": status,
+		"details": details,
+		"timestamp": InspectionConstants.utc_timestamp_now(),
+	}
+	for key in extras.keys():
+		payload[key] = extras[key]
+	return payload
+
+
+func build_validation_result(manifest: Dictionary, missing_artifacts: Array, bundle_valid: bool, notes: Array) -> Dictionary:
+	return {
+		"manifestExists": not manifest.is_empty(),
+		"artifactRefsChecked": int(manifest.get("artifactRefs", []).size()),
+		"missingArtifacts": missing_artifacts.duplicate(true),
+		"bundleValid": bundle_valid,
+		"notes": notes.duplicate(true),
+		"validatedAt": InspectionConstants.utc_timestamp_now(),
+	}
+
+
+func _write_json_atomically(path: String, payload: Variant) -> Dictionary:
+	var parent_directory := path.get_base_dir()
+	_ensure_directory(parent_directory)
+
+	var temp_path := "%s.%s.tmp" % [path, str(Time.get_ticks_usec())]
+	var write_error := _write_json(temp_path, payload)
+	if not write_error.is_empty():
+		return {
+			"ok": false,
+			"path": path,
+			"error": write_error,
+		}
+
+	var absolute_temp := ProjectSettings.globalize_path(temp_path)
+	var absolute_target := ProjectSettings.globalize_path(path)
+	if FileAccess.file_exists(path):
+		DirAccess.remove_absolute(absolute_target)
+
+	var rename_error := DirAccess.rename_absolute(absolute_temp, absolute_target)
+	if rename_error != OK:
+		DirAccess.remove_absolute(absolute_temp)
+		return {
+			"ok": false,
+			"path": path,
+			"error": "Could not move %s into place (%s)." % [path, error_string(rename_error)],
+		}
+
+	return {
+		"ok": true,
+		"path": path,
+	}
+
+
+func _write_json(path: String, payload: Variant) -> String:
+	var handle := FileAccess.open(path, FileAccess.WRITE)
+	if handle == null:
+		return "Could not open %s for writing (%s)." % [path, error_string(FileAccess.get_open_error())]
+
+	handle.store_string(JSON.stringify(payload, "\t"))
+	handle.close()
+	return ""
+
+
+func _ensure_directory(path: String) -> void:
+	if path.is_empty():
+		return
+	DirAccess.make_dir_recursive_absolute(ProjectSettings.globalize_path(path))

--- a/addons/agent_runtime_harness/editor/scenegraph_automation_broker.gd
+++ b/addons/agent_runtime_harness/editor/scenegraph_automation_broker.gd
@@ -15,6 +15,7 @@ var _artifact_store := ScenegraphAutomationArtifactStore.new()
 var _run_coordinator := ScenegraphRunCoordinator.new()
 var _config_path := "res://harness/inspection-run-config.json"
 var _poll_timer: Timer
+var _last_capability_signature := ""
 
 
 func configure(plugin: EditorPlugin, bridge: Object, config_path: String = "res://harness/inspection-run-config.json") -> void:
@@ -51,8 +52,7 @@ func _on_poll_timer_timeout() -> void:
 
 	_artifact_store.ensure_automation_layout(config)
 	var capability := evaluate_capability(config)
-	_artifact_store.write_capability_result(config, capability)
-	emit_signal("capability_updated", capability)
+	_publish_capability_if_needed(config, capability)
 
 	if _run_coordinator.is_active():
 		_run_coordinator.poll()
@@ -63,7 +63,7 @@ func _on_poll_timer_timeout() -> void:
 		return
 
 	_artifact_store.clear_request(config)
-	_run_coordinator.start_run(config, request, capability)
+	_run_coordinator.start_run(config, request, capability, _config_path)
 
 
 func evaluate_capability(config: Dictionary) -> Dictionary:
@@ -76,7 +76,6 @@ func evaluate_capability(config: Dictionary) -> Dictionary:
 	var persistence_available := not String(config.get("outputDirectory", "")).is_empty()
 	var validation_available := persistence_available
 	var shutdown_control_available := true
-	var single_target_ready := true
 
 	if target_scene.is_empty():
 		blocked_reasons.append("target_scene_missing")
@@ -84,8 +83,10 @@ func evaluate_capability(config: Dictionary) -> Dictionary:
 		blocked_reasons.append("harness_autoload_missing")
 	if _run_coordinator.is_active():
 		blocked_reasons.append("run_in_progress")
-	if EditorInterface.is_playing_scene() and not _run_coordinator.is_active():
+	if _is_playing_scene() and not _run_coordinator.is_active():
 		blocked_reasons.append("scene_already_running")
+	var deduped_blocked_reasons := _dedupe_strings(blocked_reasons)
+	var single_target_ready := deduped_blocked_reasons.is_empty()
 
 	return {
 		"checkedAt": InspectionConstants.utc_timestamp_now(),
@@ -97,12 +98,24 @@ func evaluate_capability(config: Dictionary) -> Dictionary:
 		"persistenceAvailable": persistence_available,
 		"validationAvailable": validation_available,
 		"shutdownControlAvailable": shutdown_control_available,
-		"blockedReasons": _dedupe_strings(blocked_reasons),
+		"blockedReasons": deduped_blocked_reasons,
 		"recommendedControlPath": InspectionConstants.AUTOMATION_CONTROL_PATH_FILE_BROKER,
 		"notes": [
 			"The preferred v1 control surface is the plugin-owned workspace file broker."
 		],
 	}
+
+
+func _publish_capability_if_needed(config: Dictionary, capability: Dictionary) -> void:
+	var signature_payload := capability.duplicate(true)
+	signature_payload.erase("checkedAt")
+	var signature := JSON.stringify(signature_payload)
+	if signature == _last_capability_signature and FileAccess.file_exists(_artifact_store.get_capability_result_path(config)):
+		return
+
+	_last_capability_signature = signature
+	_artifact_store.write_capability_result(config, capability)
+	emit_signal("capability_updated", capability)
 
 
 func _dedupe_strings(values: Array) -> Array:
@@ -113,6 +126,15 @@ func _dedupe_strings(values: Array) -> Array:
 			continue
 		deduped.append(text)
 	return deduped
+
+
+func _is_playing_scene() -> bool:
+	if _plugin == null:
+		return false
+	var editor_interface = _plugin.get_editor_interface()
+	if editor_interface == null:
+		return false
+	return editor_interface.is_playing_scene()
 
 
 func _on_run_completed(result: Dictionary) -> void:

--- a/addons/agent_runtime_harness/editor/scenegraph_automation_broker.gd
+++ b/addons/agent_runtime_harness/editor/scenegraph_automation_broker.gd
@@ -1,0 +1,119 @@
+@tool
+extends Node
+class_name ScenegraphAutomationBroker
+
+const InspectionConstants = preload("res://addons/agent_runtime_harness/shared/inspection_constants.gd")
+const ScenegraphAutomationArtifactStore = preload("res://addons/agent_runtime_harness/editor/scenegraph_automation_artifact_store.gd")
+const ScenegraphRunCoordinator = preload("res://addons/agent_runtime_harness/editor/scenegraph_run_coordinator.gd")
+
+signal capability_updated(result)
+signal run_result_updated(result)
+
+var _plugin: EditorPlugin
+var _bridge
+var _artifact_store := ScenegraphAutomationArtifactStore.new()
+var _run_coordinator := ScenegraphRunCoordinator.new()
+var _config_path := "res://harness/inspection-run-config.json"
+var _poll_timer: Timer
+
+
+func configure(plugin: EditorPlugin, bridge: Object, config_path: String = "res://harness/inspection-run-config.json") -> void:
+	_plugin = plugin
+	_bridge = bridge
+	_config_path = config_path
+	_run_coordinator.configure(plugin, bridge, _artifact_store)
+	_run_coordinator.run_completed.connect(_on_run_completed)
+
+	if _bridge != null:
+		_bridge.session_state_changed.connect(_run_coordinator.handle_session_state_changed)
+		_bridge.capture_updated.connect(_run_coordinator.handle_capture_updated)
+		_bridge.manifest_persisted.connect(_run_coordinator.handle_manifest_persisted)
+		_bridge.transport_error.connect(_run_coordinator.handle_transport_error)
+
+	if _poll_timer == null:
+		_poll_timer = Timer.new()
+		_poll_timer.wait_time = 0.5
+		_poll_timer.one_shot = false
+		_poll_timer.autostart = true
+		_poll_timer.timeout.connect(_on_poll_timer_timeout)
+		add_child(_poll_timer)
+
+
+func _ready() -> void:
+	if _poll_timer != null and _poll_timer.is_stopped():
+		_poll_timer.start()
+
+
+func _on_poll_timer_timeout() -> void:
+	var config := _artifact_store.load_harness_config(_config_path)
+	if config.is_empty():
+		return
+
+	_artifact_store.ensure_automation_layout(config)
+	var capability := evaluate_capability(config)
+	_artifact_store.write_capability_result(config, capability)
+	emit_signal("capability_updated", capability)
+
+	if _run_coordinator.is_active():
+		_run_coordinator.poll()
+		return
+
+	var request := _artifact_store.read_request(config)
+	if request.is_empty():
+		return
+
+	_artifact_store.clear_request(config)
+	_run_coordinator.start_run(config, request, capability)
+
+
+func evaluate_capability(config: Dictionary) -> Dictionary:
+	var blocked_reasons: Array = []
+	var target_scene := String(config.get("targetScene", ""))
+	var harness_autoload := String(ProjectSettings.get_setting("autoload/ScenegraphHarness", ""))
+	var launch_control_available := not target_scene.is_empty()
+	var runtime_bridge_available := _bridge != null and not harness_autoload.is_empty()
+	var capture_control_available := runtime_bridge_available
+	var persistence_available := not String(config.get("outputDirectory", "")).is_empty()
+	var validation_available := persistence_available
+	var shutdown_control_available := true
+	var single_target_ready := true
+
+	if target_scene.is_empty():
+		blocked_reasons.append("target_scene_missing")
+	if harness_autoload.is_empty():
+		blocked_reasons.append("harness_autoload_missing")
+	if _run_coordinator.is_active():
+		blocked_reasons.append("run_in_progress")
+	if EditorInterface.is_playing_scene() and not _run_coordinator.is_active():
+		blocked_reasons.append("scene_already_running")
+
+	return {
+		"checkedAt": InspectionConstants.utc_timestamp_now(),
+		"projectIdentifier": ProjectSettings.globalize_path("res://"),
+		"singleTargetReady": single_target_ready,
+		"launchControlAvailable": launch_control_available,
+		"runtimeBridgeAvailable": runtime_bridge_available,
+		"captureControlAvailable": capture_control_available,
+		"persistenceAvailable": persistence_available,
+		"validationAvailable": validation_available,
+		"shutdownControlAvailable": shutdown_control_available,
+		"blockedReasons": _dedupe_strings(blocked_reasons),
+		"recommendedControlPath": InspectionConstants.AUTOMATION_CONTROL_PATH_FILE_BROKER,
+		"notes": [
+			"The preferred v1 control surface is the plugin-owned workspace file broker."
+		],
+	}
+
+
+func _dedupe_strings(values: Array) -> Array:
+	var deduped: Array = []
+	for value in values:
+		var text := String(value)
+		if text.is_empty() or text in deduped:
+			continue
+		deduped.append(text)
+	return deduped
+
+
+func _on_run_completed(result: Dictionary) -> void:
+	emit_signal("run_result_updated", result)

--- a/addons/agent_runtime_harness/editor/scenegraph_debugger_bridge.gd
+++ b/addons/agent_runtime_harness/editor/scenegraph_debugger_bridge.gd
@@ -8,6 +8,7 @@ signal session_state_changed(state, details)
 signal capture_updated(snapshot, diagnostics)
 signal manifest_persisted(manifest)
 signal transport_error(message)
+signal automation_session_configured(session_context)
 
 var _session_context := {}
 var _latest_snapshot := {}
@@ -51,6 +52,10 @@ func _capture(message: String, data: Array, session_id: int) -> bool:
 			if not data.is_empty():
 				_on_persistence_completed(data[0])
 			return true
+		"session_configured":
+			if not data.is_empty() and typeof(data[0]) == TYPE_DICTIONARY:
+				_on_session_configured(data[0])
+			return true
 		"runtime_error":
 			if not data.is_empty():
 				_on_runtime_error(String(data[0]))
@@ -79,6 +84,16 @@ func get_latest_diagnostics() -> Array:
 	return _latest_diagnostics.duplicate(true)
 
 
+func has_active_session() -> bool:
+	return _get_active_session() != null
+
+
+func get_active_session_id() -> int:
+	if _get_active_session() == null:
+		return -1
+	return _active_session_id
+
+
 func _on_capture_ready(snapshot: Dictionary, diagnostics: Array) -> void:
 	_latest_snapshot = snapshot.duplicate(true)
 	_latest_diagnostics = diagnostics.duplicate(true)
@@ -89,6 +104,11 @@ func _on_capture_ready(snapshot: Dictionary, diagnostics: Array) -> void:
 func _on_persistence_completed(manifest: Dictionary) -> void:
 	emit_signal("session_state_changed", "persisted", "Scenegraph evidence bundle written.")
 	emit_signal("manifest_persisted", manifest)
+
+
+func _on_session_configured(session_context: Dictionary) -> void:
+	emit_signal("session_state_changed", "configured", "Runtime automation session configured.")
+	emit_signal("automation_session_configured", session_context)
 
 
 func _on_runtime_error(message: String) -> void:

--- a/addons/agent_runtime_harness/editor/scenegraph_run_coordinator.gd
+++ b/addons/agent_runtime_harness/editor/scenegraph_run_coordinator.gd
@@ -23,6 +23,7 @@ var _awaiting_manifest := false
 var _awaiting_stop := false
 var _stop_requested := false
 var _launch_started_at_usec := 0
+var _active_config_path := ""
 
 
 func configure(plugin: EditorPlugin, bridge: Object, artifact_store: Object) -> void:
@@ -35,9 +36,10 @@ func is_active() -> bool:
 	return _active
 
 
-func start_run(config: Dictionary, request: Dictionary, capability: Dictionary) -> Dictionary:
+func start_run(config: Dictionary, request: Dictionary, capability: Dictionary, config_path: String = "") -> Dictionary:
 	_active_config = config.duplicate(true)
 	_active_request = _resolve_request(config, request)
+	_active_config_path = config_path
 	_last_manifest = {}
 	_last_validation = _build_validation_result(false, 0, [], false, ["Validation has not completed yet."])
 	_pending_failure_kind = null
@@ -60,7 +62,10 @@ func start_run(config: Dictionary, request: Dictionary, capability: Dictionary) 
 	_awaiting_manifest = false
 
 	_bridge.set_session_context(_build_session_context())
-	EditorInterface.play_custom_scene(String(_active_request.get("targetScene", "")))
+	var editor_interface = _get_editor_interface()
+	if editor_interface == null:
+		return _finish_blocked_run(["editor_interface_unavailable"])
+	editor_interface.play_custom_scene(String(_active_request.get("targetScene", "")))
 	return {
 		"ok": true,
 		"requestId": _active_request.get("requestId", ""),
@@ -78,7 +83,7 @@ func poll() -> void:
 			_fail_run(InspectionConstants.AUTOMATION_FAILURE_KIND_ATTACHMENT, "Runtime debugger session did not attach before timeout.")
 			return
 
-	if _awaiting_stop and not EditorInterface.is_playing_scene():
+	if _awaiting_stop and not _is_playing_scene():
 		_finalize_after_stop(InspectionConstants.AUTOMATION_TERMINATION_STOPPED_CLEANLY)
 
 
@@ -177,8 +182,10 @@ func _request_stop() -> void:
 	_stop_requested = true
 	_awaiting_stop = true
 	_emit_status(InspectionConstants.AUTOMATION_STATUS_STOPPING, "Stopping the editor play session after validation.")
-	EditorInterface.stop_playing_scene()
-	if not EditorInterface.is_playing_scene():
+	var editor_interface = _get_editor_interface()
+	if editor_interface != null:
+		editor_interface.stop_playing_scene()
+	if not _is_playing_scene():
 		_finalize_after_stop(InspectionConstants.AUTOMATION_TERMINATION_STOPPED_CLEANLY)
 
 
@@ -222,7 +229,7 @@ func _fail_run(failure_kind: String, message: String) -> void:
 		"failureKind": failure_kind,
 	})
 
-	if _should_stop_after_validation() and EditorInterface.is_playing_scene() and not _stop_requested:
+	if _should_stop_after_validation() and _is_playing_scene() and not _stop_requested:
 		_pending_failure_kind = failure_kind
 		_pending_failure_message = message
 		_request_stop()
@@ -235,6 +242,12 @@ func _finalize_run(final_status: String, failure_kind, termination_status: Strin
 	var manifest_path = null
 	if not _last_manifest.is_empty():
 		manifest_path = _resolve_manifest_repo_path()
+	var validation_result := _last_validation.duplicate(true)
+	if not note.is_empty():
+		var validation_notes: Array = validation_result.get("notes", []).duplicate(true)
+		if not note in validation_notes:
+			validation_notes.append(note)
+		validation_result["notes"] = validation_notes
 
 	var result := {
 		"requestId": String(_active_request.get("requestId", "")),
@@ -243,14 +256,12 @@ func _finalize_run(final_status: String, failure_kind, termination_status: Strin
 		"failureKind": failure_kind,
 		"manifestPath": manifest_path,
 		"outputDirectory": String(_active_request.get("outputDirectory", "")),
-		"validationResult": _last_validation.duplicate(true),
+		"validationResult": validation_result,
 		"terminationStatus": termination_status,
 		"blockedReasons": [],
 		"controlPath": InspectionConstants.AUTOMATION_CONTROL_PATH_FILE_BROKER,
 		"completedAt": InspectionConstants.utc_timestamp_now(),
 	}
-	if not note.is_empty():
-		result["blockedReasons"] = [note]
 	_artifact_store.write_run_result(_active_config, result)
 	emit_signal("run_completed", result)
 	_reset_state()
@@ -268,9 +279,25 @@ func _emit_status(status: String, details: String, extras := {}) -> void:
 	emit_signal("lifecycle_status_written", payload)
 
 
+func _resolve_active_config_path() -> String:
+	if not _active_config_path.is_empty():
+		return _active_config_path
+
+	for source in [_active_request, _active_config]:
+		var camel_case_path := String(source.get("configPath", ""))
+		if not camel_case_path.is_empty():
+			return camel_case_path
+
+		var snake_case_path := String(source.get("config_path", ""))
+		if not snake_case_path.is_empty():
+			return snake_case_path
+
+	return "res://harness/inspection-run-config.json"
+
+
 func _build_session_context() -> Dictionary:
 	return {
-		"config_path": "res://harness/inspection-run-config.json",
+		"config_path": _resolve_active_config_path(),
 		"session_id": String(_active_request.get("requestId", "")),
 		"request_id": String(_active_request.get("requestId", "")),
 		"run_id": String(_active_request.get("runId", "")),
@@ -279,6 +306,7 @@ func _build_session_context() -> Dictionary:
 		"output_directory": String(_active_request.get("outputDirectory", InspectionConstants.DEFAULT_OUTPUT_DIRECTORY)),
 		"artifact_root": String(_active_request.get("artifactRoot", InspectionConstants.DEFAULT_MANIFEST_ARTIFACT_ROOT)),
 		"capture_policy": _active_request.get("capturePolicy", {}).duplicate(true),
+		"stop_policy": _active_request.get("stopPolicy", {}).duplicate(true),
 	}
 
 
@@ -293,7 +321,7 @@ func _collect_blocked_reasons(capability: Dictionary) -> Array:
 		blocked.append("run_id_missing")
 	if String(_active_request.get("targetScene", "")).is_empty():
 		blocked.append("target_scene_missing")
-	if EditorInterface.is_playing_scene():
+	if _is_playing_scene():
 		blocked.append("scene_already_running")
 
 	var capture_policy: Dictionary = _active_request.get("capturePolicy", {})
@@ -421,7 +449,7 @@ func _build_snapshot_refs(snapshot: Dictionary, diagnostics: Array) -> Array:
 func _derive_failure_termination_status() -> String:
 	if _stop_requested:
 		return InspectionConstants.AUTOMATION_TERMINATION_SHUTDOWN_FAILED
-	if EditorInterface.is_playing_scene():
+	if _is_playing_scene():
 		return InspectionConstants.AUTOMATION_TERMINATION_RUNNING
 	return InspectionConstants.AUTOMATION_TERMINATION_ALREADY_CLOSED
 
@@ -448,6 +476,19 @@ func _dedupe_strings(values: Array) -> Array:
 	return deduped
 
 
+func _get_editor_interface():
+	if _plugin == null:
+		return null
+	return _plugin.get_editor_interface()
+
+
+func _is_playing_scene() -> bool:
+	var editor_interface = _get_editor_interface()
+	if editor_interface == null:
+		return false
+	return editor_interface.is_playing_scene()
+
+
 func _reset_state() -> void:
 	_active = false
 	_awaiting_runtime = false
@@ -462,3 +503,4 @@ func _reset_state() -> void:
 	_last_manifest = {}
 	_last_validation = {}
 	_launch_started_at_usec = 0
+	_active_config_path = ""

--- a/addons/agent_runtime_harness/editor/scenegraph_run_coordinator.gd
+++ b/addons/agent_runtime_harness/editor/scenegraph_run_coordinator.gd
@@ -1,0 +1,464 @@
+@tool
+extends RefCounted
+class_name ScenegraphRunCoordinator
+
+const InspectionConstants = preload("res://addons/agent_runtime_harness/shared/inspection_constants.gd")
+
+signal lifecycle_status_written(payload)
+signal run_completed(result)
+
+var _plugin: EditorPlugin
+var _bridge
+var _artifact_store
+var _active_config := {}
+var _active_request := {}
+var _last_manifest := {}
+var _last_validation := {}
+var _pending_failure_kind := null
+var _pending_failure_message := ""
+var _active := false
+var _awaiting_runtime := false
+var _awaiting_capture := false
+var _awaiting_manifest := false
+var _awaiting_stop := false
+var _stop_requested := false
+var _launch_started_at_usec := 0
+
+
+func configure(plugin: EditorPlugin, bridge: Object, artifact_store: Object) -> void:
+	_plugin = plugin
+	_bridge = bridge
+	_artifact_store = artifact_store
+
+
+func is_active() -> bool:
+	return _active
+
+
+func start_run(config: Dictionary, request: Dictionary, capability: Dictionary) -> Dictionary:
+	_active_config = config.duplicate(true)
+	_active_request = _resolve_request(config, request)
+	_last_manifest = {}
+	_last_validation = _build_validation_result(false, 0, [], false, ["Validation has not completed yet."])
+	_pending_failure_kind = null
+	_pending_failure_message = ""
+	_stop_requested = false
+	_awaiting_stop = false
+
+	var blocked_reasons := _collect_blocked_reasons(capability)
+	if not blocked_reasons.is_empty():
+		return _finish_blocked_run(blocked_reasons)
+
+	_active = true
+	_launch_started_at_usec = Time.get_ticks_usec()
+	_emit_status(InspectionConstants.AUTOMATION_STATUS_RECEIVED, "Autonomous run request accepted.")
+	_emit_status(InspectionConstants.AUTOMATION_STATUS_LAUNCHING, "Starting the requested scene in the editor.")
+	_emit_status(InspectionConstants.AUTOMATION_STATUS_AWAITING_RUNTIME, "Waiting for the runtime debugger session to attach.")
+
+	_awaiting_runtime = true
+	_awaiting_capture = true
+	_awaiting_manifest = false
+
+	_bridge.set_session_context(_build_session_context())
+	EditorInterface.play_custom_scene(String(_active_request.get("targetScene", "")))
+	return {
+		"ok": true,
+		"requestId": _active_request.get("requestId", ""),
+		"runId": _active_request.get("runId", ""),
+	}
+
+
+func poll() -> void:
+	if not _active:
+		return
+
+	if _awaiting_runtime:
+		var elapsed_usec := Time.get_ticks_usec() - _launch_started_at_usec
+		if elapsed_usec > 15000000:
+			_fail_run(InspectionConstants.AUTOMATION_FAILURE_KIND_ATTACHMENT, "Runtime debugger session did not attach before timeout.")
+			return
+
+	if _awaiting_stop and not EditorInterface.is_playing_scene():
+		_finalize_after_stop(InspectionConstants.AUTOMATION_TERMINATION_STOPPED_CLEANLY)
+
+
+func handle_session_state_changed(state: String, details: String) -> void:
+	if not _active:
+		return
+
+	match state:
+		InspectionConstants.SESSION_STATUS_CONNECTED:
+			_on_runtime_attached()
+		"disconnected":
+			if _awaiting_stop or _stop_requested:
+				_finalize_after_stop(InspectionConstants.AUTOMATION_TERMINATION_STOPPED_CLEANLY)
+			elif _awaiting_runtime:
+				_fail_run(InspectionConstants.AUTOMATION_FAILURE_KIND_ATTACHMENT, details)
+			elif _last_manifest.is_empty():
+				_fail_run(InspectionConstants.AUTOMATION_FAILURE_KIND_GAMEPLAY, "The play session ended before a scenegraph bundle was persisted.")
+		InspectionConstants.SESSION_STATUS_ERROR:
+			if _awaiting_runtime:
+				_fail_run(InspectionConstants.AUTOMATION_FAILURE_KIND_ATTACHMENT, details)
+			elif _awaiting_manifest or _awaiting_capture:
+				_fail_run(InspectionConstants.AUTOMATION_FAILURE_KIND_CAPTURE, details)
+			else:
+				_fail_run(InspectionConstants.AUTOMATION_FAILURE_KIND_GAMEPLAY, details)
+		_:
+			pass
+
+
+func handle_capture_updated(snapshot: Dictionary, diagnostics: Array) -> void:
+	if not _active or not _awaiting_capture:
+		return
+
+	_awaiting_capture = false
+	_emit_status(InspectionConstants.AUTOMATION_STATUS_CAPTURING, "Scenegraph evidence capture completed.", {
+		"evidenceRefs": _build_snapshot_refs(snapshot, diagnostics),
+	})
+	_emit_status(InspectionConstants.AUTOMATION_STATUS_PERSISTING, "Persisting the latest scenegraph evidence bundle.")
+	_awaiting_manifest = true
+	_bridge.persist_latest_bundle()
+
+
+func handle_manifest_persisted(manifest: Dictionary) -> void:
+	if not _active or not _awaiting_manifest:
+		return
+
+	_awaiting_manifest = false
+	_last_manifest = manifest.duplicate(true)
+	_emit_status(InspectionConstants.AUTOMATION_STATUS_VALIDATING, "Validating the persisted evidence bundle.")
+	_last_validation = _validate_manifest(manifest)
+	if not bool(_last_validation.get("bundleValid", false)):
+		_pending_failure_kind = InspectionConstants.AUTOMATION_FAILURE_KIND_VALIDATION
+		_pending_failure_message = "Persisted evidence bundle failed validation."
+
+	if _should_stop_after_validation():
+		_request_stop()
+		return
+
+	if _pending_failure_kind != null:
+		_fail_run(String(_pending_failure_kind), _pending_failure_message)
+		return
+
+	_finalize_run("completed", null, InspectionConstants.AUTOMATION_TERMINATION_RUNNING)
+
+
+func handle_transport_error(message: String) -> void:
+	if not _active:
+		return
+
+	if _awaiting_runtime:
+		_fail_run(InspectionConstants.AUTOMATION_FAILURE_KIND_ATTACHMENT, message)
+	elif _awaiting_manifest or _awaiting_capture:
+		_fail_run(InspectionConstants.AUTOMATION_FAILURE_KIND_CAPTURE, message)
+	else:
+		_fail_run(InspectionConstants.AUTOMATION_FAILURE_KIND_GAMEPLAY, message)
+
+
+func _on_runtime_attached() -> void:
+	_awaiting_runtime = false
+	var capture_policy: Dictionary = _active_request.get("capturePolicy", {})
+	var startup_enabled := bool(capture_policy.get("startup", false))
+	var manual_enabled := bool(capture_policy.get("manual", false))
+
+	if startup_enabled:
+		_emit_status(InspectionConstants.AUTOMATION_STATUS_CAPTURING, "Runtime debugger session attached; waiting for startup capture.")
+		return
+
+	if manual_enabled:
+		_emit_status(InspectionConstants.AUTOMATION_STATUS_CAPTURING, "Runtime debugger session attached; requesting manual capture.")
+		_bridge.request_manual_capture()
+		return
+
+	_fail_run(InspectionConstants.AUTOMATION_FAILURE_KIND_CAPTURE, "Autonomous capture is disabled by the current capture policy.")
+
+
+func _request_stop() -> void:
+	_stop_requested = true
+	_awaiting_stop = true
+	_emit_status(InspectionConstants.AUTOMATION_STATUS_STOPPING, "Stopping the editor play session after validation.")
+	EditorInterface.stop_playing_scene()
+	if not EditorInterface.is_playing_scene():
+		_finalize_after_stop(InspectionConstants.AUTOMATION_TERMINATION_STOPPED_CLEANLY)
+
+
+func _finalize_after_stop(termination_status: String) -> void:
+	_awaiting_stop = false
+	if _pending_failure_kind != null:
+		_finalize_run("failed", String(_pending_failure_kind), termination_status, _pending_failure_message)
+		return
+
+	_finalize_run("completed", null, termination_status)
+
+
+func _finish_blocked_run(blocked_reasons: Array) -> Dictionary:
+	var request_id := String(_active_request.get("requestId", "request-blocked"))
+	var run_id := String(_active_request.get("runId", "run-blocked"))
+	_emit_status(InspectionConstants.AUTOMATION_STATUS_BLOCKED, "Autonomous run request was blocked.", {
+		"failureKind": InspectionConstants.AUTOMATION_FAILURE_KIND_LAUNCH,
+		"evidenceRefs": blocked_reasons,
+	})
+	var result := {
+		"requestId": request_id,
+		"runId": run_id,
+		"finalStatus": "blocked",
+		"failureKind": null,
+		"manifestPath": null,
+		"outputDirectory": String(_active_request.get("outputDirectory", "")),
+		"validationResult": _build_validation_result(false, 0, [], false, ["Run was blocked before evidence validation could begin."]),
+		"terminationStatus": InspectionConstants.AUTOMATION_TERMINATION_BLOCKED,
+		"blockedReasons": blocked_reasons.duplicate(true),
+		"controlPath": InspectionConstants.AUTOMATION_CONTROL_PATH_FILE_BROKER,
+		"completedAt": InspectionConstants.utc_timestamp_now(),
+	}
+	_artifact_store.write_run_result(_active_config, result)
+	emit_signal("run_completed", result)
+	_reset_state()
+	return result
+
+
+func _fail_run(failure_kind: String, message: String) -> void:
+	_emit_status(InspectionConstants.AUTOMATION_STATUS_FAILED, message, {
+		"failureKind": failure_kind,
+	})
+
+	if _should_stop_after_validation() and EditorInterface.is_playing_scene() and not _stop_requested:
+		_pending_failure_kind = failure_kind
+		_pending_failure_message = message
+		_request_stop()
+		return
+
+	_finalize_run("failed", failure_kind, _derive_failure_termination_status(), message)
+
+
+func _finalize_run(final_status: String, failure_kind, termination_status: String, note := "") -> void:
+	var manifest_path = null
+	if not _last_manifest.is_empty():
+		manifest_path = _resolve_manifest_repo_path()
+
+	var result := {
+		"requestId": String(_active_request.get("requestId", "")),
+		"runId": String(_active_request.get("runId", "")),
+		"finalStatus": final_status,
+		"failureKind": failure_kind,
+		"manifestPath": manifest_path,
+		"outputDirectory": String(_active_request.get("outputDirectory", "")),
+		"validationResult": _last_validation.duplicate(true),
+		"terminationStatus": termination_status,
+		"blockedReasons": [],
+		"controlPath": InspectionConstants.AUTOMATION_CONTROL_PATH_FILE_BROKER,
+		"completedAt": InspectionConstants.utc_timestamp_now(),
+	}
+	if not note.is_empty():
+		result["blockedReasons"] = [note]
+	_artifact_store.write_run_result(_active_config, result)
+	emit_signal("run_completed", result)
+	_reset_state()
+
+
+func _emit_status(status: String, details: String, extras := {}) -> void:
+	var payload := _artifact_store.build_status_payload(
+		String(_active_request.get("requestId", "request-pending")),
+		String(_active_request.get("runId", "run-pending")),
+		status,
+		details,
+		extras
+	)
+	_artifact_store.write_lifecycle_status(_active_config, payload)
+	emit_signal("lifecycle_status_written", payload)
+
+
+func _build_session_context() -> Dictionary:
+	return {
+		"config_path": "res://harness/inspection-run-config.json",
+		"session_id": String(_active_request.get("requestId", "")),
+		"request_id": String(_active_request.get("requestId", "")),
+		"run_id": String(_active_request.get("runId", "")),
+		"scenario_id": String(_active_request.get("scenarioId", InspectionConstants.DEFAULT_SCENARIO_ID)),
+		"requested_by": String(_active_request.get("requestedBy", "scenegraph_automation_broker")),
+		"output_directory": String(_active_request.get("outputDirectory", InspectionConstants.DEFAULT_OUTPUT_DIRECTORY)),
+		"artifact_root": String(_active_request.get("artifactRoot", InspectionConstants.DEFAULT_MANIFEST_ARTIFACT_ROOT)),
+		"capture_policy": _active_request.get("capturePolicy", {}).duplicate(true),
+	}
+
+
+func _collect_blocked_reasons(capability: Dictionary) -> Array:
+	var blocked: Array = []
+	for blocked_reason in capability.get("blockedReasons", []):
+		blocked.append(String(blocked_reason))
+
+	if String(_active_request.get("requestId", "")).is_empty():
+		blocked.append("request_id_missing")
+	if String(_active_request.get("runId", "")).is_empty():
+		blocked.append("run_id_missing")
+	if String(_active_request.get("targetScene", "")).is_empty():
+		blocked.append("target_scene_missing")
+	if EditorInterface.is_playing_scene():
+		blocked.append("scene_already_running")
+
+	var capture_policy: Dictionary = _active_request.get("capturePolicy", {})
+	if not bool(capture_policy.get("startup", false)) and not bool(capture_policy.get("manual", false)):
+		blocked.append("capture_policy_blocks_autonomous_capture")
+
+	return _dedupe_strings(blocked)
+
+
+func _resolve_request(config: Dictionary, request: Dictionary) -> Dictionary:
+	var overrides: Dictionary = request.get("overrides", {})
+	var default_overrides: Dictionary = config.get("defaultRequestOverrides", {})
+	var base_capture_policy := config.get("capturePolicy", {}).duplicate(true)
+	var base_stop_policy := {"stopAfterValidation": true}
+	var resolved := {
+		"requestId": String(request.get("requestId", "request-%s" % str(Time.get_ticks_usec()))),
+		"scenarioId": String(request.get("scenarioId", config.get("scenarioId", InspectionConstants.DEFAULT_SCENARIO_ID))),
+		"runId": String(request.get("runId", config.get("runId", "run-%s" % str(Time.get_ticks_usec())))),
+		"targetScene": String(config.get("targetScene", "")),
+		"outputDirectory": String(config.get("outputDirectory", InspectionConstants.DEFAULT_OUTPUT_DIRECTORY)),
+		"artifactRoot": String(config.get("artifactRoot", InspectionConstants.DEFAULT_MANIFEST_ARTIFACT_ROOT)),
+		"expectationFiles": _copy_array(config.get("expectationFiles", [])),
+		"capturePolicy": base_capture_policy,
+		"stopPolicy": base_stop_policy,
+		"requestedBy": String(request.get("requestedBy", "scenegraph_automation_broker")),
+	}
+
+	_apply_scalar_override(resolved, default_overrides, "targetScene")
+	_apply_scalar_override(resolved, default_overrides, "outputDirectory")
+	_apply_scalar_override(resolved, default_overrides, "artifactRoot")
+	_apply_array_override(resolved, default_overrides, "expectationFiles")
+	_merge_nested_override(resolved, "capturePolicy", default_overrides.get("capturePolicy", {}))
+	_merge_nested_override(resolved, "stopPolicy", default_overrides.get("stopPolicy", {}))
+
+	_apply_scalar_override(resolved, request, "targetScene")
+	_apply_scalar_override(resolved, request, "outputDirectory")
+	_apply_scalar_override(resolved, request, "artifactRoot")
+	_apply_array_override(resolved, request, "expectationFiles")
+	_merge_nested_override(resolved, "capturePolicy", request.get("capturePolicy", {}))
+	_merge_nested_override(resolved, "stopPolicy", request.get("stopPolicy", {}))
+
+	_apply_scalar_override(resolved, overrides, "targetScene")
+	_apply_scalar_override(resolved, overrides, "outputDirectory")
+	_apply_scalar_override(resolved, overrides, "artifactRoot")
+	_apply_array_override(resolved, overrides, "expectationFiles")
+	_merge_nested_override(resolved, "capturePolicy", overrides.get("capturePolicy", {}))
+	_merge_nested_override(resolved, "stopPolicy", overrides.get("stopPolicy", {}))
+
+	return resolved
+
+
+func _apply_scalar_override(target: Dictionary, source: Dictionary, key: String) -> void:
+	if source.has(key):
+		target[key] = source.get(key)
+
+
+func _apply_array_override(target: Dictionary, source: Dictionary, key: String) -> void:
+	if source.has(key):
+		target[key] = _copy_array(source.get(key, []))
+
+
+func _merge_nested_override(target: Dictionary, key: String, source: Dictionary) -> void:
+	if typeof(source) != TYPE_DICTIONARY:
+		return
+	var merged: Dictionary = target.get(key, {}).duplicate(true)
+	for nested_key in source.keys():
+		merged[nested_key] = source[nested_key]
+	target[key] = merged
+
+
+func _copy_array(values: Array) -> Array:
+	var copied: Array = []
+	for value in values:
+		copied.append(value)
+	return copied
+
+
+func _build_validation_result(manifest_exists: bool, artifact_refs_checked: int, missing_artifacts: Array, bundle_valid: bool, notes: Array) -> Dictionary:
+	return {
+		"manifestExists": manifest_exists,
+		"artifactRefsChecked": artifact_refs_checked,
+		"missingArtifacts": missing_artifacts.duplicate(true),
+		"bundleValid": bundle_valid,
+		"notes": notes.duplicate(true),
+		"validatedAt": InspectionConstants.utc_timestamp_now(),
+	}
+
+
+func _validate_manifest(manifest: Dictionary) -> Dictionary:
+	if manifest.is_empty():
+		return _build_validation_result(false, 0, [], false, ["No manifest was produced for the autonomous run."])
+
+	var missing_artifacts: Array = []
+	var notes: Array = []
+	var output_directory := String(_active_request.get("outputDirectory", InspectionConstants.DEFAULT_OUTPUT_DIRECTORY))
+	var artifact_refs: Array = manifest.get("artifactRefs", [])
+	for artifact_ref_value in artifact_refs:
+		var artifact_ref: Dictionary = artifact_ref_value
+		var expected_path := output_directory.path_join(String(artifact_ref.get("path", "")).get_file())
+		if not FileAccess.file_exists(expected_path):
+			missing_artifacts.append(String(artifact_ref.get("path", "")))
+
+	var run_id_matches := String(manifest.get("runId", "")) == String(_active_request.get("runId", ""))
+	var scenario_matches := String(manifest.get("scenarioId", "")) == String(_active_request.get("scenarioId", ""))
+	if not run_id_matches:
+		notes.append("Manifest runId did not match the active automation request.")
+	if not scenario_matches:
+		notes.append("Manifest scenarioId did not match the active automation request.")
+	if missing_artifacts.is_empty():
+		notes.append("Manifest and referenced scenegraph artifacts exist for the active run.")
+
+	var bundle_valid := run_id_matches and scenario_matches and missing_artifacts.is_empty() and bool(manifest.get("validation", {}).get("bundleValid", false))
+	return _build_validation_result(true, artifact_refs.size(), missing_artifacts, bundle_valid, notes)
+
+
+func _build_snapshot_refs(snapshot: Dictionary, diagnostics: Array) -> Array:
+	var refs: Array = []
+	if not snapshot.is_empty():
+		refs.append(String(snapshot.get("snapshot_id", "")))
+	if not diagnostics.is_empty():
+		refs.append("diagnostics:%d" % diagnostics.size())
+	return refs
+
+
+func _derive_failure_termination_status() -> String:
+	if _stop_requested:
+		return InspectionConstants.AUTOMATION_TERMINATION_SHUTDOWN_FAILED
+	if EditorInterface.is_playing_scene():
+		return InspectionConstants.AUTOMATION_TERMINATION_RUNNING
+	return InspectionConstants.AUTOMATION_TERMINATION_ALREADY_CLOSED
+
+
+func _should_stop_after_validation() -> bool:
+	var stop_policy: Dictionary = _active_request.get("stopPolicy", {})
+	return bool(stop_policy.get("stopAfterValidation", true))
+
+
+func _resolve_manifest_repo_path() -> String:
+	var artifact_root := String(_active_request.get("artifactRoot", ""))
+	if artifact_root.is_empty():
+		artifact_root = String(_active_request.get("outputDirectory", InspectionConstants.DEFAULT_OUTPUT_DIRECTORY)).trim_prefix("res://")
+	return artifact_root.path_join("evidence-manifest.json")
+
+
+func _dedupe_strings(values: Array) -> Array:
+	var deduped: Array = []
+	for value in values:
+		var text := String(value)
+		if text.is_empty() or text in deduped:
+			continue
+		deduped.append(text)
+	return deduped
+
+
+func _reset_state() -> void:
+	_active = false
+	_awaiting_runtime = false
+	_awaiting_capture = false
+	_awaiting_manifest = false
+	_awaiting_stop = false
+	_stop_requested = false
+	_pending_failure_kind = null
+	_pending_failure_message = ""
+	_active_config = {}
+	_active_request = {}
+	_last_manifest = {}
+	_last_validation = {}
+	_launch_started_at_usec = 0

--- a/addons/agent_runtime_harness/editor/scenegraph_run_coordinator.gd
+++ b/addons/agent_runtime_harness/editor/scenegraph_run_coordinator.gd
@@ -14,7 +14,7 @@ var _active_config := {}
 var _active_request := {}
 var _last_manifest := {}
 var _last_validation := {}
-var _pending_failure_kind := null
+var _pending_failure_kind: Variant = null
 var _pending_failure_message := ""
 var _active := false
 var _awaiting_runtime := false
@@ -268,7 +268,7 @@ func _finalize_run(final_status: String, failure_kind, termination_status: Strin
 
 
 func _emit_status(status: String, details: String, extras := {}) -> void:
-	var payload := _artifact_store.build_status_payload(
+	var payload: Dictionary = _artifact_store.build_status_payload(
 		String(_active_request.get("requestId", "request-pending")),
 		String(_active_request.get("runId", "run-pending")),
 		status,
@@ -334,7 +334,7 @@ func _collect_blocked_reasons(capability: Dictionary) -> Array:
 func _resolve_request(config: Dictionary, request: Dictionary) -> Dictionary:
 	var overrides: Dictionary = request.get("overrides", {})
 	var default_overrides: Dictionary = config.get("defaultRequestOverrides", {})
-	var base_capture_policy := config.get("capturePolicy", {}).duplicate(true)
+	var base_capture_policy: Dictionary = config.get("capturePolicy", {}).duplicate(true)
 	var base_stop_policy := {"stopAfterValidation": true}
 	var resolved := {
 		"requestId": String(request.get("requestId", "request-%s" % str(Time.get_ticks_usec()))),

--- a/addons/agent_runtime_harness/plugin.gd
+++ b/addons/agent_runtime_harness/plugin.gd
@@ -3,10 +3,12 @@ extends EditorPlugin
 
 const ScenegraphDock = preload("res://addons/agent_runtime_harness/editor/scenegraph_dock.gd")
 const ScenegraphDebuggerBridge = preload("res://addons/agent_runtime_harness/editor/scenegraph_debugger_bridge.gd")
+const ScenegraphAutomationBroker = preload("res://addons/agent_runtime_harness/editor/scenegraph_automation_broker.gd")
 const AgentAssetDeployer = preload("res://addons/agent_runtime_harness/editor/agent_asset_deployer.gd")
 
 var _dock: Control
 var _bridge
+var _automation_broker: Node
 var _agent_asset_deployer: AgentAssetDeployer
 
 
@@ -17,6 +19,10 @@ func _enter_tree() -> void:
 		"requested_by": "editor_plugin",
 	})
 	add_debugger_plugin(_bridge)
+
+	_automation_broker = ScenegraphAutomationBroker.new()
+	_automation_broker.configure(self, _bridge, "res://harness/inspection-run-config.json")
+	add_child(_automation_broker)
 
 	_agent_asset_deployer = AgentAssetDeployer.new()
 
@@ -31,6 +37,10 @@ func _exit_tree() -> void:
 		remove_control_from_bottom_panel(_dock)
 		_dock.queue_free()
 		_dock = null
+
+	if _automation_broker != null:
+		_automation_broker.queue_free()
+		_automation_broker = null
 
 	if _bridge != null:
 		remove_debugger_plugin(_bridge)

--- a/addons/agent_runtime_harness/runtime/scenegraph_artifact_writer.gd
+++ b/addons/agent_runtime_harness/runtime/scenegraph_artifact_writer.gd
@@ -62,6 +62,7 @@ func persist_bundle(snapshot: Dictionary, diagnostics: Array, session_context: D
 				"Persisted artifact references were written successfully. Validate the manifest schema and paths with tools/evidence/validate-evidence-manifest.ps1 after the editor run.",
 			],
 		},
+		"producer": _build_producer(session_context),
 		"createdAt": InspectionConstants.utc_timestamp_now(),
 	}
 
@@ -111,3 +112,13 @@ func _build_artifact_ref(kind: String, artifact_root: String, file_name: String,
 		"mediaType": media_type,
 		"description": description,
 	}
+
+
+func _build_producer(session_context: Dictionary) -> Dictionary:
+	var producer := {
+		"surface": "scenegraph_harness_runtime",
+	}
+	var request_id := String(session_context.get("request_id", ""))
+	if not request_id.is_empty():
+		producer["toolingArtifactId"] = "scenegraph_automation_broker"
+	return producer

--- a/addons/agent_runtime_harness/runtime/scenegraph_runtime.gd
+++ b/addons/agent_runtime_harness/runtime/scenegraph_runtime.gd
@@ -36,6 +36,7 @@ func _exit_tree() -> void:
 func configure_session(session_context: Dictionary) -> void:
 	_session_context = {
 		"session_id": session_context.get("session_id", _build_identifier("session")),
+		"request_id": session_context.get("request_id", _build_identifier("request")),
 		"run_id": session_context.get("run_id", _build_identifier("run")),
 		"scenario_id": session_context.get("scenario_id", InspectionConstants.DEFAULT_SCENARIO_ID),
 		"requested_by": session_context.get("requested_by", "editor_plugin"),
@@ -46,10 +47,15 @@ func configure_session(session_context: Dictionary) -> void:
 			"manual": true,
 			"failure": true,
 		}),
+		"stop_policy": session_context.get("stop_policy", {
+			"stopAfterValidation": true,
+		}),
 	}
 
 	if session_context.has("config_path"):
 		_load_session_config(String(session_context.get("config_path")))
+
+	_send_debugger_message("session_configured", [_build_session_configuration_event()])
 
 
 func request_manual_capture() -> Dictionary:
@@ -127,6 +133,7 @@ func _load_session_config(config_path: String) -> void:
 	_session_context["artifact_root"] = parsed.get("artifactRoot", _session_context.get("artifact_root", InspectionConstants.DEFAULT_MANIFEST_ARTIFACT_ROOT))
 	_session_context["output_directory"] = parsed.get("outputDirectory", _session_context.get("output_directory", InspectionConstants.DEFAULT_OUTPUT_DIRECTORY))
 	_session_context["capture_policy"] = parsed.get("capturePolicy", _session_context.get("capture_policy", {}))
+	_session_context["stop_policy"] = parsed.get("defaultRequestOverrides", {}).get("stopPolicy", _session_context.get("stop_policy", {}))
 
 	_expectations.clear()
 	for expectation_path_value in parsed.get("expectationFiles", []):
@@ -182,6 +189,16 @@ func _on_debugger_request(message: String, data: Array) -> bool:
 func _send_debugger_message(message_name: String, data: Array) -> void:
 	if EngineDebugger.is_active():
 		EngineDebugger.send_message("%s:%s" % [InspectionConstants.RUNTIME_TO_EDITOR_CHANNEL, message_name], data)
+
+
+func _build_session_configuration_event() -> Dictionary:
+	return {
+		"request_id": String(_session_context.get("request_id", "")),
+		"session_id": String(_session_context.get("session_id", "")),
+		"run_id": String(_session_context.get("run_id", "")),
+		"scenario_id": String(_session_context.get("scenario_id", "")),
+		"stop_policy": _session_context.get("stop_policy", {}).duplicate(true),
+	}
 
 
 func _emit_runtime_error(message: String) -> void:

--- a/addons/agent_runtime_harness/shared/inspection_constants.gd
+++ b/addons/agent_runtime_harness/shared/inspection_constants.gd
@@ -8,6 +8,9 @@ const RUNTIME_TO_EDITOR_CHANNEL := "agent_runtime_harness/scenegraph/capture"
 const ARTIFACT_KIND_SCENEGRAPH_SNAPSHOT := "scenegraph-snapshot"
 const ARTIFACT_KIND_SCENEGRAPH_DIAGNOSTICS := "scenegraph-diagnostics"
 const ARTIFACT_KIND_SCENEGRAPH_SUMMARY := "scenegraph-summary"
+const ARTIFACT_KIND_AUTOMATION_CAPABILITY := "automation-capability"
+const ARTIFACT_KIND_AUTOMATION_LIFECYCLE_STATUS := "automation-lifecycle-status"
+const ARTIFACT_KIND_AUTOMATION_RUN_RESULT := "automation-run-result"
 
 const TRIGGER_STARTUP := "startup"
 const TRIGGER_MANUAL := "manual"
@@ -24,6 +27,39 @@ const SESSION_STATUS_PERSISTED := "persisted"
 const SESSION_STATUS_CLOSED := "closed"
 const SESSION_STATUS_ERROR := "error"
 
+const AUTOMATION_CONTROL_PATH_FILE_BROKER := "file_broker"
+const AUTOMATION_CONTROL_PATH_EDITOR_SCRIPT_FORWARDER := "editor_script_forwarder"
+const AUTOMATION_CONTROL_PATH_LOCAL_IPC := "local_ipc"
+
+const AUTOMATION_STATUS_RECEIVED := "received"
+const AUTOMATION_STATUS_BLOCKED := "blocked"
+const AUTOMATION_STATUS_LAUNCHING := "launching"
+const AUTOMATION_STATUS_AWAITING_RUNTIME := "awaiting_runtime"
+const AUTOMATION_STATUS_CAPTURING := "capturing"
+const AUTOMATION_STATUS_PERSISTING := "persisting"
+const AUTOMATION_STATUS_VALIDATING := "validating"
+const AUTOMATION_STATUS_STOPPING := "stopping"
+const AUTOMATION_STATUS_COMPLETED := "completed"
+const AUTOMATION_STATUS_FAILED := "failed"
+
+const AUTOMATION_FAILURE_KIND_LAUNCH := "launch"
+const AUTOMATION_FAILURE_KIND_ATTACHMENT := "attachment"
+const AUTOMATION_FAILURE_KIND_CAPTURE := "capture"
+const AUTOMATION_FAILURE_KIND_PERSISTENCE := "persistence"
+const AUTOMATION_FAILURE_KIND_VALIDATION := "validation"
+const AUTOMATION_FAILURE_KIND_SHUTDOWN := "shutdown"
+const AUTOMATION_FAILURE_KIND_GAMEPLAY := "gameplay"
+
+const AUTOMATION_TERMINATION_NOT_STARTED := "not_started"
+const AUTOMATION_TERMINATION_RUNNING := "running"
+const AUTOMATION_TERMINATION_STOPPING := "stopping"
+const AUTOMATION_TERMINATION_STOPPED_CLEANLY := "stopped_cleanly"
+const AUTOMATION_TERMINATION_ALREADY_CLOSED := "already_closed"
+const AUTOMATION_TERMINATION_CRASHED := "crashed"
+const AUTOMATION_TERMINATION_SHUTDOWN_FAILED := "shutdown_failed"
+const AUTOMATION_TERMINATION_BLOCKED := "blocked"
+const AUTOMATION_TERMINATION_UNKNOWN := "unknown"
+
 const DIAGNOSTIC_KIND_MISSING_NODE := "missing_node"
 const DIAGNOSTIC_KIND_HIERARCHY_MISMATCH := "hierarchy_mismatch"
 const DIAGNOSTIC_KIND_CAPTURE_ERROR := "capture_error"
@@ -31,6 +67,11 @@ const DIAGNOSTIC_KIND_CAPTURE_ERROR := "capture_error"
 const DEFAULT_SCENARIO_ID := "runtime-smoke-test"
 const DEFAULT_OUTPUT_DIRECTORY := "res://evidence/scenegraph/latest"
 const DEFAULT_MANIFEST_ARTIFACT_ROOT := ""
+const DEFAULT_AUTOMATION_REQUEST_PATH := "res://harness/automation/requests/run-request.json"
+const DEFAULT_AUTOMATION_RESULTS_DIRECTORY := "res://harness/automation/results"
+const DEFAULT_AUTOMATION_CAPABILITY_RESULT_PATH := "res://harness/automation/results/capability.json"
+const DEFAULT_AUTOMATION_LIFECYCLE_STATUS_PATH := "res://harness/automation/results/lifecycle-status.json"
+const DEFAULT_AUTOMATION_RUN_RESULT_PATH := "res://harness/automation/results/run-result.json"
 
 
 static func supported_artifact_kinds() -> PackedStringArray:
@@ -38,6 +79,24 @@ static func supported_artifact_kinds() -> PackedStringArray:
 		ARTIFACT_KIND_SCENEGRAPH_SNAPSHOT,
 		ARTIFACT_KIND_SCENEGRAPH_DIAGNOSTICS,
 		ARTIFACT_KIND_SCENEGRAPH_SUMMARY,
+		ARTIFACT_KIND_AUTOMATION_CAPABILITY,
+		ARTIFACT_KIND_AUTOMATION_LIFECYCLE_STATUS,
+		ARTIFACT_KIND_AUTOMATION_RUN_RESULT,
+	])
+
+
+static func supported_automation_states() -> PackedStringArray:
+	return PackedStringArray([
+		AUTOMATION_STATUS_RECEIVED,
+		AUTOMATION_STATUS_BLOCKED,
+		AUTOMATION_STATUS_LAUNCHING,
+		AUTOMATION_STATUS_AWAITING_RUNTIME,
+		AUTOMATION_STATUS_CAPTURING,
+		AUTOMATION_STATUS_PERSISTING,
+		AUTOMATION_STATUS_VALIDATING,
+		AUTOMATION_STATUS_STOPPING,
+		AUTOMATION_STATUS_COMPLETED,
+		AUTOMATION_STATUS_FAILED,
 	])
 
 

--- a/addons/agent_runtime_harness/templates/project_root/.github/agents/godot-evidence-triage.agent.md
+++ b/addons/agent_runtime_harness/templates/project_root/.github/agents/godot-evidence-triage.agent.md
@@ -15,6 +15,7 @@ Interpret a Godot scenegraph evidence bundle from its manifest, explain the obse
 
 - Read `.github/copilot-instructions.md` and `AGENTS.md` before acting.
 - Start from the evidence manifest and inspect raw artifacts only when the manifest points to them.
+- Stay in post-run diagnosis mode. If the user needs a fresh runtime proof, stop and route to `godot-runtime-verification.agent.md` instead of launching a new evidence run from this artifact.
 - Prefer proving runtime state from persisted scenegraph artifacts instead of editor narration.
 - Separate likely gameplay issues from harness setup issues such as missing autoload wiring or missing persisted evidence.
 

--- a/addons/agent_runtime_harness/templates/project_root/.github/agents/godot-runtime-verification.agent.md
+++ b/addons/agent_runtime_harness/templates/project_root/.github/agents/godot-runtime-verification.agent.md
@@ -1,0 +1,37 @@
+---
+description: Run Scenegraph Harness runtime verification for a Godot task, combine existing tests when needed, and report the result from persisted scenegraph evidence.
+---
+
+## Mission
+
+Interpret a Godot task, choose between ordinary tests, Scenegraph Harness runtime verification, or combined validation, and prove any runtime-visible claim from persisted scenegraph evidence without broad project rediscovery.
+
+## Inputs
+
+- Change request or verification request
+- Optional expected runtime node, hierarchy, or gameplay symptom
+- Optional ordinary test command or existing deterministic test surface to include in combined validation
+
+## Scope
+
+- Read `.github/copilot-instructions.md` and `AGENTS.md` before acting.
+- Route runtime-visible requests to the Scenegraph Harness workflow.
+- If the user already provides `evidence/scenegraph/latest/evidence-manifest.json` and only wants diagnosis, stop and route to `godot-evidence-triage.agent.md`.
+- Read `harness/automation/results/capability.json` before requesting a fresh run.
+- Use the brokered request and result files under `harness/automation/requests/` and `harness/automation/results/` instead of hidden editor interaction.
+- Read the manifest first once a run has persisted evidence.
+- Separate gameplay conclusions from harness wiring or automation failures.
+
+## Stop conditions
+
+- Capability is blocked, missing, or stale.
+- Final run result is blocked or failed before a persisted bundle is available.
+- The task requires fabricating a new ordinary test suite only to satisfy combined validation.
+- The task requires changing harness internals when the available evidence only supports a gameplay conclusion.
+
+## Expected outputs
+
+- The selected validation mode with a short reason
+- The runtime verification outcome or explicit blocked reason
+- Whether existing ordinary tests were also run or should run
+- The next validation or debugging step grounded in the manifest or run result

--- a/addons/agent_runtime_harness/templates/project_root/.github/copilot-instructions.runtime-harness.md
+++ b/addons/agent_runtime_harness/templates/project_root/.github/copilot-instructions.runtime-harness.md
@@ -5,7 +5,12 @@
 - Persisted evidence goes to `res://evidence/scenegraph/latest` by default and consists of `evidence-manifest.json`, `scenegraph-summary.json`, `scenegraph-diagnostics.json`, and `scenegraph-snapshot.json`.
 
 ## Runtime Evidence Workflow
+- Use **ordinary tests** for unit, contract, framework, and other non-runtime checks.
+- Use **Scenegraph Harness runtime verification** for requests such as "verify at runtime," "test the running code," "make sure the node appears in game," "confirm the node exists while playing," or other runtime-visible outcomes.
+- Use **combined validation** when a change affects runtime-visible behavior and there is already a direct deterministic test surface. Run the existing tests plus the harness flow, but do not invent new ordinary tests only to satisfy the rule.
+- If the user already points to a scenegraph evidence manifest and only wants diagnosis, keep the task in `godot-evidence-triage` mode instead of starting a fresh run.
 - When runtime evidence exists, read `evidence/scenegraph/latest/evidence-manifest.json` first and inspect raw artifacts only when the manifest points to them.
 - The default read order is: `evidence-manifest.json`, then `scenegraph-summary.json`, then `scenegraph-diagnostics.json` if the run is partial or fail, then `scenegraph-snapshot.json` for detailed tree inspection.
 - For runtime verification requests, prefer proving behavior from the persisted scenegraph artifacts instead of relying on a human description of what happened in the editor.
+- For end-to-end runtime verification, read `harness/automation/results/capability.json` first, request or inspect a brokered run under `harness/automation/requests/` and `harness/automation/results/`, then inspect the persisted bundle manifest.
 - When asked whether a runtime node exists, report the manifest status first, then the node path if found, and then any diagnostic or capture limitation that affects confidence.

--- a/addons/agent_runtime_harness/templates/project_root/.github/prompts/godot-evidence-triage.prompt.md
+++ b/addons/agent_runtime_harness/templates/project_root/.github/prompts/godot-evidence-triage.prompt.md
@@ -23,7 +23,8 @@ Summarize a manifest-centered scenegraph evidence bundle, identify the most rele
 2. Read the summary artifact next.
 3. Read diagnostics only if the manifest or summary indicates a partial or failed run.
 4. Read the full snapshot only if you need exact node paths, hierarchy details, or property state.
-5. Distinguish gameplay failures from harness wiring failures such as missing autoload setup or no persisted evidence bundle.
+5. Stay in post-run diagnosis mode. If the user needs a fresh runtime proof instead of diagnosis of an existing bundle, hand off to `godot-runtime-verification.prompt.md`.
+6. Distinguish gameplay failures from harness wiring failures such as missing autoload setup or no persisted evidence bundle.
 
 ## Output
 

--- a/addons/agent_runtime_harness/templates/project_root/.github/prompts/godot-runtime-verification.prompt.md
+++ b/addons/agent_runtime_harness/templates/project_root/.github/prompts/godot-runtime-verification.prompt.md
@@ -1,0 +1,36 @@
+---
+description: Verify a runtime-visible Godot change with the Scenegraph Harness and combine existing tests when they also apply.
+---
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+## Goal
+
+Choose the correct validation mode for a Godot task and use the Scenegraph Harness when the request is about proving what happens in the running game.
+
+## Routing rules
+
+1. Use ordinary tests only for unit, contract, framework, or schema checks that do not ask about the running game.
+2. Use Scenegraph Harness runtime verification for requests such as "verify at runtime," "test the running code," "make sure the node appears in game," "confirm the node exists while playing," or other runtime-visible outcomes.
+3. Use combined validation when the change affects runtime-visible behavior and there is already a direct deterministic test surface. Run the existing tests plus the harness flow, but do not invent new ordinary tests solely to satisfy the combined rule.
+4. If the user already provides `evidence/scenegraph/latest/evidence-manifest.json` and only wants diagnosis, hand the task to `godot-evidence-triage.prompt.md`.
+
+## Runtime verification workflow
+
+1. Read `harness/automation/results/capability.json` first to confirm whether the open project can accept a brokered evidence request.
+2. If capability is blocked, missing, or stale, report that blocked state explicitly instead of guessing around the editor.
+3. Write or inspect the brokered request under `harness/automation/requests/run-request.json`.
+4. Wait for the final result under `harness/automation/results/` and confirm that the persisted bundle exists.
+5. Read `evidence/scenegraph/latest/evidence-manifest.json` first, then the summary, then diagnostics or snapshot only if needed.
+6. Separate gameplay failures from harness wiring or automation failures such as missing autoload setup, blocked capability, or no persisted bundle.
+
+## Output
+
+- Selected validation mode
+- Runtime evidence result or blocked reason
+- Whether ordinary tests were also required
+- Next concrete validation or debugging step

--- a/addons/agent_runtime_harness/templates/project_root/AGENTS.runtime-harness.md
+++ b/addons/agent_runtime_harness/templates/project_root/AGENTS.runtime-harness.md
@@ -9,3 +9,6 @@
 - Keep gameplay changes separate from harness changes when possible. Modify `addons/agent_runtime_harness/` only when the task actually concerns capture, transport, or evidence persistence.
 - Treat the Scenegraph Harness dock as the operator control surface and the persisted evidence bundle as the agent handoff surface.
 - If runtime verification fails, distinguish between a gameplay failure and a harness wiring failure such as a missing autoload or no persisted bundle.
+- For autonomous editor evidence runs, prefer the file-broker path under `harness/automation/requests/` and `harness/automation/results/` before considering fallback surfaces.
+- Read `harness/automation/results/capability.json` or the latest final run result before opening raw evidence files.
+- Treat blocked capability or run results as explicit unsupported-state signals; do not guess around them with hidden editor interaction.

--- a/addons/agent_runtime_harness/templates/project_root/AGENTS.runtime-harness.md
+++ b/addons/agent_runtime_harness/templates/project_root/AGENTS.runtime-harness.md
@@ -5,6 +5,10 @@
 4. Only inspect raw scenegraph artifacts that the manifest references.
 
 ## Runtime Verification Rules
+- Use **ordinary tests** for unit, contract, framework, and other non-runtime checks.
+- Use **Scenegraph Harness runtime verification** for requests such as "verify at runtime," "test the running code," "make sure the node appears in game," "confirm the node exists while playing," or other runtime-visible outcomes.
+- Use **combined validation** when a change affects runtime-visible behavior and there is already a direct deterministic test surface. Run the existing tests and the harness flow together, but do not invent new ordinary tests only to satisfy the combined rule.
+- If the user already provides `evidence/scenegraph/latest/evidence-manifest.json` and only wants diagnosis, stay in the evidence-triage workflow instead of launching a fresh run.
 - Prefer runtime evidence over human retellings when verifying whether a gameplay change worked.
 - Keep gameplay changes separate from harness changes when possible. Modify `addons/agent_runtime_harness/` only when the task actually concerns capture, transport, or evidence persistence.
 - Treat the Scenegraph Harness dock as the operator control surface and the persisted evidence bundle as the agent handoff surface.

--- a/addons/agent_runtime_harness/templates/project_root/harness/inspection-run-config.json
+++ b/addons/agent_runtime_harness/templates/project_root/harness/inspection-run-config.json
@@ -1,12 +1,31 @@
 {
   "scenarioId": "runtime-smoke-test",
   "runId": "runtime-smoke-test-run-01",
+  "targetScene": "",
   "outputDirectory": "res://evidence/scenegraph/latest",
   "artifactRoot": "",
   "capturePolicy": {
     "startup": true,
     "manual": true,
     "failure": true
+  },
+  "automation": {
+    "requestPath": "res://harness/automation/requests/run-request.json",
+    "requestsDirectory": "res://harness/automation/requests",
+    "resultsDirectory": "res://harness/automation/results",
+    "capabilityResultPath": "res://harness/automation/results/capability.json",
+    "lifecycleStatusPath": "res://harness/automation/results/lifecycle-status.json",
+    "runResultPath": "res://harness/automation/results/run-result.json"
+  },
+  "defaultRequestOverrides": {
+    "capturePolicy": {
+      "startup": true,
+      "manual": true,
+      "failure": true
+    },
+    "stopPolicy": {
+      "stopAfterValidation": true
+    }
   },
   "expectationFiles": []
 }

--- a/docs/AGENT_RUNTIME_HARNESS.md
+++ b/docs/AGENT_RUNTIME_HARNESS.md
@@ -232,6 +232,12 @@ Likely implementation:
 - `EditorPlugin`
 - `EditorDebuggerPlugin`
 
+The current autonomous editor evidence loop extends this layer with a plugin-owned file broker:
+
+- request artifacts are read from `harness/automation/requests/run-request.json`
+- capability, lifecycle, and final result artifacts are written under `harness/automation/results/`
+- the broker starts the requested target scene, waits for runtime attachment, persists the scenegraph bundle, validates the manifest, and stops the play session when configured to do so
+
 ### B. Runtime instrumentation addon
 
 Responsibilities:

--- a/docs/AGENT_TOOLING_FOUNDATION.md
+++ b/docs/AGENT_TOOLING_FOUNDATION.md
@@ -54,6 +54,22 @@ pwsh ./tools/automation/new-autonomous-run-record.ps1 -ArtifactId <artifact-id> 
 
 Use this when you want an auditable JSON record of what an automation flow attempted and whether it stayed within its declared boundary.
 
+### Read the current editor-evidence capability artifact
+
+```powershell
+pwsh ./tools/automation/get-editor-evidence-capability.ps1 -ProjectRoot <game-root>
+```
+
+Use this when the Godot project is already open in the editor and you want a deterministic read of the latest capability artifact that the plugin-owned broker wrote.
+
+### Write an autonomous editor-evidence run request
+
+```powershell
+pwsh ./tools/automation/request-editor-evidence-run.ps1 -ProjectRoot <game-root> -RequestFixturePath <fixture-path>
+```
+
+Use this when you want to submit a machine-readable request into the plugin-owned file broker without editing the request JSON by hand.
+
 ### Run the automated PowerShell tool tests
 
 ```powershell
@@ -74,6 +90,12 @@ It provides:
 - boundary checks and run logs for any approval-free automation
 
 It does **not** implement runtime harness behavior by itself.
+
+It now does provide the workspace-side helper surface for the autonomous editor evidence loop:
+
+- read capability artifacts from `harness/automation/results/`
+- write run requests into `harness/automation/requests/`
+- validate the resulting run-result and manifest-centered evidence artifacts with the existing schema and manifest tools
 
 If you want collision events, frame traces, scene snapshots, or other runtime data streams, those still need to be implemented in `addons/agent_runtime_harness/` or another runtime-facing part of the repo. The tooling here helps define what those outputs should look like and how to validate them once they exist.
 

--- a/docs/AGENT_TOOLING_FOUNDATION.md
+++ b/docs/AGENT_TOOLING_FOUNDATION.md
@@ -60,7 +60,7 @@ Use this when you want an auditable JSON record of what an automation flow attem
 pwsh ./tools/automation/get-editor-evidence-capability.ps1 -ProjectRoot <game-root>
 ```
 
-Use this when the Godot project is already open in the editor and you want a deterministic read of the latest capability artifact that the plugin-owned broker wrote.
+Use this when the Godot project is already open in the editor and you want a deterministic read of the latest capability artifact that the plugin-owned broker wrote. This is the first step in Scenegraph Harness runtime verification from the source repository.
 
 ### Write an autonomous editor-evidence run request
 
@@ -68,7 +68,7 @@ Use this when the Godot project is already open in the editor and you want a det
 pwsh ./tools/automation/request-editor-evidence-run.ps1 -ProjectRoot <game-root> -RequestFixturePath <fixture-path>
 ```
 
-Use this when you want to submit a machine-readable request into the plugin-owned file broker without editing the request JSON by hand.
+Use this when you want to submit a machine-readable request into the plugin-owned file broker without editing the request JSON by hand. Use it after a ready capability check when a task needs Scenegraph Harness runtime verification.
 
 ### Run the automated PowerShell tool tests
 
@@ -96,6 +96,20 @@ It now does provide the workspace-side helper surface for the autonomous editor 
 - read capability artifacts from `harness/automation/results/`
 - write run requests into `harness/automation/requests/`
 - validate the resulting run-result and manifest-centered evidence artifacts with the existing schema and manifest tools
+
+## Validation routing modes
+
+The agent-tooling stack now distinguishes three validation modes:
+
+1. **Ordinary tests** for unit, contract, framework, and other non-runtime checks.
+2. **Scenegraph Harness runtime verification** for runtime-visible requests such as "verify at runtime," "test the running code," "check what appears in game," or "confirm the node exists while playing."
+3. **Combined validation** when a change affects runtime-visible behavior and there is already an existing deterministic test surface.
+
+Use the runtime harness when the request is about proving the running result, not just exercising code paths in isolation.
+Do not substitute runtime verification for normal tests that already cover the changed logic.
+Do not invent new ordinary tests solely to satisfy the combined-validation rule.
+
+If a user already provides an evidence manifest and only wants diagnosis, use the manifest-centered evidence-triage workflow rather than launching a fresh run.
 
 If you want collision events, frame traces, scene snapshots, or other runtime data streams, those still need to be implemented in `addons/agent_runtime_harness/` or another runtime-facing part of the repo. The tooling here helps define what those outputs should look like and how to validate them once they exist.
 
@@ -142,6 +156,11 @@ Recommended deployment flow for a fresh game project:
 
 That flow installs the same `.github/`, `AGENTS.md`, `harness/`, and `project.godot` wiring that the PowerShell deployment script installs from the source repository.
 
+The deployed templates now install two reusable workflow pairs:
+
+- `godot-evidence-triage` for post-run manifest-centered diagnosis
+- `godot-runtime-verification` for end-to-end runtime proof from capability check through persisted bundle review
+
 Examples:
 
 - run a validator yourself before trusting a generated JSON file
@@ -179,6 +198,15 @@ That keeps the plugin self-sufficient after it has been copied into another game
 3. Assemble or update an evidence manifest.
 4. Validate the manifest.
 5. Add or update eval fixtures that describe how an agent should consume the new artifact.
+
+### When verifying a runtime-visible gameplay change
+
+1. Decide whether the task needs runtime verification only or combined validation with existing ordinary tests.
+2. Read the current capability artifact with `pwsh ./tools/automation/get-editor-evidence-capability.ps1 -ProjectRoot <game-root>`.
+3. If capability is ready, write a brokered run request with `pwsh ./tools/automation/request-editor-evidence-run.ps1 -ProjectRoot <game-root> -RequestFixturePath <fixture-path>`.
+4. Wait for the final run result and then read the persisted `evidence-manifest.json` first.
+5. Read summary, diagnostics, and snapshot artifacts only as needed.
+6. Report blocked capability, blocked runs, or missing persisted bundles explicitly instead of guessing from editor narration.
 
 ### When authoring a new prompt or agent artifact
 

--- a/docs/AI_TOOLING_AUTOMATION_MATRIX.md
+++ b/docs/AI_TOOLING_AUTOMATION_MATRIX.md
@@ -16,9 +16,21 @@ Use this matrix to decide whether a repository concern belongs in instructions, 
 
 - Prefer instructions for rules that should apply on most tasks or across a subtree.
 - Prefer scripts for contract validation, manifest assembly, and other deterministic operations.
-- Use prompt artifacts for guided evidence triage where a human still chooses whether to run the workflow.
-- Use agent artifacts only when the repo task is open-ended enough to justify planning and tool iteration.
+- Use prompt artifacts for guided evidence triage or runtime verification where a human still chooses whether to run the workflow.
+- Use agent artifacts when the repo task is open-ended enough to justify planning and tool iteration, including end-to-end runtime verification that may need capability reads, brokered requests, and manifest-first inspection.
 - Defer local skills until the same workflow repeats across multiple tasks or runtimes.
+
+## Validation routing matrix
+
+| Request shape | Validation mode | Best fit | Why |
+|------|----------|----------|-----|
+| Unit, contract, framework, or schema check with no running-game claim | Ordinary tests | Existing test runner or validation script | The task can be proven without runtime scenegraph evidence. |
+| "Verify at runtime," "test the running code," "make sure the node appears in game," or another runtime-visible claim | Scenegraph Harness runtime verification | Runtime-verification prompt or agent plus the editor-evidence workflow | The task needs a brokered run and persisted runtime evidence. |
+| Runtime-visible behavior change plus an existing deterministic direct test surface | Combined validation | Ordinary tests plus runtime-verification workflow | The task needs both code-level and live-runtime proof. |
+| Existing evidence manifest with a request to diagnose the result | Evidence triage | Evidence-triage prompt or agent | A fresh run is unnecessary because the manifest-centered bundle already exists. |
+
+Runtime harness invocation is a routed workflow chosen by task intent.
+It is not a replacement for ordinary tests, and evidence triage is not a replacement for a fresh runtime-verification run.
 
 ## Safety rules
 

--- a/docs/AI_TOOLING_BEST_PRACTICES.md
+++ b/docs/AI_TOOLING_BEST_PRACTICES.md
@@ -234,6 +234,7 @@ Good instruction content includes:
 - style and review expectations
 - known failure modes and required workarounds
 - what to trust first before searching more broadly
+- validation routing rules that should apply on most tasks, such as when to use ordinary tests versus Scenegraph Harness runtime verification
 
 Repo-wide instruction files are a poor place for exhaustive reference material.
 Because this guidance may be attached broadly, large instruction files create noisy context and can lower signal quality.
@@ -258,6 +259,18 @@ Write instructions in a structure the model can parse easily:
 
 Use short headings, flat lists, and concrete commands.
 Prefer exact file paths, exact command names, and exact success criteria over prose-heavy advice.
+
+### Validation routing for this repo
+
+For this repository, the validation taxonomy itself belongs in instructions and `AGENTS.md`:
+
+- ordinary tests
+- Scenegraph Harness runtime verification
+- combined validation
+
+That routing rule is durable and should not be buried only inside a reusable prompt.
+The reusable prompt and agent layer should then carry the end-to-end runtime-verification workflow after the routing decision is made.
+Keep manifest-centered evidence triage separate so post-run diagnosis does not become overloaded with capability checks and run orchestration.
 
 ### Suggested instruction layout for this repo
 
@@ -368,6 +381,7 @@ For this repository in particular:
 - tie agent outputs to machine-readable runtime evidence wherever possible
 - keep Godot-specific API references in docs, not inside every prompt
 - prefer plugin-first and scenario-driven validation language, matching the constitution
+- keep the validation split explicit: instructions choose between ordinary tests, runtime verification, and combined validation, while prompt and agent artifacts execute the chosen workflow
 - document any requirement to inspect sibling checkouts such as ../godot only when truly needed
 
 ## Validation Heuristics

--- a/examples/pong-testbed/harness/automation/requests/run-request.blocked.json
+++ b/examples/pong-testbed/harness/automation/requests/run-request.blocked.json
@@ -1,0 +1,22 @@
+{
+  "requestId": "pong-request-blocked-001",
+  "scenarioId": "pong-scenegraph-blocked-path",
+  "runId": "pong-autonomous-run-blocked-001",
+  "targetScene": "res://scenes/main.tscn",
+  "outputDirectory": "res://evidence/automation/pong-autonomous-run-blocked-001",
+  "artifactRoot": "examples/pong-testbed/evidence/automation/pong-autonomous-run-blocked-001",
+  "expectationFiles": [],
+  "capturePolicy": {
+    "startup": true,
+    "manual": false,
+    "failure": true
+  },
+  "stopPolicy": {
+    "stopAfterValidation": true
+  },
+  "requestedBy": "scenegraph-automation-fixture",
+  "createdAt": "2026-04-12T12:13:00Z",
+  "overrides": {
+    "targetScene": "res://scenes/main.tscn"
+  }
+}

--- a/examples/pong-testbed/harness/automation/requests/run-request.healthy.json
+++ b/examples/pong-testbed/harness/automation/requests/run-request.healthy.json
@@ -1,0 +1,24 @@
+{
+  "requestId": "pong-request-healthy-001",
+  "scenarioId": "pong-scenegraph-happy-path",
+  "runId": "pong-autonomous-run-001",
+  "targetScene": "res://scenes/main.tscn",
+  "outputDirectory": "res://evidence/automation/pong-autonomous-run-001",
+  "artifactRoot": "examples/pong-testbed/evidence/automation/pong-autonomous-run-001",
+  "expectationFiles": [
+    "res://harness/expectations/common.json"
+  ],
+  "capturePolicy": {
+    "startup": true,
+    "manual": true,
+    "failure": true
+  },
+  "stopPolicy": {
+    "stopAfterValidation": true
+  },
+  "requestedBy": "scenegraph-automation-fixture",
+  "createdAt": "2026-04-12T12:12:00Z",
+  "overrides": {
+    "outputDirectory": "res://evidence/automation/pong-autonomous-run-001"
+  }
+}

--- a/examples/pong-testbed/harness/automation/results/capability-blocked.expected.json
+++ b/examples/pong-testbed/harness/automation/results/capability-blocked.expected.json
@@ -1,0 +1,19 @@
+{
+  "checkedAt": "2026-04-12T12:11:00Z",
+  "projectIdentifier": "examples/pong-testbed",
+  "singleTargetReady": false,
+  "launchControlAvailable": true,
+  "runtimeBridgeAvailable": false,
+  "captureControlAvailable": false,
+  "persistenceAvailable": true,
+  "validationAvailable": true,
+  "shutdownControlAvailable": true,
+  "blockedReasons": [
+    "multiple_open_projects",
+    "runtime_bridge_unavailable"
+  ],
+  "recommendedControlPath": "file_broker",
+  "notes": [
+    "The broker must block instead of guessing when the eligible editor target is ambiguous."
+  ]
+}

--- a/examples/pong-testbed/harness/automation/results/capability-options.expected.json
+++ b/examples/pong-testbed/harness/automation/results/capability-options.expected.json
@@ -1,0 +1,18 @@
+{
+  "checkedAt": "2026-04-12T12:26:00Z",
+  "projectIdentifier": "examples/pong-testbed",
+  "singleTargetReady": true,
+  "launchControlAvailable": true,
+  "runtimeBridgeAvailable": true,
+  "captureControlAvailable": true,
+  "persistenceAvailable": true,
+  "validationAvailable": true,
+  "shutdownControlAvailable": true,
+  "blockedReasons": [],
+  "recommendedControlPath": "file_broker",
+  "notes": [
+    "The plugin-owned file broker is the preferred v1 path.",
+    "Editor-script forwarding remains a documented fallback.",
+    "Local IPC is deferred and not part of the supported default path."
+  ]
+}

--- a/examples/pong-testbed/harness/automation/results/capability-ready.expected.json
+++ b/examples/pong-testbed/harness/automation/results/capability-ready.expected.json
@@ -1,0 +1,16 @@
+{
+  "checkedAt": "2026-04-12T12:10:00Z",
+  "projectIdentifier": "examples/pong-testbed",
+  "singleTargetReady": true,
+  "launchControlAvailable": true,
+  "runtimeBridgeAvailable": true,
+  "captureControlAvailable": true,
+  "persistenceAvailable": true,
+  "validationAvailable": true,
+  "shutdownControlAvailable": true,
+  "blockedReasons": [],
+  "recommendedControlPath": "file_broker",
+  "notes": [
+    "The example project is ready for autonomous editor evidence runs."
+  ]
+}

--- a/examples/pong-testbed/harness/automation/results/run-result.attachment-failure.expected.json
+++ b/examples/pong-testbed/harness/automation/results/run-result.attachment-failure.expected.json
@@ -1,0 +1,22 @@
+{
+  "requestId": "pong-request-healthy-001",
+  "runId": "pong-autonomous-run-attachment-failure-001",
+  "finalStatus": "failed",
+  "failureKind": "attachment",
+  "manifestPath": null,
+  "outputDirectory": "res://evidence/automation/pong-autonomous-run-attachment-failure-001",
+  "validationResult": {
+    "manifestExists": false,
+    "artifactRefsChecked": 0,
+    "missingArtifacts": [],
+    "bundleValid": false,
+    "notes": [
+      "The runtime debugger session never attached."
+    ],
+    "validatedAt": "2026-04-12T12:21:00Z"
+  },
+  "terminationStatus": "already_closed",
+  "blockedReasons": [],
+  "controlPath": "file_broker",
+  "completedAt": "2026-04-12T12:21:10Z"
+}

--- a/examples/pong-testbed/harness/automation/results/run-result.blocked.expected.json
+++ b/examples/pong-testbed/harness/automation/results/run-result.blocked.expected.json
@@ -1,0 +1,24 @@
+{
+  "requestId": "pong-request-blocked-001",
+  "runId": "pong-autonomous-run-blocked-001",
+  "finalStatus": "blocked",
+  "failureKind": null,
+  "manifestPath": null,
+  "outputDirectory": "res://evidence/automation/pong-autonomous-run-blocked-001",
+  "validationResult": {
+    "manifestExists": false,
+    "artifactRefsChecked": 0,
+    "missingArtifacts": [],
+    "bundleValid": false,
+    "notes": [
+      "The run was blocked before launch because the editor target was not eligible."
+    ],
+    "validatedAt": "2026-04-12T12:27:00Z"
+  },
+  "terminationStatus": "blocked",
+  "blockedReasons": [
+    "scene_already_running"
+  ],
+  "controlPath": "file_broker",
+  "completedAt": "2026-04-12T12:27:10Z"
+}

--- a/examples/pong-testbed/harness/automation/results/run-result.capture-failure.expected.json
+++ b/examples/pong-testbed/harness/automation/results/run-result.capture-failure.expected.json
@@ -1,0 +1,22 @@
+{
+  "requestId": "pong-request-healthy-001",
+  "runId": "pong-autonomous-run-capture-failure-001",
+  "finalStatus": "failed",
+  "failureKind": "capture",
+  "manifestPath": null,
+  "outputDirectory": "res://evidence/automation/pong-autonomous-run-capture-failure-001",
+  "validationResult": {
+    "manifestExists": false,
+    "artifactRefsChecked": 0,
+    "missingArtifacts": [],
+    "bundleValid": false,
+    "notes": [
+      "Scenegraph capture did not produce a bundle."
+    ],
+    "validatedAt": "2026-04-12T12:22:00Z"
+  },
+  "terminationStatus": "already_closed",
+  "blockedReasons": [],
+  "controlPath": "file_broker",
+  "completedAt": "2026-04-12T12:22:10Z"
+}

--- a/examples/pong-testbed/harness/automation/results/run-result.gameplay-failure.expected.json
+++ b/examples/pong-testbed/harness/automation/results/run-result.gameplay-failure.expected.json
@@ -1,0 +1,22 @@
+{
+  "requestId": "pong-request-healthy-001",
+  "runId": "pong-autonomous-run-gameplay-failure-001",
+  "finalStatus": "failed",
+  "failureKind": "gameplay",
+  "manifestPath": "examples/pong-testbed/harness/expected-evidence-manifest.json",
+  "outputDirectory": "res://evidence",
+  "validationResult": {
+    "manifestExists": true,
+    "artifactRefsChecked": 3,
+    "missingArtifacts": [],
+    "bundleValid": true,
+    "notes": [
+      "Evidence was captured, but scenario expectations still failed."
+    ],
+    "validatedAt": "2026-04-12T12:25:00Z"
+  },
+  "terminationStatus": "stopped_cleanly",
+  "blockedReasons": [],
+  "controlPath": "file_broker",
+  "completedAt": "2026-04-12T12:25:20Z"
+}

--- a/examples/pong-testbed/harness/automation/results/run-result.shutdown-failure.expected.json
+++ b/examples/pong-testbed/harness/automation/results/run-result.shutdown-failure.expected.json
@@ -1,0 +1,22 @@
+{
+  "requestId": "pong-request-healthy-001",
+  "runId": "pong-autonomous-run-shutdown-failure-001",
+  "finalStatus": "failed",
+  "failureKind": "shutdown",
+  "manifestPath": "examples/pong-testbed/harness/expected-evidence-manifest.json",
+  "outputDirectory": "res://evidence",
+  "validationResult": {
+    "manifestExists": true,
+    "artifactRefsChecked": 3,
+    "missingArtifacts": [],
+    "bundleValid": true,
+    "notes": [
+      "Evidence validated, but the editor play session did not stop cleanly."
+    ],
+    "validatedAt": "2026-04-12T12:24:00Z"
+  },
+  "terminationStatus": "shutdown_failed",
+  "blockedReasons": [],
+  "controlPath": "file_broker",
+  "completedAt": "2026-04-12T12:24:20Z"
+}

--- a/examples/pong-testbed/harness/automation/results/run-result.success.expected.json
+++ b/examples/pong-testbed/harness/automation/results/run-result.success.expected.json
@@ -1,0 +1,22 @@
+{
+  "requestId": "pong-request-healthy-001",
+  "runId": "pong-autonomous-run-001",
+  "finalStatus": "completed",
+  "failureKind": null,
+  "manifestPath": "examples/pong-testbed/harness/expected-evidence-manifest.json",
+  "outputDirectory": "res://evidence",
+  "validationResult": {
+    "manifestExists": true,
+    "artifactRefsChecked": 3,
+    "missingArtifacts": [],
+    "bundleValid": true,
+    "notes": [
+      "Manifest and referenced scenegraph artifacts passed validation."
+    ],
+    "validatedAt": "2026-04-12T12:20:00Z"
+  },
+  "terminationStatus": "stopped_cleanly",
+  "blockedReasons": [],
+  "controlPath": "file_broker",
+  "completedAt": "2026-04-12T12:20:30Z"
+}

--- a/examples/pong-testbed/harness/automation/results/run-result.validation-failure.expected.json
+++ b/examples/pong-testbed/harness/automation/results/run-result.validation-failure.expected.json
@@ -1,0 +1,24 @@
+{
+  "requestId": "pong-request-healthy-001",
+  "runId": "pong-autonomous-run-validation-failure-001",
+  "finalStatus": "failed",
+  "failureKind": "validation",
+  "manifestPath": "examples/pong-testbed/harness/expected-evidence-manifest.json",
+  "outputDirectory": "res://evidence",
+  "validationResult": {
+    "manifestExists": true,
+    "artifactRefsChecked": 3,
+    "missingArtifacts": [
+      "examples/pong-testbed/evidence/missing-scenegraph-summary.json"
+    ],
+    "bundleValid": false,
+    "notes": [
+      "Manifest references did not validate for the current run."
+    ],
+    "validatedAt": "2026-04-12T12:23:00Z"
+  },
+  "terminationStatus": "stopped_cleanly",
+  "blockedReasons": [],
+  "controlPath": "file_broker",
+  "completedAt": "2026-04-12T12:23:20Z"
+}

--- a/examples/pong-testbed/harness/inspection-run-config.json
+++ b/examples/pong-testbed/harness/inspection-run-config.json
@@ -1,12 +1,31 @@
 {
   "scenarioId": "pong-scenegraph-happy-path",
   "runId": "pong-scenegraph-happy-path-run-01",
+  "targetScene": "res://scenes/main.tscn",
   "outputDirectory": "res://evidence",
   "artifactRoot": "examples/pong-testbed/evidence",
   "capturePolicy": {
     "startup": true,
     "manual": true,
     "failure": true
+  },
+  "automation": {
+    "requestPath": "res://harness/automation/requests/run-request.json",
+    "requestsDirectory": "res://harness/automation/requests",
+    "resultsDirectory": "res://harness/automation/results",
+    "capabilityResultPath": "res://harness/automation/results/capability.json",
+    "lifecycleStatusPath": "res://harness/automation/results/lifecycle-status.json",
+    "runResultPath": "res://harness/automation/results/run-result.json"
+  },
+  "defaultRequestOverrides": {
+    "capturePolicy": {
+      "startup": true,
+      "manual": true,
+      "failure": true
+    },
+    "stopPolicy": {
+      "stopAfterValidation": true
+    }
   },
   "expectationFiles": [
     "res://harness/expectations/common.json"

--- a/examples/pong-testbed/project.godot
+++ b/examples/pong-testbed/project.godot
@@ -16,3 +16,5 @@ enabled=PackedStringArray("res://../../addons/agent_runtime_harness/plugin.cfg")
 
 [harness]
 inspection_run_config="res://harness/inspection-run-config.json"
+automation_request_path="res://harness/automation/requests/run-request.json"
+automation_results_directory="res://harness/automation/results"

--- a/specs/001-agent-tooling-foundation/quickstart.md
+++ b/specs/001-agent-tooling-foundation/quickstart.md
@@ -36,9 +36,16 @@ Validate that the first-release tooling works in VS Code Copilot Chat and Copilo
 4. Emit the machine-readable run log with `pwsh ./tools/automation/new-autonomous-run-record.ps1 -ArtifactId 'godot-evidence-triage.agent' -WriteBoundaryId 'godot-evidence-triage-first-release' -RequestSummary 'Validate in-scope eval result output for manifest-centered evidence triage.' -OperationPath 'tools/evals/001-agent-tooling-foundation/us3-validation-results.json' -OperationEditType 'update' -OperationStatus 'performed' -OperationNote 'Eval result file updated inside the declared boundary.' -ValidationName 'write-boundary-check' -ValidationStatus 'pass' -ValidationDetails 'Requested eval result path is allowed by the boundary contract.' -OutputPath 'tools/automation/run-records/godot-evidence-triage-validation.json'`.
 5. Record the validation result in `tools/evals/001-agent-tooling-foundation/us3-validation-results.json` and validate it with `pwsh ./tools/validate-json.ps1 -InputPath 'tools/evals/001-agent-tooling-foundation/us3-validation-results.json' -SchemaPath 'tools/evals/agent-eval-result.schema.json'`.
 
-## 5. Final Validation
+## 5. Runtime Routing Validation
 
-1. Confirm the story result files exist in `tools/evals/001-agent-tooling-foundation/`.
+1. Use `tools/evals/001-agent-tooling-foundation/us4-runtime-routing.md` to review how the guidance stack routes ambiguous testing language.
+2. Compare the resulting classifications against `tools/evals/001-agent-tooling-foundation/us4-expected-results.json`.
+3. Confirm the routing distinguishes between ordinary tests, Scenegraph Harness runtime verification, combined validation, and post-run evidence triage.
+4. Validate `tools/evals/001-agent-tooling-foundation/us4-routing-results.json` with `pwsh ./tools/validate-json.ps1 -InputPath 'tools/evals/001-agent-tooling-foundation/us4-routing-results.json' -SchemaPath 'tools/evals/agent-eval-result.schema.json'`.
+
+## 6. Final Validation
+
+1. Confirm the story result files exist in `tools/evals/001-agent-tooling-foundation/`, including the runtime-routing eval outputs.
 2. Validate `tools/evals/001-agent-tooling-foundation/final-validation-results.json` with `pwsh ./tools/validate-json.ps1 -InputPath 'tools/evals/001-agent-tooling-foundation/final-validation-results.json' -SchemaPath 'tools/evals/agent-eval-result.schema.json'`.
 
 ## Exit Criteria
@@ -46,4 +53,5 @@ Validate that the first-release tooling works in VS Code Copilot Chat and Copilo
 - Copilot Chat and Copilot CLI both consume the planned guidance stack successfully.
 - Evidence manifests validate and point cleanly to raw runtime artifacts.
 - At least one autonomous artifact stays fully within its declared write boundary during seeded evals.
+- Ambiguous testing requests route cleanly to ordinary tests, Scenegraph Harness runtime verification, combined validation, or evidence triage.
 - Evaluation results are concrete enough to retain, narrow, or remove shipped tooling artifacts.

--- a/specs/003-editor-evidence-loop/checklists/requirements.md
+++ b/specs/003-editor-evidence-loop/checklists/requirements.md
@@ -1,0 +1,37 @@
+# Specification Quality Checklist: Autonomous Editor Evidence Loop
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning  
+**Created**: 2026-04-12  
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Validation passed on the first review.
+- The spec intentionally keeps packaged executable launches out of scope and treats the one-time deploy-assets action as an acceptable prerequisite rather than part of the automated loop.
+- The spec preserves the current manifest-centered evidence handoff and focuses the new work on editor-run orchestration and capability reporting.
+- Clarification pass on 2026-04-12 made three policy decisions explicit: full autonomous start-and-stop behavior is required, validation is always part of the run contract, and the first release blocks ambiguous multi-project targeting.

--- a/specs/003-editor-evidence-loop/contracts/automation-capability.schema.json
+++ b/specs/003-editor-evidence-loop/contracts/automation-capability.schema.json
@@ -1,0 +1,68 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://godot-agent-harness.local/specs/003-editor-evidence-loop/contracts/automation-capability.schema.json",
+  "title": "Automation Capability Result",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "checkedAt",
+    "projectIdentifier",
+    "singleTargetReady",
+    "launchControlAvailable",
+    "runtimeBridgeAvailable",
+    "captureControlAvailable",
+    "persistenceAvailable",
+    "validationAvailable",
+    "shutdownControlAvailable",
+    "blockedReasons",
+    "recommendedControlPath"
+  ],
+  "properties": {
+    "checkedAt": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "projectIdentifier": {
+      "type": "string",
+      "minLength": 1
+    },
+    "singleTargetReady": {
+      "type": "boolean"
+    },
+    "launchControlAvailable": {
+      "type": "boolean"
+    },
+    "runtimeBridgeAvailable": {
+      "type": "boolean"
+    },
+    "captureControlAvailable": {
+      "type": "boolean"
+    },
+    "persistenceAvailable": {
+      "type": "boolean"
+    },
+    "validationAvailable": {
+      "type": "boolean"
+    },
+    "shutdownControlAvailable": {
+      "type": "boolean"
+    },
+    "blockedReasons": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "recommendedControlPath": {
+      "type": "string",
+      "enum": ["file_broker", "editor_script_forwarder", "local_ipc"]
+    },
+    "notes": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    }
+  }
+}

--- a/specs/003-editor-evidence-loop/contracts/automation-lifecycle-status.schema.json
+++ b/specs/003-editor-evidence-loop/contracts/automation-lifecycle-status.schema.json
@@ -1,0 +1,65 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://godot-agent-harness.local/specs/003-editor-evidence-loop/contracts/automation-lifecycle-status.schema.json",
+  "title": "Automation Lifecycle Status",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "requestId",
+    "runId",
+    "status",
+    "details",
+    "timestamp"
+  ],
+  "properties": {
+    "requestId": {
+      "type": "string",
+      "minLength": 1
+    },
+    "runId": {
+      "type": "string",
+      "minLength": 1
+    },
+    "status": {
+      "type": "string",
+      "enum": [
+        "received",
+        "blocked",
+        "launching",
+        "awaiting_runtime",
+        "capturing",
+        "persisting",
+        "validating",
+        "stopping",
+        "completed",
+        "failed"
+      ]
+    },
+    "details": {
+      "type": "string",
+      "minLength": 1
+    },
+    "timestamp": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "sessionId": {
+      "type": "string"
+    },
+    "controlPath": {
+      "type": "string",
+      "enum": ["file_broker", "editor_script_forwarder", "local_ipc"]
+    },
+    "failureKind": {
+      "type": "string",
+      "enum": ["launch", "attachment", "capture", "persistence", "validation", "shutdown", "gameplay"]
+    },
+    "evidenceRefs": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    }
+  }
+}

--- a/specs/003-editor-evidence-loop/contracts/automation-run-request.schema.json
+++ b/specs/003-editor-evidence-loop/contracts/automation-run-request.schema.json
@@ -1,0 +1,123 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://godot-agent-harness.local/specs/003-editor-evidence-loop/contracts/automation-run-request.schema.json",
+  "title": "Automation Run Request",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "requestId",
+    "scenarioId",
+    "runId",
+    "outputDirectory",
+    "artifactRoot",
+    "expectationFiles",
+    "capturePolicy",
+    "stopPolicy",
+    "requestedBy",
+    "createdAt"
+  ],
+  "properties": {
+    "requestId": {
+      "type": "string",
+      "minLength": 1
+    },
+    "scenarioId": {
+      "type": "string",
+      "minLength": 1
+    },
+    "runId": {
+      "type": "string",
+      "minLength": 1
+    },
+    "targetScene": {
+      "type": "string",
+      "minLength": 1
+    },
+    "outputDirectory": {
+      "type": "string",
+      "minLength": 1
+    },
+    "artifactRoot": {
+      "type": "string"
+    },
+    "expectationFiles": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "capturePolicy": {
+      "$ref": "#/$defs/capturePolicy"
+    },
+    "stopPolicy": {
+      "$ref": "#/$defs/stopPolicy"
+    },
+    "requestedBy": {
+      "type": "string",
+      "minLength": 1
+    },
+    "createdAt": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "overrides": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "targetScene": {
+          "type": "string",
+          "minLength": 1
+        },
+        "outputDirectory": {
+          "type": "string",
+          "minLength": 1
+        },
+        "artifactRoot": {
+          "type": "string"
+        },
+        "expectationFiles": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "capturePolicy": {
+          "$ref": "#/$defs/capturePolicy"
+        },
+        "stopPolicy": {
+          "$ref": "#/$defs/stopPolicy"
+        }
+      }
+    }
+  },
+  "$defs": {
+    "capturePolicy": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["startup", "manual", "failure"],
+      "properties": {
+        "startup": {
+          "type": "boolean"
+        },
+        "manual": {
+          "type": "boolean"
+        },
+        "failure": {
+          "type": "boolean"
+        }
+      }
+    },
+    "stopPolicy": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["stopAfterValidation"],
+      "properties": {
+        "stopAfterValidation": {
+          "type": "boolean"
+        }
+      }
+    }
+  }
+}

--- a/specs/003-editor-evidence-loop/contracts/automation-run-result.schema.json
+++ b/specs/003-editor-evidence-loop/contracts/automation-run-result.schema.json
@@ -1,0 +1,116 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://godot-agent-harness.local/specs/003-editor-evidence-loop/contracts/automation-run-result.schema.json",
+  "title": "Automation Run Result",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "requestId",
+    "runId",
+    "finalStatus",
+    "failureKind",
+    "manifestPath",
+    "outputDirectory",
+    "validationResult",
+    "terminationStatus",
+    "completedAt"
+  ],
+  "properties": {
+    "requestId": {
+      "type": "string",
+      "minLength": 1
+    },
+    "runId": {
+      "type": "string",
+      "minLength": 1
+    },
+    "finalStatus": {
+      "type": "string",
+      "enum": ["completed", "blocked", "failed"]
+    },
+    "failureKind": {
+      "type": ["string", "null"],
+      "enum": ["launch", "attachment", "capture", "persistence", "validation", "shutdown", "gameplay", null]
+    },
+    "manifestPath": {
+      "type": ["string", "null"]
+    },
+    "outputDirectory": {
+      "type": "string"
+    },
+    "validationResult": {
+      "$ref": "#/$defs/validationResult"
+    },
+    "terminationStatus": {
+      "type": "string",
+      "enum": [
+        "not_started",
+        "running",
+        "stopping",
+        "stopped_cleanly",
+        "already_closed",
+        "crashed",
+        "shutdown_failed",
+        "blocked",
+        "unknown"
+      ]
+    },
+    "blockedReasons": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "controlPath": {
+      "type": "string",
+      "enum": ["file_broker", "editor_script_forwarder", "local_ipc"]
+    },
+    "completedAt": {
+      "type": "string",
+      "format": "date-time"
+    }
+  },
+  "$defs": {
+    "validationResult": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "manifestExists",
+        "artifactRefsChecked",
+        "missingArtifacts",
+        "bundleValid",
+        "notes",
+        "validatedAt"
+      ],
+      "properties": {
+        "manifestExists": {
+          "type": "boolean"
+        },
+        "artifactRefsChecked": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "missingArtifacts": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "bundleValid": {
+          "type": "boolean"
+        },
+        "notes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "validatedAt": {
+          "type": ["string", "null"],
+          "format": "date-time"
+        }
+      }
+    }
+  }
+}

--- a/specs/003-editor-evidence-loop/contracts/editor-evidence-loop-contract.md
+++ b/specs/003-editor-evidence-loop/contracts/editor-evidence-loop-contract.md
@@ -1,0 +1,96 @@
+# Contract: Editor Evidence Loop
+
+## Purpose
+
+Define the planned machine-readable contract between a workspace-side agent and the open Godot editor for autonomous scenegraph evidence runs.
+
+## Contract Surfaces
+
+### Capability Result
+
+- **Role**: Reports whether the current open-editor environment is safe to target.
+- **Produced by**: Editor-owned automation broker.
+- **Consumed by**: VS Code agent or deterministic helper workflow.
+- **Minimum fields**:
+  - `singleTargetReady`
+  - `launchControlAvailable`
+  - `runtimeBridgeAvailable`
+  - `captureControlAvailable`
+  - `persistenceAvailable`
+  - `validationAvailable`
+  - `shutdownControlAvailable`
+  - `blockedReasons`
+  - `recommendedControlPath`
+
+### Automated Run Request
+
+- **Role**: Tells the editor broker to perform one end-to-end autonomous run.
+- **Produced by**: VS Code agent or deterministic helper workflow.
+- **Consumed by**: Editor-owned automation broker.
+- **Minimum fields**:
+  - `requestId`
+  - `scenarioId`
+  - `runId`
+  - `outputDirectory`
+  - `artifactRoot`
+  - `expectationFiles`
+  - `capturePolicy`
+  - `stopPolicy`
+  - `requestedBy`
+  - `createdAt`
+
+### Lifecycle Status
+
+- **Role**: Exposes observable progress without requiring the agent to infer state from raw evidence files.
+- **Produced by**: Editor-owned automation broker.
+- **Consumed by**: VS Code agent or deterministic helper workflow.
+- **Expected states**:
+  - `received`
+  - `blocked`
+  - `launching`
+  - `awaiting_runtime`
+  - `capturing`
+  - `persisting`
+  - `validating`
+  - `stopping`
+  - `completed`
+  - `failed`
+
+### Automated Run Result
+
+- **Role**: Final machine-readable outcome for the autonomous run.
+- **Produced by**: Editor-owned automation broker.
+- **Consumed by**: VS Code agent.
+- **Minimum fields**:
+  - `requestId`
+  - `runId`
+  - `finalStatus`
+  - `failureKind`
+  - `manifestPath`
+  - `outputDirectory`
+  - `validationResult`
+  - `terminationStatus`
+  - `completedAt`
+
+## Evidence Requirements
+
+- The run result must reference the manifest-centered evidence bundle rather than embedding all raw runtime artifacts inline.
+- The manifest remains the primary handoff surface for scenegraph snapshot, diagnostics, and summary artifacts.
+- A run cannot report success until the manifest and referenced artifacts have been validated.
+- The evidence bundle must be traceable to the current `runId` so stale outputs cannot satisfy a new request accidentally.
+
+## Control Path Options
+
+| Option | Status | Summary | Why | Risk |
+|--------|--------|---------|-----|------|
+| Plugin-owned file broker | Preferred for v1 | Workspace-visible request and result artifacts are exchanged with the open editor plugin. | Deterministic, inspectable, and aligned with plugin-first design. | Requires safe file polling or ingestion semantics. |
+| Editor-script forwarder | Viable fallback | A deterministic command forwards the request into the same plugin-owned orchestration path. | Could bootstrap automation if a persistent broker is not ready. | May complicate the already-open-editor assumption. |
+| Local IPC broker | Deferred | Plugin exposes a loopback command surface. | Richer control and progress streaming. | More security and lifecycle complexity than v1 needs. |
+| External GUI automation | Rejected | Simulate user interaction to press play and stop. | No plugin changes required. | Brittle, opaque, and contrary to repo guidance. |
+
+## Safety Requirements
+
+- The broker must block when more than one eligible open project or session could satisfy the request.
+- The broker must process at most one autonomous run at a time for the first release and reject overlap with a machine-readable blocked result.
+- Any workspace-side helper that writes request artifacts should integrate with the repository’s existing automation boundary and run-log guidance when those helpers are added.
+- Launch, validation, and shutdown failures must be distinguishable in machine-readable form.

--- a/specs/003-editor-evidence-loop/contracts/editor-evidence-loop-contract.md
+++ b/specs/003-editor-evidence-loop/contracts/editor-evidence-loop-contract.md
@@ -6,6 +6,18 @@ Define the planned machine-readable contract between a workspace-side agent and 
 
 ## Contract Surfaces
 
+The implemented v1 control surface is the plugin-owned file broker:
+
+- Requests: `harness/automation/requests/run-request.json`
+- Capability: `harness/automation/results/capability.json`
+- Lifecycle status: `harness/automation/results/lifecycle-status.json`
+- Final run result: `harness/automation/results/run-result.json`
+
+Workspace-side helpers mirror those paths:
+
+- `pwsh ./tools/automation/get-editor-evidence-capability.ps1`
+- `pwsh ./tools/automation/request-editor-evidence-run.ps1`
+
 ### Capability Result
 
 - **Role**: Reports whether the current open-editor environment is safe to target.
@@ -94,3 +106,4 @@ Define the planned machine-readable contract between a workspace-side agent and 
 - The broker must process at most one autonomous run at a time for the first release and reject overlap with a machine-readable blocked result.
 - Any workspace-side helper that writes request artifacts should integrate with the repository’s existing automation boundary and run-log guidance when those helpers are added.
 - Launch, validation, and shutdown failures must be distinguishable in machine-readable form.
+- Agents should read the capability or final run-result artifact before opening raw scenegraph evidence files.

--- a/specs/003-editor-evidence-loop/data-model.md
+++ b/specs/003-editor-evidence-loop/data-model.md
@@ -1,0 +1,154 @@
+# Data Model: Autonomous Editor Evidence Loop
+
+## Entities
+
+### Automation Capability Result
+
+- **Purpose**: Describes whether the current open-editor project can accept an autonomous run request safely.
+- **Fields**:
+  - `checked_at`: Timestamp for the capability evaluation.
+  - `project_identifier`: Canonical identifier for the eligible open project.
+  - `single_target_ready`: Whether exactly one eligible project or editor session was found.
+  - `launch_control_available`: Whether the plugin can start playtesting.
+  - `runtime_bridge_available`: Whether debugger-backed runtime coordination is available.
+  - `capture_control_available`: Whether capture can be triggered for the active project.
+  - `persistence_available`: Whether bundle persistence is wired and writable.
+  - `validation_available`: Whether the manifest and artifact validation path is available.
+  - `shutdown_control_available`: Whether the plugin can stop the play session after validation.
+  - `blocked_reasons`: Array of machine-readable reasons when the run cannot proceed.
+  - `recommended_control_path`: Preferred automation path for the environment.
+
+### Automated Run Request
+
+- **Purpose**: The machine-readable request an agent submits to start one autonomous evidence run.
+- **Fields**:
+  - `request_id`: Stable identifier for the request artifact.
+  - `scenario_id`: Scenario or validation target identifier.
+  - `run_id`: Intended evidence run identifier.
+  - `output_directory`: Target directory for the evidence bundle.
+  - `artifact_root`: Artifact root to use in the persisted manifest.
+  - `expectation_files`: Optional expectation file list.
+  - `capture_policy`: Startup, explicit, or failure-triggered capture preferences.
+  - `stop_policy`: Whether the session should end automatically after validation.
+  - `requested_by`: Request origin such as VS Code agent or workflow helper.
+  - `created_at`: Request timestamp.
+
+### Automation Control Path
+
+- **Purpose**: Identifies which cross-tool orchestration pattern is active for a run.
+- **Fields**:
+  - `path_kind`: `file_broker`, `editor_script_forwarder`, or `local_ipc`.
+  - `default_for_v1`: Whether this path is the first-release default.
+  - `supports_launch`: Whether the path can trigger play start.
+  - `supports_shutdown`: Whether the path can stop the session after validation.
+  - `supports_status_updates`: Whether the path can expose incremental lifecycle state.
+  - `notes`: Short explanation of assumptions or limits.
+
+### Automated Run Session
+
+- **Purpose**: Represents one end-to-end autonomous run managed by the editor plugin.
+- **Fields**:
+  - `request_id`: Source Automated Run Request identifier.
+  - `session_id`: Editor-side session identifier.
+  - `run_id`: Persisted evidence run identifier.
+  - `scenario_id`: Scenario identifier.
+  - `status`: Current lifecycle status.
+  - `play_state`: Editor play session state.
+  - `started_at`: Run start timestamp.
+  - `ended_at`: Run end timestamp when available.
+  - `control_path`: Automation Control Path record.
+  - `manifest_path`: Final manifest path when available.
+  - `validation_result`: Final Run Validation Result when available.
+  - `termination_status`: How play ended.
+- **Relationships**:
+  - One Automated Run Session is created from one Automated Run Request.
+  - One Automated Run Session produces one final Automated Run Result.
+  - One Automated Run Session may emit many Lifecycle Status records.
+
+### Lifecycle Status Record
+
+- **Purpose**: Captures a point-in-time machine-readable state transition for the autonomous run.
+- **Fields**:
+  - `request_id`: Parent request identifier.
+  - `run_id`: Parent run identifier.
+  - `status`: `received`, `blocked`, `launching`, `awaiting_runtime`, `capturing`, `persisting`, `validating`, `stopping`, `completed`, or `failed`.
+  - `details`: Short human-readable explanation.
+  - `timestamp`: Status timestamp.
+  - `evidence_refs`: Optional manifest or artifact references already known at that point.
+
+### Automated Run Result
+
+- **Purpose**: Final machine-readable outcome returned to the agent after the run finishes or fails.
+- **Fields**:
+  - `request_id`: Source request identifier.
+  - `run_id`: Final run identifier.
+  - `final_status`: Completed, blocked, or failed.
+  - `failure_kind`: Launch, attachment, capture, persistence, validation, shutdown, or gameplay failure when relevant.
+  - `manifest_path`: Final manifest path when available.
+  - `output_directory`: Final evidence directory.
+  - `validation_result`: Final validation details.
+  - `termination_status`: Whether play stopped cleanly, crashed, or was already closed.
+  - `completed_at`: Completion timestamp.
+
+### Run Validation Result
+
+- **Purpose**: Confirms whether the evidence bundle produced by the run is safe for agent consumption.
+- **Fields**:
+  - `manifest_exists`: Whether the manifest file exists.
+  - `artifact_refs_checked`: Number of referenced artifacts checked.
+  - `missing_artifacts`: List of missing artifact paths.
+  - `bundle_valid`: Whether the bundle passed validation.
+  - `notes`: Validation notes for the agent.
+  - `validated_at`: Validation timestamp.
+
+### Persisted Evidence Bundle
+
+- **Purpose**: Existing manifest-centered scenegraph evidence package produced by the autonomous run.
+- **Fields**:
+  - `manifest`: Persisted manifest dictionary.
+  - `snapshot_artifact`: Scenegraph snapshot artifact.
+  - `diagnostics_artifact`: Scenegraph diagnostics artifact.
+  - `summary_artifact`: Scenegraph summary artifact.
+- **Relationships**:
+  - One Persisted Evidence Bundle belongs to one Automated Run Session.
+
+## State Transitions
+
+### Capability Flow
+
+1. `unknown` → project has not been checked yet.
+2. `ready` → exactly one eligible project exists and all required control surfaces are available.
+3. `blocked` → ambiguity or a prerequisite gap prevents autonomous execution.
+
+### Automated Run Lifecycle
+
+1. `received` → request artifact accepted.
+2. `launching` → plugin initiates the editor play session.
+3. `awaiting_runtime` → waiting for debugger-backed runtime attachment.
+4. `capturing` → startup or explicit capture occurs.
+5. `persisting` → latest bundle is being written.
+6. `validating` → manifest and referenced artifacts are being checked.
+7. `stopping` → plugin ends the play session after validation.
+8. `completed` → result artifact written successfully.
+9. `blocked` → prerequisites or target selection prevented execution.
+10. `failed` → a lifecycle stage failed and the result records the failure kind.
+
+### Termination Flow
+
+1. `not_started` → no play session exists yet.
+2. `running` → editor play session is active.
+3. `stopping` → plugin requested shutdown.
+4. `stopped_cleanly` → play ended as intended.
+5. `already_closed` → runtime ended before requested shutdown.
+6. `crashed` → runtime exited unexpectedly.
+7. `shutdown_failed` → stop request did not complete as expected.
+
+## Invariants
+
+- Only one eligible open project may be targeted in the first release.
+- Only one active Automated Run Session may be in progress for that project at a time.
+- Overlapping run requests must be rejected with a blocked result rather than queued.
+- A run cannot report `completed` unless `bundle_valid` is true.
+- A run cannot report success if `termination_status` is unknown after validation.
+- A final result must always identify the failure kind when `final_status` is `failed`.
+- Evidence reported for a run must match the run’s `run_id` and output directory.

--- a/specs/003-editor-evidence-loop/plan.md
+++ b/specs/003-editor-evidence-loop/plan.md
@@ -1,0 +1,141 @@
+
+# Implementation Plan: Autonomous Editor Evidence Loop
+
+**Branch**: `[003-create-feature-branch]` | **Date**: 2026-04-12 | **Spec**: [specs/003-editor-evidence-loop/spec.md](specs/003-editor-evidence-loop/spec.md)
+**Input**: Feature specification from `/specs/003-editor-evidence-loop/spec.md`
+
+## Summary
+
+Close the edit-run-capture-persist-validate-stop loop for a Godot project that is already open in the editor by adding an editor-owned automation path on top of the existing scenegraph harness. The plan keeps the current runtime capture, debugger transport, and manifest-centered evidence bundle as the core product surface, then layers in a deterministic automation broker that can accept a machine-readable run request, start the editor play session, coordinate capture and persistence, validate the resulting evidence bundle, stop the session, and return a machine-readable run result. Where the implementation path is not fully proven yet, the plan captures concrete alternatives and explicitly defers the ones that add more complexity than the first release can justify.
+
+## Technical Context
+
+**Language/Version**: GDScript for Godot 4.x addon and runtime scripts, Markdown planning artifacts, JSON request and result contracts, and optional PowerShell support scripts for deterministic local workflows  
+**Primary Dependencies**: Godot `EditorPlugin`, editor-owned run-control surfaces, `EditorDebuggerPlugin`, `EditorDebuggerSession`, `EngineDebugger`, existing harness runtime scripts under `addons/agent_runtime_harness/`, evidence helpers under `tools/evidence/`, and automation guardrails under `tools/automation/`  
+**Storage**: Machine-readable JSON request, capability, status, and result artifacts under project-local harness directories; manifest-centered scenegraph evidence under project evidence output directories; feature docs under `specs/003-editor-evidence-loop/`  
+**Testing**: Deterministic Godot editor validation in `examples/pong-testbed/`, manifest validation with `pwsh ./tools/evidence/validate-evidence-manifest.ps1`, JSON validation with `pwsh ./tools/validate-json.ps1` where applicable, and existing PowerShell test coverage if new helper scripts are introduced  
+**Target Platform**: Godot 4.x editor with the project already open on the same machine as VS Code, Windows first with design choices that remain portable where practical  
+**Project Type**: Editor addon plus runtime addon and debugger integration, with a local automation broker contract for agent-driven playtest control  
+**Performance Goals**: Reach a validated persisted evidence bundle and stopped play session within the spec target of 3 minutes; keep automation polling or coordination light enough to avoid noticeable editor stalls during normal playtesting; avoid stale-artifact confusion across repeated runs  
+**Constraints**: Plugin-first, no engine fork, packaged executable launches out of scope, mandatory evidence validation before success, single eligible open project in v1, machine-readable blocked results instead of hidden manual fallback, reuse the existing manifest-centered evidence contract before inventing new bundle formats  
+**Scale/Scope**: Primarily touches `addons/agent_runtime_harness/`, addon template assets under `addons/agent_runtime_harness/templates/project_root/`, deterministic validation assets under `examples/pong-testbed/`, feature docs under `specs/003-editor-evidence-loop/`, and only minimal helper tooling under `tools/` if deterministic submission or validation helpers are justified
+
+## Reference Inputs
+
+- **Internal Docs**: `README.md`, `AGENTS.md`, `docs/AGENT_RUNTIME_HARNESS.md`, `docs/AGENT_TOOLING_FOUNDATION.md`, `docs/AI_TOOLING_AUTOMATION_MATRIX.md`, `docs/AI_TOOLING_BEST_PRACTICES.md`, `docs/GODOT_PLUGIN_REFERENCES.md`, `specs/002-inspect-scene-tree/spec.md`, `specs/002-inspect-scene-tree/plan.md`, `specs/002-inspect-scene-tree/research.md`, `specs/002-inspect-scene-tree/data-model.md`, `specs/002-inspect-scene-tree/quickstart.md`, `addons/agent_runtime_harness/plugin.gd`, `addons/agent_runtime_harness/editor/scenegraph_dock.gd`, `addons/agent_runtime_harness/editor/scenegraph_debugger_bridge.gd`, `addons/agent_runtime_harness/runtime/scenegraph_runtime.gd`, `addons/agent_runtime_harness/runtime/scenegraph_artifact_writer.gd`, `addons/agent_runtime_harness/shared/inspection_constants.gd`
+- **External Docs**: Godot editor plugins overview, `EditorPlugin`, `EditorDebuggerPlugin`, `EditorDebuggerSession`, `EngineDebugger`, autoload singletons, and scene tree documentation as cited in the spec
+- **Source References**: No `../godot` source files were inspected for this plan. Current repo docs plus the existing addon, debugger, and runtime harness surfaces were sufficient to define a plugin-first implementation path.
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+- [x] Plugin-first approach preserved: the plan stays within editor plugin, runtime addon, debugger transport, and project-local automation artifacts, with no engine changes planned.
+- [x] Reference coverage complete: internal docs, external Godot references, and current repo source surfaces are cited for the key technical decisions.
+- [x] Runtime evidence defined: the plan names the capability report, run lifecycle record, manifest-centered evidence bundle, and validation result as machine-readable outputs.
+- [x] Test loop defined: each story maps to a deterministic editor-run validation path in the example project, including blocked, healthy, and failure outcomes.
+- [x] Reuse justified: the plan extends the existing scenegraph harness, manifest bundle, and automation safety guidance instead of creating a separate runtime-evidence system.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/003-editor-evidence-loop/
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── contracts/
+│   └── editor-evidence-loop-contract.md
+└── tasks.md
+```
+
+### Source Code (repository root)
+
+```text
+addons/
+└── agent_runtime_harness/
+
+docs/
+├── AGENT_RUNTIME_HARNESS.md
+├── AGENT_TOOLING_FOUNDATION.md
+├── AI_TOOLING_AUTOMATION_MATRIX.md
+└── GODOT_PLUGIN_REFERENCES.md
+
+examples/
+└── pong-testbed/
+
+tools/
+├── automation/
+└── evidence/
+```
+
+**Structure Decision**: Keep the implementation centered in `addons/agent_runtime_harness/` because the open-editor control loop belongs to the plugin and its existing debugger bridge. Extend the addon’s project-root templates so a target game can receive any new automation request or result paths during the existing one-time deployment step. Use `examples/pong-testbed/` for deterministic validation scenes and expected artifacts. Touch `tools/evidence/` only if the existing manifest validators need narrow updates, and touch `tools/automation/` only if a deterministic workspace-side helper or run-log contract is needed to support approval-free automation safely.
+
+## Implementation Alternatives
+
+### Preferred V1 Path: Editor-owned automation broker plus workspace-visible request and result artifacts
+
+- The Godot plugin owns launch, capture, persist, validate, and stop orchestration inside the open editor session.
+- A VS Code agent triggers that flow by writing a machine-readable run request into a project-local harness path the plugin watches or polls.
+- The plugin writes capability and result artifacts back into the workspace so the agent can inspect them deterministically.
+- This path fits the repo’s automation matrix: the cross-tool handoff is a deterministic local operation, while the agent remains responsible for open-ended reasoning over the result.
+
+### Alternative 1: Editor script or secondary Godot command entrypoint that invokes the same broker
+
+- This remains viable if a lightweight workspace-side trigger is needed before a persistent in-editor listener is trusted.
+- It is not the preferred first path because it risks starting a second editor context or drifting away from the “already open in the designer” assumption.
+
+### Alternative 2: Local IPC server exposed by the plugin
+
+- A local HTTP, socket, or named-pipe broker could provide lower-latency command handling and richer progress streaming.
+- It is deferred because it adds security, lifecycle, and cleanup complexity that the first release does not need if file-based request and result artifacts are sufficient.
+
+### Alternative 3: External UI automation
+
+- Simulated keystrokes or window automation could trigger the editor play button without plugin changes.
+- This is rejected for v1 because it is brittle, platform-specific, hard to validate, and violates the repo’s preference for machine-readable plugin-level control over hidden human-like behavior.
+
+### Escalation Paths Not Planned For V1
+
+- GDExtension remains unnecessary unless editor-side or scripting-level control surfaces prove insufficient during implementation.
+- Engine changes remain out of scope unless supported addon and debugger layers are proven inadequate with cited evidence.
+
+## Phase 0: Research Focus
+
+1. Confirm the lowest-complexity editor-owned control path for a project that is already open in Godot and determine whether the plugin can own both play start and play stop directly.
+2. Confirm the best workspace-to-editor request channel for the first release, comparing file-based command ingestion against script-invocation and IPC alternatives.
+3. Define the machine-readable capability report, run request, lifecycle status, and final result contracts that agents will rely on before and after the run.
+4. Confirm how the existing scenegraph runtime and debugger bridge should be extended so launch control and post-validation shutdown integrate cleanly with today’s capture and persistence flow.
+5. Confirm stale-evidence prevention, single-project targeting, and blocked-result semantics so the first release cannot silently operate on the wrong editor session.
+
+## Phase 1: Design Focus
+
+1. Design the editor automation broker, including request intake, capability checks, run lifecycle coordination, and session shutdown behavior.
+2. Design the machine-readable contracts for capability results, run requests, lifecycle events or status snapshots, and final run results, including explicit shutdown readiness and blocked concurrency results.
+3. Design the bridge and runtime changes needed to reuse existing capture and persistence behavior while adding automation-aware state transitions.
+4. Design the deterministic validation flow in `examples/pong-testbed/`, covering a healthy autonomous run, a blocked prerequisite case, and at least one expectation-driven failure case.
+5. Design any minimal workspace-side helper surfaces, deployment-template changes, or automation run-log integration needed to make the loop reliable and auditable.
+
+## Post-Design Constitution Check
+
+- [x] Plugin-first approach preserved after design: the proposed default path still relies on addon, runtime autoload, debugger transport, and project-local artifacts only.
+- [x] Reference coverage remains complete after design: plan decisions still map back to repo docs, existing addon code, and cited Godot plugin references.
+- [x] Runtime evidence remains the product surface: the new automation layer routes agents to capability reports, run results, and the existing manifest-centered evidence bundle.
+- [x] Test loop remains defined after design: deterministic example-project validation still proves ready, blocked, successful, and failed runs.
+- [x] Reuse remains justified after design: the plan reuses the scenegraph harness, evidence manifest, and automation-safety patterns instead of introducing a parallel runtime control stack.
+
+## Phase 2 Preview
+
+Expected tasks will group into:
+
+1. Editor automation broker: add plugin-side request intake, capability checks, lifecycle coordination, and play start and stop control.
+2. Bridge and runtime integration: extend the existing debugger bridge and runtime coordinator to support automation states without breaking current capture and persistence behavior.
+3. Contracts and deployment assets: add request, capability, and result contract docs plus any project-root template assets required during one-time deployment.
+4. Example-project validation: add deterministic fixtures and evidence expectations in `examples/pong-testbed/` that prove healthy, blocked, and failing autonomous runs.
+5. Minimal helper tooling and docs: add only the scripts or guidance needed to submit requests deterministically, validate outputs, measure repeated-run reliability and timing, and keep autonomous actions within declared boundaries.
+
+## Complexity Tracking
+
+No constitution violations are expected. The preferred path intentionally stays conservative: an editor-owned automation broker layered over the existing scenegraph harness is sufficient unless implementation proves that the open editor cannot expose stable run-control surfaces. If that blocker appears, the first fallback to evaluate is a secondary script-invocation path that still routes through the same plugin-owned orchestration rather than jumping directly to IPC, GDExtension, or engine changes.

--- a/specs/003-editor-evidence-loop/quickstart.md
+++ b/specs/003-editor-evidence-loop/quickstart.md
@@ -13,13 +13,13 @@ Validate that an agent can trigger an autonomous editor run for the example proj
 
 ## 2. Validate Capability Detection
 
-1. From the workspace, request an automation capability check for the open example project.
+1. From the workspace, run `pwsh ./tools/automation/get-editor-evidence-capability.ps1 -ProjectRoot examples/pong-testbed`.
 2. Confirm the result reports exactly one eligible open project and marks launch, capture, persistence, validation, and shutdown control as ready.
 3. Confirm the capability check returns a blocked result instead of guessing if prerequisites are missing or the target is ambiguous.
 
 ## 3. Validate A Healthy Autonomous Run
 
-1. Submit a machine-readable automated run request for the healthy example scene.
+1. Submit a machine-readable automated run request with `pwsh ./tools/automation/request-editor-evidence-run.ps1 -ProjectRoot examples/pong-testbed -RequestFixturePath examples/pong-testbed/harness/automation/requests/run-request.healthy.json`.
 2. Confirm the plugin starts a play session in the open editor without requiring a play-button click.
 3. Confirm the runtime session attaches, the harness captures a scenegraph snapshot, and the latest bundle is persisted.
 4. Confirm the run performs manifest and artifact validation before reporting success.
@@ -38,6 +38,11 @@ Validate that an agent can trigger an autonomous editor run for the example proj
 2. Trigger a blocked prerequisite condition, such as missing harness wiring or ambiguous target detection, and confirm the capability or run result reports `blocked` rather than a misleading runtime failure.
 3. Submit a second request while one autonomous run is already active and confirm the system returns a machine-readable blocked result instead of queueing silently.
 4. Confirm stale artifacts from a previous run are not misreported as the output of the current request.
+
+## Current Validation Status
+
+- Schema, fixture, helper-script, and manifest-backed PowerShell validation for the brokered path is implemented and covered by `pwsh ./tools/tests/run-tool-tests.ps1`.
+- Live Godot editor execution still has to be performed manually against an open `examples/pong-testbed/` session to satisfy the full end-to-end quickstart.
 
 ## Exit Criteria
 

--- a/specs/003-editor-evidence-loop/quickstart.md
+++ b/specs/003-editor-evidence-loop/quickstart.md
@@ -1,0 +1,48 @@
+# Quickstart: Autonomous Editor Evidence Loop
+
+## Goal
+
+Validate that an agent can trigger an autonomous editor run for the example project, persist and validate the resulting scenegraph evidence bundle, and receive a machine-readable result without any dock interaction after the request is issued.
+
+## 1. Prepare the Example Project
+
+1. Open `examples/pong-testbed/` in the Godot editor once the feature implementation is present.
+2. Enable the harness addon and confirm the Scenegraph Harness plugin loads normally.
+3. Use the one-time `Deploy Agent Assets` action so the project receives the required harness templates and automation-facing assets.
+4. Confirm the project has a valid `harness/inspection-run-config.json` and the example scenes needed for healthy and failing runs.
+
+## 2. Validate Capability Detection
+
+1. From the workspace, request an automation capability check for the open example project.
+2. Confirm the result reports exactly one eligible open project and marks launch, capture, persistence, validation, and shutdown control as ready.
+3. Confirm the capability check returns a blocked result instead of guessing if prerequisites are missing or the target is ambiguous.
+
+## 3. Validate A Healthy Autonomous Run
+
+1. Submit a machine-readable automated run request for the healthy example scene.
+2. Confirm the plugin starts a play session in the open editor without requiring a play-button click.
+3. Confirm the runtime session attaches, the harness captures a scenegraph snapshot, and the latest bundle is persisted.
+4. Confirm the run performs manifest and artifact validation before reporting success.
+5. Confirm the play session stops automatically after validation finishes.
+
+## 4. Validate Result And Evidence Handoff
+
+1. Inspect the final automated run result artifact from the workspace.
+2. Confirm it reports the run identifier, manifest path, output directory, validation outcome, and termination status.
+3. Open the reported manifest and confirm the referenced snapshot, diagnostics, and summary artifacts exist.
+4. Validate the manifest with `pwsh ./tools/evidence/validate-evidence-manifest.ps1 -ManifestPath <manifest-path>` if helper tooling remains unchanged.
+
+## 5. Validate Failure And Blocked Cases
+
+1. Submit a run against an intentionally broken expectation case and confirm the final result classifies the failure correctly while still returning the persisted evidence path.
+2. Trigger a blocked prerequisite condition, such as missing harness wiring or ambiguous target detection, and confirm the capability or run result reports `blocked` rather than a misleading runtime failure.
+3. Submit a second request while one autonomous run is already active and confirm the system returns a machine-readable blocked result instead of queueing silently.
+4. Confirm stale artifacts from a previous run are not misreported as the output of the current request.
+
+## Exit Criteria
+
+- The open Godot editor can accept an autonomous run request from the workspace without manual dock interaction after the request is issued.
+- The automation loop produces a machine-readable capability result, lifecycle-aware final result, and a validated manifest-centered evidence bundle.
+- Healthy, blocked, and failing runs are distinguishable from their machine-readable outputs alone.
+- The play session stops automatically after the required evidence has been captured and validated.
+- Repeated run validation demonstrates the loop can meet the target success rate and end-to-end timing expectations for the seeded example flow.

--- a/specs/003-editor-evidence-loop/research.md
+++ b/specs/003-editor-evidence-loop/research.md
@@ -83,3 +83,6 @@
 - The current plan assumes the scenegraph runtime and bridge remain the evidence-producing core; no new runtime evidence family is needed.
 - No `../godot` source inspection was required for planning. If editor-owned run control proves ambiguous during implementation, inspect `../godot` only to confirm plugin-layer limitations before considering deeper escalation.
 - If workspace-side helper scripts are added, they should remain deterministic and should integrate with existing automation boundary and run-log expectations rather than inventing a parallel safety model.
+- The implemented v1 path uses `scenegraph_automation_broker.gd` plus `scenegraph_run_coordinator.gd` to sequence launch, runtime attachment, capture, persistence, validation, and shutdown through the existing debugger bridge.
+- Workspace-side helpers now exist at `tools/automation/get-editor-evidence-capability.ps1` and `tools/automation/request-editor-evidence-run.ps1` so agents can interact with the broker through deterministic files instead of ad hoc manual edits.
+- This environment validated schemas, fixtures, helper scripts, and task-level PowerShell coverage, but it did not execute a live Godot editor session. End-to-end healthy, blocked, reliability, and timing checks still require running the quickstart against an open example project.

--- a/specs/003-editor-evidence-loop/research.md
+++ b/specs/003-editor-evidence-loop/research.md
@@ -1,0 +1,85 @@
+# Research: Autonomous Editor Evidence Loop
+
+## Decision 1: Make the open Godot editor the automation owner
+
+- **Decision**: Keep orchestration inside the Godot editor plugin and treat the already-open editor as the single owner of launch, capture, persist, validate, and stop actions for one project.
+- **Rationale**: The user workflow is explicitly “game open in the designer, VS Code open in the directory.” The editor already owns the plugin lifecycle, debugger session awareness, and access to existing dock and bridge state, so it is the lowest-complexity place to coordinate the run.
+- **Alternatives considered**: A second Godot process or standalone runner was deferred because it breaks the open-editor assumption. OS-level UI automation was rejected because it is brittle and hard to validate.
+
+## Decision 2: Use workspace-visible request and result artifacts as the default cross-tool handoff
+
+- **Decision**: Let the VS Code side trigger autonomous runs by writing a machine-readable request artifact into the project workspace and let the plugin answer with capability, status, and final result artifacts in the same workspace-visible surface.
+- **Rationale**: Agents already know how to read and write files deterministically. This matches the repo’s automation matrix, avoids hidden side channels, and keeps the handoff inspectable after the run.
+- **Alternatives considered**: A local IPC server is viable but deferred because it adds lifecycle and security complexity. A one-shot editor-script entrypoint is viable as a fallback if the file-driven broker proves too slow or too awkward, but it should still invoke the same plugin-owned orchestration path.
+
+## Decision 3: Reuse the existing scenegraph harness for runtime capture and persistence
+
+- **Decision**: Treat current runtime capture, debugger transport, and evidence persistence as the base system and add automation coordination around them rather than redesigning the scenegraph bundle.
+- **Rationale**: The existing plugin already supports `configure_session`, startup capture, explicit capture requests, and `persist_latest_bundle`. The missing piece is editor automation and lifecycle control, not a new evidence format.
+- **Alternatives considered**: A separate automation-only evidence bundle was rejected because it would duplicate manifest routing and increase agent complexity. Replacing the debugger transport was rejected because current repo guidance already prefers debugger-backed messaging for editor-runtime coordination.
+
+## Decision 4: Require a capability check before every autonomous run
+
+- **Decision**: The automation layer must emit a capability result before attempting launch so blocked states are explicit and deterministic.
+- **Rationale**: The spec requires a blocked result when prerequisites are missing or the target is ambiguous. A capability check is the cleanest place to detect missing addon wiring, missing runtime configuration, multiple candidate sessions, or unavailable launch control before any side effects occur.
+- **Alternatives considered**: Optimistically trying the run first and classifying failures later was rejected because it hides prerequisite problems behind noisier runtime errors. Manual operator confirmation was rejected because the first release requires zero manual intervention after the request is issued.
+
+## Decision 5: Use a single run coordinator with explicit state transitions
+
+- **Decision**: Introduce one plugin-side coordinator that owns the run lifecycle from request receipt through completion or failure and emits machine-readable state updates.
+- **Rationale**: Today, the dock triggers capture and persist as isolated actions. Autonomous runs need stronger sequencing: prepare session metadata, launch playtest, await debugger attachment, capture, persist, validate, stop, and report. One coordinator reduces race conditions and makes stale-evidence protection easier.
+- **Alternatives considered**: Wiring separate subsystems directly to request artifacts was rejected because it would make state ownership and failure classification ambiguous.
+
+## Decision 6: Protect against stale evidence with per-run identity and validation-aware completion
+
+- **Decision**: Every autonomous run must generate or confirm a unique run identity, ensure evidence paths map to that identity, and validate the final manifest before reporting success.
+- **Rationale**: The spec explicitly calls out stale evidence risk. Reusing the manifest contract is only safe if the run coordinator can prove the output belongs to the current request.
+- **Alternatives considered**: Reusing a fixed latest directory without run-specific verification was rejected because it allows false positives when prior artifacts linger. Relying only on timestamps without run identifiers was rejected because it is harder to reason about across rapid repeated runs.
+
+## Decision 7: Keep v1 single-project and block ambiguity rather than inventing target selection logic
+
+- **Decision**: Support exactly one eligible open Godot project for the first release and block when the target is ambiguous.
+- **Rationale**: The clarified spec prefers a blocked result over guessing. This keeps the first release focused on a reliable single-project loop instead of fragile editor-window discovery heuristics.
+- **Alternatives considered**: Picking the active editor window automatically was rejected because it is too implicit. User-specified target identifiers are a reasonable future extension, but they are unnecessary if the first release can safely block ambiguity.
+
+## Decision 7a: Reject overlapping run requests in v1
+
+- **Decision**: Reject overlapping autonomous run requests with a machine-readable blocked result instead of queueing them.
+- **Rationale**: The first release already limits the system to one eligible open project and one active run. Rejecting overlap keeps state ownership clear and makes it easier for agents to reason about failures without guessing which request owns the active session.
+- **Alternatives considered**: Queueing was rejected for v1 because it complicates lifecycle ownership, stale-artifact protection, and timeout reasoning before the core single-run broker is proven.
+
+## Decision 8: Capture implementation options explicitly instead of pretending the run-control path is already proven
+
+- **Decision**: Document a preferred path and viable alternatives in the planning package so implementation can validate the actual editor control surfaces without reopening the product requirements.
+- **Rationale**: The user explicitly asked for alternatives where the build path is not obvious. Capturing them in planning artifacts preserves a clean implementation-agnostic spec while still giving maintainers concrete choices to discuss.
+- **Alternatives considered**: Encoding implementation alternatives directly in the feature spec was rejected because it would blur product requirements and design decisions.
+
+## Options To Validate During Implementation
+
+### Option A: File-based automation broker inside the plugin
+
+- **Shape**: The plugin watches a project-local request path, processes one request at a time, and writes capability and result artifacts back to the workspace.
+- **Why it fits**: It is inspectable, deterministic, and easy for VS Code agents to use.
+- **Primary risk**: The editor-side file watch or polling loop must remain lightweight and must handle partial writes safely.
+
+### Option B: Secondary editor-script trigger that forwards into the same broker
+
+- **Shape**: A deterministic workspace-side command invokes a Godot editor script or similar entrypoint, which forwards the run request into plugin-owned orchestration.
+- **Why it fits**: It could bootstrap automation before a persistent listener is trusted.
+- **Primary risk**: It may create another editor lifecycle path and complicate the “already open project” model.
+
+### Option C: Local IPC server owned by the plugin
+
+- **Shape**: The plugin exposes a loopback-only command surface for run requests and status reporting.
+- **Why it fits**: It could provide lower-latency control and streaming updates.
+- **Primary risk**: It introduces avoidable security, lifecycle, and cleanup complexity for v1.
+
+### Rejected Option: External GUI automation
+
+- **Why rejected**: It bypasses machine-readable editor state, is platform-fragile, and does not align with the plugin-first constitution.
+
+## Implementation Notes
+
+- The current plan assumes the scenegraph runtime and bridge remain the evidence-producing core; no new runtime evidence family is needed.
+- No `../godot` source inspection was required for planning. If editor-owned run control proves ambiguous during implementation, inspect `../godot` only to confirm plugin-layer limitations before considering deeper escalation.
+- If workspace-side helper scripts are added, they should remain deterministic and should integrate with existing automation boundary and run-log expectations rather than inventing a parallel safety model.

--- a/specs/003-editor-evidence-loop/spec.md
+++ b/specs/003-editor-evidence-loop/spec.md
@@ -1,0 +1,170 @@
+# Feature Specification: Autonomous Editor Evidence Loop
+
+**Feature Branch**: `[003-create-feature-branch]`  
+**Created**: 2026-04-12  
+**Status**: Draft  
+**Input**: User description: "We now have a working plugin that will deploy assets and generate files based on the runtime state of the scene graph. We want to complete the automation circle so agents working from VS Code can edit the game, run the open project from the Godot editor, capture a scenegraph snapshot, persist the evidence bundle, and inspect the output without further user interaction after the one-time asset deployment step. The first release must stay focused on the game opened in the Godot editor and should define the viable options for closing that loop with the current plugin or with additional plugin hooks if needed."
+
+## Clarifications
+
+### Session 2026-04-12
+
+- Q: What level of editor-run autonomy is required in the first release? → A: Full autonomy is required: the agent must start the playtest and terminate it after it has captured and validated the evidence it needs.
+- Q: Is evidence validation part of the same automated run contract? → A: Yes. Validation is mandatory before the run is reported as successful.
+- Q: How should the first release handle target selection if multiple editor projects or sessions are open? → A: First release is single-project only. If the target is ambiguous, the run must block instead of guessing.
+- Q: What should determine which scene the editor launches for an autonomous run? → A: The requested scenario or harness configuration must declare the target scene.
+- Q: How should per-run settings be supplied for autonomous runs? → A: Shared harness configuration stays stable, and each run request may provide temporary request-scoped overrides.
+- Q: How should the first release handle overlapping autonomous run requests? → A: First release rejects overlapping requests with a machine-readable blocked result instead of queueing them.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Start An Editor Run Autonomously (Priority: P1)
+
+As a coding agent operator, I want an agent working against a project that is already open in the Godot editor to start an in-editor playtest run and wait for the harness session to attach so I can verify gameplay changes without taking over the keyboard after the initial setup.
+
+**Why this priority**: The automation loop does not close unless the agent can move from source edits to a live playtest session on its own. Capture and persistence only matter after the editor run can be initiated reliably.
+
+**Independent Test**: With the harness addon enabled in the example project and agent assets already deployed once, request an automated inspection run for a scenario whose harness configuration declares a target scene and verify the run produces a machine-readable status flow that reaches a connected runtime session without requiring the operator to click play, capture, persist, or stop controls.
+
+**Acceptance Scenarios**:
+
+1. **Given** the target project is open in the Godot editor with the harness enabled and the requested scenario declares a valid target scene, **When** an agent requests an automated inspection run for that scenario, **Then** the system starts an editor playtest session for that declared scene and reports when the runtime harness session is attached and ready.
+2. **Given** the editor is open but the harness plugin, autoload wiring, or target project state is not ready for an automated run, **When** the agent requests the run, **Then** the system returns a machine-readable blocked result that identifies the missing prerequisite instead of pretending the run started.
+3. **Given** an automated run is already active for the same project, **When** another run is requested, **Then** the system rejects the second request with a machine-readable blocked result and reports that decision to the agent.
+
+---
+
+### User Story 2 - Capture, Persist, And Validate Evidence Without Dock Clicks (Priority: P2)
+
+As a coding agent operator, I want the agent-run playtest to drive capture, bundle persistence, evidence validation, and orderly session shutdown automatically so the agent can inspect the resulting manifest and artifacts directly from the workspace.
+
+**Why this priority**: The current plugin already captures and persists evidence once a debugger session exists, but the loop still breaks if a human must click dock buttons during or after the run.
+
+**Independent Test**: Execute a seeded editor run for the example project, let the automation request or rely on the configured capture policy, persist the latest bundle, validate the manifest and referenced artifacts, terminate the play session, and confirm the agent can locate the final evidence files from the reported output path alone.
+
+**Acceptance Scenarios**:
+
+1. **Given** an automated editor run reaches an attached runtime session, **When** the capture point defined for the run is reached, **Then** the system triggers snapshot capture without requiring a manual dock interaction.
+2. **Given** a snapshot and diagnostics are available for the active run, **When** the automated run reaches its persistence step, **Then** the system writes a manifest-centered evidence bundle and returns the manifest path and output directory to the agent.
+3. **Given** the bundle has been written, **When** the agent checks the evidence, **Then** the system verifies that the manifest and referenced files exist before reporting the run as successful and ending the play session.
+
+---
+
+### User Story 3 - Expose The Supported Automation Options Clearly (Priority: P3)
+
+As a harness maintainer, I want the agent-facing workflow to state which editor automation surfaces are supported, which one is the default, and when additional plugin hooks are required so future work can extend the loop without ambiguity.
+
+**Why this priority**: The user request explicitly asks whether the current plugin is sufficient or whether new methods, events, or hooks are needed. That decision must become part of the supported workflow instead of remaining tribal knowledge.
+
+**Independent Test**: Review the agent-facing run workflow for the feature and verify it reports whether the current environment can launch a run, request capture, persist the bundle, and validate output using existing surfaces or whether a richer editor control surface is unavailable and must fall back to a documented blocked state.
+
+**Acceptance Scenarios**:
+
+1. **Given** the project environment supports the chosen automation path, **When** an agent asks how the run loop will execute, **Then** the system reports the supported control path, required prerequisites, and expected lifecycle states.
+2. **Given** the current plugin can capture and persist evidence but cannot fully launch the editor playtest on its own, **When** the agent performs a pre-run capability check, **Then** the system reports that gap explicitly instead of masking it behind capture or persistence errors.
+3. **Given** a future iteration adds new plugin commands, hooks, or events for editor-run control, **When** an agent inspects the automation capability for a project, **Then** it can distinguish between launch control, capture control, persistence control, validation support, and session shutdown support.
+
+### Edge Cases
+
+- The Godot editor is open, but the requested scenario or harness configuration does not resolve to a valid target scene for the automated run.
+- More than one eligible open project or editor session exists, making the target ambiguous for the first release.
+- A playtest launch is requested, but the runtime debugger session never attaches, leaving capture commands with no active session.
+- Capture or persistence is requested for the current run after a previous run has already left evidence files in the same output directory.
+- The playtest crashes or exits before the configured capture point, leaving only partial runtime evidence.
+- Manifest writing succeeds, but one or more referenced evidence files are missing or stale by the time the agent validates the bundle.
+- The agent requests an automated run while source changes are still being written, creating a race between code edits and the launched playtest.
+- Repeated rapid run requests must not start a second concurrent run and must return a machine-readable blocked result instead.
+
+## References *(mandatory)*
+
+### Internal References
+
+- README.md
+- AGENTS.md
+- docs/AGENT_RUNTIME_HARNESS.md
+- docs/AGENT_TOOLING_FOUNDATION.md
+- docs/AI_TOOLING_BEST_PRACTICES.md
+- docs/GODOT_PLUGIN_REFERENCES.md
+- specs/002-inspect-scene-tree/spec.md
+- specs/002-inspect-scene-tree/quickstart.md
+- addons/agent_runtime_harness/plugin.gd
+- addons/agent_runtime_harness/editor/scenegraph_dock.gd
+- addons/agent_runtime_harness/editor/scenegraph_debugger_bridge.gd
+- addons/agent_runtime_harness/runtime/scenegraph_runtime.gd
+- addons/agent_runtime_harness/runtime/scenegraph_artifact_writer.gd
+- addons/agent_runtime_harness/shared/inspection_constants.gd
+
+### External References
+
+- Godot editor plugins overview: https://docs.godotengine.org/en/stable/tutorials/plugins/editor/index.html
+- Godot EditorPlugin class reference: https://docs.godotengine.org/en/stable/classes/class_editorplugin.html
+- Godot EditorDebuggerPlugin class reference: https://docs.godotengine.org/en/stable/classes/class_editordebuggerplugin.html
+- Godot EditorDebuggerSession class reference: https://docs.godotengine.org/en/stable/classes/class_editordebuggersession.html
+- Godot EngineDebugger class reference: https://docs.godotengine.org/en/stable/classes/class_enginedebugger.html
+- Godot autoload singletons guide: https://docs.godotengine.org/en/stable/tutorials/scripting/singletons_autoload.html
+- Godot scene tree basics: https://docs.godotengine.org/en/stable/tutorials/scripting/scene_tree.html
+
+### Source References
+
+- No `../godot` source files were inspected for this specification; the current scope is grounded in repository docs plus the plugin, debugger, and runtime harness surfaces already present in this repo.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: System MUST allow an agent operating from the workspace to request an automated evidence run against a Godot project that is already open in the editor after the one-time asset deployment step has been completed.
+- **FR-002**: System MUST perform a pre-run capability check that determines whether editor-run launch control, runtime session attachment, capture control, persistence control, evidence validation, and session shutdown control are available for the requested project state.
+- **FR-003**: System MUST return a machine-readable blocked result when a requested automated run cannot start because prerequisites are missing, including at minimum editor availability, harness availability, active project availability, or run concurrency conflicts.
+- **FR-004**: System MUST represent the automated run lifecycle in machine-readable states that cover request receipt, launch attempt, runtime session attachment, capture, persistence, validation, completion, and failure.
+- **FR-005**: System MUST associate each automated run with explicit run metadata before launch, including scenario identity, run identity, intended output location, and any expectation inputs that govern diagnostics.
+- **FR-005a**: System MUST resolve the playtest launch target from the requested scenario or harness configuration and MUST not depend on whichever editor scene happens to be active when the request is issued.
+- **FR-005b**: System MUST support request-scoped overrides for per-run settings and MUST not require rewriting shared harness configuration files in order to launch an autonomous run.
+- **FR-006**: System MUST autonomously start an editor playtest session for the requested project without requiring a human to click the Godot dock or play button after the run request is issued.
+- **FR-007**: System MUST autonomously terminate the playtest session after the required evidence has been captured and validation has completed, unless the run has already ended because of a crash or other failure.
+- **FR-008**: System MUST support at least one agent-invoked path that triggers snapshot capture for the active run without manual dock interaction, either by relying on configured automatic capture policy or by issuing an explicit capture request during the run.
+- **FR-009**: System MUST persist the latest capture bundle for the active run without requiring a manual dock interaction once the run reaches its persistence step.
+- **FR-010**: System MUST preserve the existing manifest-centered scenegraph evidence contract so agents can continue to read the manifest first and then inspect only the referenced raw artifacts as needed.
+- **FR-011**: System MUST return the persisted manifest path, evidence output directory, run identity, lifecycle status, and session termination status to the requesting agent when an automated run completes or fails.
+- **FR-012**: System MUST validate the persisted manifest and its referenced scenegraph artifacts as part of every automated run before reporting success.
+- **FR-013**: System MUST distinguish between launch-control failures, runtime-session attachment failures, capture failures, persistence failures, validation failures, session-shutdown failures, and gameplay or expectation failures in its machine-readable run outcome.
+- **FR-014**: System MUST prevent stale evidence from a prior run from being misreported as the result of the current automated run.
+- **FR-015**: System MUST support exactly one eligible open Godot project or editor session in the first release and MUST return a blocked result instead of guessing when multiple possible targets are available.
+- **FR-016**: System MUST reject concurrent or overlapping run requests for that single supported project with a machine-readable blocked result so agents do not issue capture or persistence commands against the wrong playtest session.
+- **FR-017**: System MUST keep the first release scoped to projects opened in the Godot editor and MUST not require launching packaged or compiled game builds.
+- **FR-018**: System MUST describe the supported automation options for closing the edit-run-capture-persist-inspect loop, identify the default path for the first release, and document the blocked behavior when full editor launch control is unavailable.
+- **FR-019**: System MUST explicitly identify which plugin-first extension points are sufficient for the chosen automation path and MUST justify any newly introduced plugin commands, events, or hooks before considering escalation beyond addon, autoload, debugger, or GDExtension layers.
+- **FR-020**: System MUST allow agents to inspect the completed evidence bundle directly from workspace-accessible files without relying on a human-written summary of the run outcome.
+- **FR-021**: System MUST preserve the existing scenegraph snapshot, diagnostics, and summary semantics so the automated loop remains compatible with the current evidence triage workflow.
+
+### Key Entities *(include if feature involves data)*
+
+- **Automated Run Request**: The machine-readable instruction that tells the harness to launch an in-editor playtest, apply run metadata, and execute the evidence loop for one scenario.
+- **Automation Capability Result**: A machine-readable report of which parts of the loop are available for the current project and editor state, including launch, session attachment, capture, persistence, validation, and shutdown readiness.
+- **Editor Playtest Session**: The specific Godot editor run instance that the harness binds to for capture and persistence.
+- **Run Lifecycle Record**: The machine-readable progression of states and timestamps for one automated evidence run from request through completion or failure.
+- **Evidence Bundle**: The persisted manifest-centered set of scenegraph snapshot, diagnostics, and summary artifacts produced by the automated run.
+- **Run Validation Result**: The machine-readable outcome that confirms whether the expected evidence files for the run were written correctly, are safe for the agent to inspect, and were secured before the play session ended.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: After the one-time asset deployment step, an agent can complete the edit-run-capture-persist-validate-stop loop for the seeded example project without further human input in at least 90% of validation runs.
+- **SC-002**: In 100% of successful automated runs, the reported manifest path resolves to a manifest whose referenced scenegraph snapshot, diagnostics, and summary files are present at validation time.
+- **SC-003**: In seeded blocked or failure cases, an agent can determine within 2 minutes whether the loop failed at launch control, runtime-session attachment, capture, persistence, validation, session shutdown, or gameplay expectation evaluation by reading the machine-readable run output alone.
+- **SC-004**: For the example project under normal validation conditions, the time from automated run request to a validated persisted evidence bundle and a stopped play session is under 3 minutes.
+- **SC-005**: Successful automated runs require zero manual dock interactions after the run request is issued.
+- **SC-006**: In 100% of validation runs, the pre-run capability check returns a decisive ready or blocked result before the system attempts playtest launch, including a blocked result when multiple possible editor targets are open.
+
+## Assumptions
+
+- The game project is already open in the Godot editor on the same machine as the agent workspace when an automated run is requested.
+- A one-time manual click on `Deploy Agent Assets` is acceptable before the autonomous run loop is used.
+- The harness addon, project wiring, and runtime autoload are already installed in the target project before autonomous runs are attempted.
+- The requested scenario or harness configuration can declare the scene that the autonomous run should launch.
+- Shared harness configuration can remain stable while autonomous runs provide temporary per-run overrides.
+- The first release only needs to support one eligible open Godot project and one active automated inspection run at a time; ambiguous multi-project conditions are blocked.
+- Agents can read the persisted evidence files from the project workspace once the harness reports their paths.
+- The current scenegraph snapshot, diagnostics, summary, and evidence-manifest contract remains the base evidence handoff model for the automated loop.
+- The automated run is responsible for ending the play session once required evidence is captured and validated.
+- Packaged executable launches remain out of scope for this feature.

--- a/specs/003-editor-evidence-loop/tasks.md
+++ b/specs/003-editor-evidence-loop/tasks.md
@@ -1,0 +1,205 @@
+# Tasks: Autonomous Editor Evidence Loop
+
+**Input**: Design documents from `/specs/003-editor-evidence-loop/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, quickstart.md, contracts/
+
+**Tests**: Every user story includes executable validation tasks using deterministic example-project runs, contract validation, or PowerShell-based automation checks that produce machine-readable evidence.
+
+**Organization**: Tasks are grouped by user story so each story can be implemented and validated independently once the shared automation contracts and broker plumbing exist.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel when file ownership does not overlap
+- **[Story]**: Which user story the task belongs to (`US1`, `US2`, `US3`)
+- All tasks include exact repository paths in the description
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Create the fixture, template, and test locations that every story depends on.
+
+- [ ] T001 Create automation fixture directories under `examples/pong-testbed/harness/automation/requests/` and `examples/pong-testbed/harness/automation/results/`
+- [ ] T002 [P] Create template automation directories under `addons/agent_runtime_harness/templates/project_root/harness/automation/requests/` and `addons/agent_runtime_harness/templates/project_root/harness/automation/results/`
+- [ ] T003 [P] Add the new task-level test suite file `tools/tests/ScenegraphAutomationLoop.Tests.ps1` and register it from `tools/tests/run-tool-tests.ps1`
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Establish the shared automation contracts, artifact plumbing, and configuration defaults that block all user stories.
+
+**⚠️ CRITICAL**: No user story work should begin until this phase is complete.
+
+- [ ] T004 Create contract schemas in `specs/003-editor-evidence-loop/contracts/automation-capability.schema.json`, `specs/003-editor-evidence-loop/contracts/automation-run-request.schema.json`, `specs/003-editor-evidence-loop/contracts/automation-lifecycle-status.schema.json`, and `specs/003-editor-evidence-loop/contracts/automation-run-result.schema.json`
+- [ ] T005 [P] Add shared automation constants, artifact names, and lifecycle states in `addons/agent_runtime_harness/shared/inspection_constants.gd`
+- [ ] T006 [P] Implement shared request and result file handling in `addons/agent_runtime_harness/editor/scenegraph_automation_artifact_store.gd`
+- [ ] T007 [P] Extend `examples/pong-testbed/harness/inspection-run-config.json` and `addons/agent_runtime_harness/templates/project_root/harness/inspection-run-config.json` with scenario-declared target-scene fields, automation paths, and default request-scoped override support
+- [ ] T008 Extend `tools/tests/ScenegraphAutomationLoop.Tests.ps1` to validate the new automation schemas with `tools/validate-json.ps1`
+
+**Checkpoint**: Shared automation contracts and artifact plumbing are ready; story work can begin.
+
+---
+
+## Phase 3: User Story 1 - Start An Editor Run Autonomously (Priority: P1) 🎯 MVP
+
+**Goal**: Allow a workspace-side agent to submit an autonomous run request, resolve the scenario-declared scene target, and start a single-project editor play session or return a blocked result deterministically.
+
+**Independent Test**: Submit healthy and blocked request fixtures for `examples/pong-testbed/`, confirm the plugin reports capability correctly, resolves the scene from scenario or harness config rather than the active editor tab, emits lifecycle status through runtime attachment, and either launches the run or emits a blocked result with no hidden manual fallback.
+
+### Validation for User Story 1 ⚠️
+
+- [ ] T009 [P] [US1] Add capability fixtures at `examples/pong-testbed/harness/automation/results/capability-ready.expected.json` and `examples/pong-testbed/harness/automation/results/capability-blocked.expected.json`
+- [ ] T010 [P] [US1] Add request fixtures at `examples/pong-testbed/harness/automation/requests/run-request.healthy.json` and `examples/pong-testbed/harness/automation/requests/run-request.blocked.json`
+- [ ] T011 [P] [US1] Add capability, single-project, scene-target, shutdown-readiness, and runtime-attachment lifecycle validation coverage in `tools/tests/ScenegraphAutomationLoop.Tests.ps1` against `specs/003-editor-evidence-loop/contracts/automation-capability.schema.json` and `specs/003-editor-evidence-loop/contracts/automation-lifecycle-status.schema.json`
+
+### Implementation for User Story 1
+
+- [ ] T012 [US1] Implement the plugin-owned automation broker in `addons/agent_runtime_harness/editor/scenegraph_automation_broker.gd` and wire it from `addons/agent_runtime_harness/plugin.gd`
+- [ ] T013 [P] [US1] Implement request intake, single-run locking, and request-scoped override parsing in `addons/agent_runtime_harness/editor/scenegraph_automation_broker.gd`
+- [ ] T014 [P] [US1] Implement scenario-declared target-scene resolution and play-start control in `addons/agent_runtime_harness/editor/scenegraph_automation_broker.gd`
+- [ ] T015 [US1] Emit capability results, lifecycle-status artifacts through runtime attachment, and blocked run results from `addons/agent_runtime_harness/editor/scenegraph_automation_broker.gd` and `addons/agent_runtime_harness/editor/scenegraph_automation_artifact_store.gd`
+- [ ] T016 [US1] Add example-project wiring for automation request and result paths in `examples/pong-testbed/project.godot` and `examples/pong-testbed/harness/inspection-run-config.json`
+
+**Checkpoint**: User Story 1 is complete when a healthy request can start the declared scene and report attached-runtime status, and blocked requests return deterministic machine-readable results without touching the dock.
+
+---
+
+## Phase 4: User Story 2 - Capture, Persist, And Validate Evidence Without Dock Clicks (Priority: P2)
+
+**Goal**: Extend the autonomous run from launch into capture, manifest-centered persistence, evidence validation, stale-artifact protection, and orderly session shutdown.
+
+**Independent Test**: Run the healthy example request end to end, confirm the autonomous loop captures scenegraph evidence, persists the bundle, validates the manifest and artifact refs, stops the play session, and emits a final run result that points to the current run’s evidence only.
+
+### Validation for User Story 2 ⚠️
+
+- [ ] T017 [P] [US2] Add autonomous run result fixtures at `examples/pong-testbed/harness/automation/results/run-result.success.expected.json`, `examples/pong-testbed/harness/automation/results/run-result.attachment-failure.expected.json`, `examples/pong-testbed/harness/automation/results/run-result.capture-failure.expected.json`, `examples/pong-testbed/harness/automation/results/run-result.validation-failure.expected.json`, `examples/pong-testbed/harness/automation/results/run-result.shutdown-failure.expected.json`, and `examples/pong-testbed/harness/automation/results/run-result.gameplay-failure.expected.json`
+- [ ] T018 [P] [US2] Add manifest-backed automated run validation and failure-kind matrix coverage in `tools/tests/ScenegraphAutomationLoop.Tests.ps1` using `specs/003-editor-evidence-loop/contracts/automation-run-result.schema.json` and `specs/001-agent-tooling-foundation/contracts/evidence-manifest.schema.json`
+
+### Implementation for User Story 2
+
+- [ ] T019 [P] [US2] Implement end-to-end run lifecycle sequencing in `addons/agent_runtime_harness/editor/scenegraph_run_coordinator.gd`
+- [ ] T020 [P] [US2] Extend `addons/agent_runtime_harness/editor/scenegraph_debugger_bridge.gd` and `addons/agent_runtime_harness/runtime/scenegraph_runtime.gd` with automation-aware session configuration and completion signaling
+- [ ] T021 [US2] Implement lifecycle-status and final run-result artifact writing in `addons/agent_runtime_harness/editor/scenegraph_automation_artifact_store.gd` and `addons/agent_runtime_harness/editor/scenegraph_run_coordinator.gd`
+- [ ] T022 [US2] Wire validated capture, persistence, and shutdown sequencing in `addons/agent_runtime_harness/editor/scenegraph_run_coordinator.gd` and `addons/agent_runtime_harness/runtime/scenegraph_artifact_writer.gd`
+- [ ] T023 [US2] Implement run-id-based stale-artifact protection in `addons/agent_runtime_harness/editor/scenegraph_run_coordinator.gd`, `addons/agent_runtime_harness/editor/scenegraph_automation_artifact_store.gd`, and `examples/pong-testbed/harness/automation/results/`
+- [ ] T024 [US2] Extend template and example-project automation output settings in `addons/agent_runtime_harness/templates/project_root/harness/inspection-run-config.json` and `examples/pong-testbed/harness/inspection-run-config.json`
+
+**Checkpoint**: User Story 2 is complete when the autonomous loop can run end to end and the final result always points to a validated, current evidence bundle.
+
+---
+
+## Phase 5: User Story 3 - Expose The Supported Automation Options Clearly (Priority: P3)
+
+**Goal**: Make the default automation path, blocked behaviors, helper surfaces, and fallback options explicit for agents and maintainers.
+
+**Independent Test**: Inspect capability results, helper outputs, and agent-facing docs to confirm the implemented flow reports the preferred path, distinguishes blocked states cleanly, and documents the deferred alternatives without implying hidden support.
+
+### Validation for User Story 3 ⚠️
+
+- [ ] T025 [P] [US3] Add control-path and blocked-behavior fixtures at `examples/pong-testbed/harness/automation/results/capability-options.expected.json` and `examples/pong-testbed/harness/automation/results/run-result.blocked.expected.json`
+- [ ] T026 [P] [US3] Add helper and control-path validation coverage in `tools/tests/ScenegraphAutomationLoop.Tests.ps1` and `tools/tests/AutomationTools.Tests.ps1`
+
+### Implementation for User Story 3
+
+- [ ] T027 [P] [US3] Finalize contract docs and align schemas in `specs/003-editor-evidence-loop/contracts/editor-evidence-loop-contract.md`, `specs/003-editor-evidence-loop/contracts/automation-capability.schema.json`, `specs/003-editor-evidence-loop/contracts/automation-run-request.schema.json`, `specs/003-editor-evidence-loop/contracts/automation-lifecycle-status.schema.json`, and `specs/003-editor-evidence-loop/contracts/automation-run-result.schema.json`
+- [ ] T028 [P] [US3] Update `addons/agent_runtime_harness/templates/project_root/AGENTS.runtime-harness.md` with the preferred file-broker path, blocked conditions, and manifest-first evidence workflow for autonomous runs
+- [ ] T029 [P] [US3] Implement deterministic workspace helpers in `tools/automation/get-editor-evidence-capability.ps1` and `tools/automation/request-editor-evidence-run.ps1`
+- [ ] T030 [US3] Add helper-script coverage in `tools/tests/AutomationTools.Tests.ps1` and document the supported automation surfaces in `docs/AGENT_TOOLING_FOUNDATION.md`
+- [ ] T031 [US3] Update `specs/003-editor-evidence-loop/quickstart.md` and `specs/003-editor-evidence-loop/research.md` with the implemented default path and any validated fallback findings
+
+**Checkpoint**: User Story 3 is complete when agents and maintainers can see exactly what path is supported, what is blocked, and what alternatives remain deferred.
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+**Purpose**: Final synchronization, end-to-end validation, and documentation cleanup across stories.
+
+- [ ] T032 [P] Update `README.md` and `docs/AGENT_RUNTIME_HARNESS.md` with the implemented autonomous editor evidence loop entry points, constraints, and validation flow
+- [ ] T033 [P] Run `pwsh ./tools/tests/run-tool-tests.ps1` and fix regressions in `tools/tests/ScenegraphAutomationLoop.Tests.ps1`, `tools/tests/AutomationTools.Tests.ps1`, and any touched automation helpers
+- [ ] T034 Run the full validation flow in `specs/003-editor-evidence-loop/quickstart.md` against `examples/pong-testbed/` and record implementation notes in `specs/003-editor-evidence-loop/research.md`
+- [ ] T035 [P] Run repeated seeded autonomous runs for `examples/pong-testbed/` and record machine-readable reliability results in `examples/pong-testbed/harness/automation/results/reliability-summary.json`
+- [ ] T036 [P] Measure end-to-end request-to-stop timing for the seeded healthy flow and record the result in `examples/pong-testbed/harness/automation/results/performance-summary.json`
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Phase 1: Setup**: No dependencies
+- **Phase 2: Foundational**: Depends on Phase 1 and blocks all user stories
+- **Phase 3: User Story 1**: Depends on Phase 2 and is the MVP
+- **Phase 4: User Story 2**: Depends on Phase 2 and the launch broker established in User Story 1 because it extends the same autonomous run lifecycle
+- **Phase 5: User Story 3**: Depends on Phase 2 and can begin once contract names and helper surfaces are stable
+- **Phase 6: Polish**: Depends on all desired user stories being complete
+
+### User Story Dependencies
+
+- **US1**: No dependency on other user stories after Phase 2
+- **US2**: Builds on the autonomous launch path from US1 because capture, persistence, validation, and shutdown happen within that same broker-owned run
+- **US3**: Reuses shared contracts from Phase 2 and can overlap with late US1 or US2 work as long as file ownership stays coordinated
+
+### Within Each User Story
+
+- Validation fixtures and contract checks should land before implementation tasks
+- Runtime artifact production must land with the feature, not as a later cleanup
+- Story-specific validation should run before moving to the next priority if working sequentially
+
+### Parallel Opportunities
+
+- T002 and T003 can run in parallel after T001
+- T005, T006, and T007 can run in parallel after T004 starts defining the shared contract shapes
+- In US1, T009, T010, and T011 can run in parallel; T013 and T014 can run in parallel after T012 defines the broker entrypoint
+- In US2, T017 and T018 can run in parallel; T019 and T020 can run in parallel once the broker contract is stable
+- In US3, T025 and T026 can run in parallel; T027, T028, and T029 can run in parallel once the implemented contract surface is known
+- In Phase 6, T035 and T036 can run in parallel after T034 establishes the end-to-end validation flow
+
+---
+
+## Parallel Example: User Story 1
+
+```text
+T009 Add capability fixtures at examples/pong-testbed/harness/automation/results/capability-ready.expected.json and capability-blocked.expected.json
+T010 Add request fixtures at examples/pong-testbed/harness/automation/requests/run-request.healthy.json and run-request.blocked.json
+T011 Add capability, scene-target, shutdown-readiness, and lifecycle validation coverage in tools/tests/ScenegraphAutomationLoop.Tests.ps1
+```
+
+```text
+T013 Implement request intake, single-run locking, and request-scoped override parsing in addons/agent_runtime_harness/editor/scenegraph_automation_broker.gd
+T014 Implement scenario-declared target-scene resolution and play-start control in addons/agent_runtime_harness/editor/scenegraph_automation_broker.gd
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Complete Phase 1: Setup
+2. Complete Phase 2: Foundational
+3. Complete Phase 3: User Story 1
+4. Validate healthy and blocked launch behavior plus runtime-attachment status in `examples/pong-testbed/`
+5. Stop and confirm the autonomous launch path works before extending it into persistence and shutdown
+
+### Incremental Delivery
+
+1. Deliver shared contracts, artifact storage, and configuration defaults
+2. Deliver autonomous launch and blocked-result handling and validate it
+3. Deliver capture, persistence, validation, and shutdown sequencing and validate it
+4. Deliver helper surfaces and documentation for the supported automation path and alternatives
+5. Run the full quickstart, repeated-run reliability check, and timing validation, then sync docs and fixtures
+
+### Parallel Team Strategy
+
+1. One contributor handles shared contracts and artifact-store plumbing in Phase 2
+2. After Phase 2, one contributor can focus on US1 broker behavior while another prepares US3 docs and helper scaffolding that depend only on stable contract names
+3. US2 starts once US1 fixes the broker entrypoint and launch semantics
+
+---
+
+## Notes
+
+- `[P]` means the task is safe to parallelize only if file ownership does not overlap
+- All validation outputs should stay machine-readable and point back to the example project’s evidence and automation artifacts
+- The clarified spec requires scenario-declared launch targets and request-scoped overrides; tasks above assume those decisions are not optional
+- The preferred v1 path is the plugin-owned file broker; script forwarding and local IPC remain documented alternatives, not first-release commitments

--- a/specs/003-editor-evidence-loop/tasks.md
+++ b/specs/003-editor-evidence-loop/tasks.md
@@ -17,9 +17,9 @@
 
 **Purpose**: Create the fixture, template, and test locations that every story depends on.
 
-- [ ] T001 Create automation fixture directories under `examples/pong-testbed/harness/automation/requests/` and `examples/pong-testbed/harness/automation/results/`
-- [ ] T002 [P] Create template automation directories under `addons/agent_runtime_harness/templates/project_root/harness/automation/requests/` and `addons/agent_runtime_harness/templates/project_root/harness/automation/results/`
-- [ ] T003 [P] Add the new task-level test suite file `tools/tests/ScenegraphAutomationLoop.Tests.ps1` and register it from `tools/tests/run-tool-tests.ps1`
+- [X] T001 Create automation fixture directories under `examples/pong-testbed/harness/automation/requests/` and `examples/pong-testbed/harness/automation/results/`
+- [X] T002 [P] Create template automation directories under `addons/agent_runtime_harness/templates/project_root/harness/automation/requests/` and `addons/agent_runtime_harness/templates/project_root/harness/automation/results/`
+- [X] T003 [P] Add the new task-level test suite file `tools/tests/ScenegraphAutomationLoop.Tests.ps1` and register it from `tools/tests/run-tool-tests.ps1`
 
 ---
 
@@ -29,11 +29,11 @@
 
 **⚠️ CRITICAL**: No user story work should begin until this phase is complete.
 
-- [ ] T004 Create contract schemas in `specs/003-editor-evidence-loop/contracts/automation-capability.schema.json`, `specs/003-editor-evidence-loop/contracts/automation-run-request.schema.json`, `specs/003-editor-evidence-loop/contracts/automation-lifecycle-status.schema.json`, and `specs/003-editor-evidence-loop/contracts/automation-run-result.schema.json`
-- [ ] T005 [P] Add shared automation constants, artifact names, and lifecycle states in `addons/agent_runtime_harness/shared/inspection_constants.gd`
-- [ ] T006 [P] Implement shared request and result file handling in `addons/agent_runtime_harness/editor/scenegraph_automation_artifact_store.gd`
-- [ ] T007 [P] Extend `examples/pong-testbed/harness/inspection-run-config.json` and `addons/agent_runtime_harness/templates/project_root/harness/inspection-run-config.json` with scenario-declared target-scene fields, automation paths, and default request-scoped override support
-- [ ] T008 Extend `tools/tests/ScenegraphAutomationLoop.Tests.ps1` to validate the new automation schemas with `tools/validate-json.ps1`
+- [X] T004 Create contract schemas in `specs/003-editor-evidence-loop/contracts/automation-capability.schema.json`, `specs/003-editor-evidence-loop/contracts/automation-run-request.schema.json`, `specs/003-editor-evidence-loop/contracts/automation-lifecycle-status.schema.json`, and `specs/003-editor-evidence-loop/contracts/automation-run-result.schema.json`
+- [X] T005 [P] Add shared automation constants, artifact names, and lifecycle states in `addons/agent_runtime_harness/shared/inspection_constants.gd`
+- [X] T006 [P] Implement shared request and result file handling in `addons/agent_runtime_harness/editor/scenegraph_automation_artifact_store.gd`
+- [X] T007 [P] Extend `examples/pong-testbed/harness/inspection-run-config.json` and `addons/agent_runtime_harness/templates/project_root/harness/inspection-run-config.json` with scenario-declared target-scene fields, automation paths, and default request-scoped override support
+- [X] T008 Extend `tools/tests/ScenegraphAutomationLoop.Tests.ps1` to validate the new automation schemas with `tools/validate-json.ps1`
 
 **Checkpoint**: Shared automation contracts and artifact plumbing are ready; story work can begin.
 
@@ -47,17 +47,16 @@
 
 ### Validation for User Story 1 ⚠️
 
-- [ ] T009 [P] [US1] Add capability fixtures at `examples/pong-testbed/harness/automation/results/capability-ready.expected.json` and `examples/pong-testbed/harness/automation/results/capability-blocked.expected.json`
-- [ ] T010 [P] [US1] Add request fixtures at `examples/pong-testbed/harness/automation/requests/run-request.healthy.json` and `examples/pong-testbed/harness/automation/requests/run-request.blocked.json`
-- [ ] T011 [P] [US1] Add capability, single-project, scene-target, shutdown-readiness, and runtime-attachment lifecycle validation coverage in `tools/tests/ScenegraphAutomationLoop.Tests.ps1` against `specs/003-editor-evidence-loop/contracts/automation-capability.schema.json` and `specs/003-editor-evidence-loop/contracts/automation-lifecycle-status.schema.json`
+- [X] T009 [P] [US1] Add capability fixtures at `examples/pong-testbed/harness/automation/results/capability-ready.expected.json` and `examples/pong-testbed/harness/automation/results/capability-blocked.expected.json`
+- [X] T010 [P] [US1] Add request fixtures at `examples/pong-testbed/harness/automation/requests/run-request.healthy.json` and `examples/pong-testbed/harness/automation/requests/run-request.blocked.json`
+- [X] T011 [P] [US1] Add capability, single-project, scene-target, shutdown-readiness, and runtime-attachment lifecycle validation coverage in `tools/tests/ScenegraphAutomationLoop.Tests.ps1` against `specs/003-editor-evidence-loop/contracts/automation-capability.schema.json` and `specs/003-editor-evidence-loop/contracts/automation-lifecycle-status.schema.json`
 
 ### Implementation for User Story 1
-
-- [ ] T012 [US1] Implement the plugin-owned automation broker in `addons/agent_runtime_harness/editor/scenegraph_automation_broker.gd` and wire it from `addons/agent_runtime_harness/plugin.gd`
-- [ ] T013 [P] [US1] Implement request intake, single-run locking, and request-scoped override parsing in `addons/agent_runtime_harness/editor/scenegraph_automation_broker.gd`
-- [ ] T014 [P] [US1] Implement scenario-declared target-scene resolution and play-start control in `addons/agent_runtime_harness/editor/scenegraph_automation_broker.gd`
-- [ ] T015 [US1] Emit capability results, lifecycle-status artifacts through runtime attachment, and blocked run results from `addons/agent_runtime_harness/editor/scenegraph_automation_broker.gd` and `addons/agent_runtime_harness/editor/scenegraph_automation_artifact_store.gd`
-- [ ] T016 [US1] Add example-project wiring for automation request and result paths in `examples/pong-testbed/project.godot` and `examples/pong-testbed/harness/inspection-run-config.json`
+- [X] T012 [US1] Implement the plugin-owned automation broker in `addons/agent_runtime_harness/editor/scenegraph_automation_broker.gd` and wire it from `addons/agent_runtime_harness/plugin.gd`
+- [X] T013 [P] [US1] Implement request intake, single-run locking, and request-scoped override parsing in `addons/agent_runtime_harness/editor/scenegraph_automation_broker.gd`
+- [X] T014 [P] [US1] Implement scenario-declared target-scene resolution and play-start control in `addons/agent_runtime_harness/editor/scenegraph_automation_broker.gd`
+- [X] T015 [US1] Emit capability results, lifecycle-status artifacts through runtime attachment, and blocked run results from `addons/agent_runtime_harness/editor/scenegraph_automation_broker.gd` and `addons/agent_runtime_harness/editor/scenegraph_automation_artifact_store.gd`
+- [X] T016 [US1] Add example-project wiring for automation request and result paths in `examples/pong-testbed/project.godot` and `examples/pong-testbed/harness/inspection-run-config.json`
 
 **Checkpoint**: User Story 1 is complete when a healthy request can start the declared scene and report attached-runtime status, and blocked requests return deterministic machine-readable results without touching the dock.
 
@@ -71,17 +70,17 @@
 
 ### Validation for User Story 2 ⚠️
 
-- [ ] T017 [P] [US2] Add autonomous run result fixtures at `examples/pong-testbed/harness/automation/results/run-result.success.expected.json`, `examples/pong-testbed/harness/automation/results/run-result.attachment-failure.expected.json`, `examples/pong-testbed/harness/automation/results/run-result.capture-failure.expected.json`, `examples/pong-testbed/harness/automation/results/run-result.validation-failure.expected.json`, `examples/pong-testbed/harness/automation/results/run-result.shutdown-failure.expected.json`, and `examples/pong-testbed/harness/automation/results/run-result.gameplay-failure.expected.json`
-- [ ] T018 [P] [US2] Add manifest-backed automated run validation and failure-kind matrix coverage in `tools/tests/ScenegraphAutomationLoop.Tests.ps1` using `specs/003-editor-evidence-loop/contracts/automation-run-result.schema.json` and `specs/001-agent-tooling-foundation/contracts/evidence-manifest.schema.json`
+- [X] T017 [P] [US2] Add autonomous run result fixtures at `examples/pong-testbed/harness/automation/results/run-result.success.expected.json`, `examples/pong-testbed/harness/automation/results/run-result.attachment-failure.expected.json`, `examples/pong-testbed/harness/automation/results/run-result.capture-failure.expected.json`, `examples/pong-testbed/harness/automation/results/run-result.validation-failure.expected.json`, `examples/pong-testbed/harness/automation/results/run-result.shutdown-failure.expected.json`, and `examples/pong-testbed/harness/automation/results/run-result.gameplay-failure.expected.json`
+- [X] T018 [P] [US2] Add manifest-backed automated run validation and failure-kind matrix coverage in `tools/tests/ScenegraphAutomationLoop.Tests.ps1` using `specs/003-editor-evidence-loop/contracts/automation-run-result.schema.json` and `specs/001-agent-tooling-foundation/contracts/evidence-manifest.schema.json`
 
 ### Implementation for User Story 2
 
-- [ ] T019 [P] [US2] Implement end-to-end run lifecycle sequencing in `addons/agent_runtime_harness/editor/scenegraph_run_coordinator.gd`
-- [ ] T020 [P] [US2] Extend `addons/agent_runtime_harness/editor/scenegraph_debugger_bridge.gd` and `addons/agent_runtime_harness/runtime/scenegraph_runtime.gd` with automation-aware session configuration and completion signaling
-- [ ] T021 [US2] Implement lifecycle-status and final run-result artifact writing in `addons/agent_runtime_harness/editor/scenegraph_automation_artifact_store.gd` and `addons/agent_runtime_harness/editor/scenegraph_run_coordinator.gd`
-- [ ] T022 [US2] Wire validated capture, persistence, and shutdown sequencing in `addons/agent_runtime_harness/editor/scenegraph_run_coordinator.gd` and `addons/agent_runtime_harness/runtime/scenegraph_artifact_writer.gd`
-- [ ] T023 [US2] Implement run-id-based stale-artifact protection in `addons/agent_runtime_harness/editor/scenegraph_run_coordinator.gd`, `addons/agent_runtime_harness/editor/scenegraph_automation_artifact_store.gd`, and `examples/pong-testbed/harness/automation/results/`
-- [ ] T024 [US2] Extend template and example-project automation output settings in `addons/agent_runtime_harness/templates/project_root/harness/inspection-run-config.json` and `examples/pong-testbed/harness/inspection-run-config.json`
+- [X] T019 [P] [US2] Implement end-to-end run lifecycle sequencing in `addons/agent_runtime_harness/editor/scenegraph_run_coordinator.gd`
+- [X] T020 [P] [US2] Extend `addons/agent_runtime_harness/editor/scenegraph_debugger_bridge.gd` and `addons/agent_runtime_harness/runtime/scenegraph_runtime.gd` with automation-aware session configuration and completion signaling
+- [X] T021 [US2] Implement lifecycle-status and final run-result artifact writing in `addons/agent_runtime_harness/editor/scenegraph_automation_artifact_store.gd` and `addons/agent_runtime_harness/editor/scenegraph_run_coordinator.gd`
+- [X] T022 [US2] Wire validated capture, persistence, and shutdown sequencing in `addons/agent_runtime_harness/editor/scenegraph_run_coordinator.gd` and `addons/agent_runtime_harness/runtime/scenegraph_artifact_writer.gd`
+- [X] T023 [US2] Implement run-id-based stale-artifact protection in `addons/agent_runtime_harness/editor/scenegraph_run_coordinator.gd`, `addons/agent_runtime_harness/editor/scenegraph_automation_artifact_store.gd`, and `examples/pong-testbed/harness/automation/results/`
+- [X] T024 [US2] Extend template and example-project automation output settings in `addons/agent_runtime_harness/templates/project_root/harness/inspection-run-config.json` and `examples/pong-testbed/harness/inspection-run-config.json`
 
 **Checkpoint**: User Story 2 is complete when the autonomous loop can run end to end and the final result always points to a validated, current evidence bundle.
 
@@ -95,16 +94,16 @@
 
 ### Validation for User Story 3 ⚠️
 
-- [ ] T025 [P] [US3] Add control-path and blocked-behavior fixtures at `examples/pong-testbed/harness/automation/results/capability-options.expected.json` and `examples/pong-testbed/harness/automation/results/run-result.blocked.expected.json`
-- [ ] T026 [P] [US3] Add helper and control-path validation coverage in `tools/tests/ScenegraphAutomationLoop.Tests.ps1` and `tools/tests/AutomationTools.Tests.ps1`
+- [X] T025 [P] [US3] Add control-path and blocked-behavior fixtures at `examples/pong-testbed/harness/automation/results/capability-options.expected.json` and `examples/pong-testbed/harness/automation/results/run-result.blocked.expected.json`
+- [X] T026 [P] [US3] Add helper and control-path validation coverage in `tools/tests/ScenegraphAutomationLoop.Tests.ps1` and `tools/tests/AutomationTools.Tests.ps1`
 
 ### Implementation for User Story 3
 
-- [ ] T027 [P] [US3] Finalize contract docs and align schemas in `specs/003-editor-evidence-loop/contracts/editor-evidence-loop-contract.md`, `specs/003-editor-evidence-loop/contracts/automation-capability.schema.json`, `specs/003-editor-evidence-loop/contracts/automation-run-request.schema.json`, `specs/003-editor-evidence-loop/contracts/automation-lifecycle-status.schema.json`, and `specs/003-editor-evidence-loop/contracts/automation-run-result.schema.json`
-- [ ] T028 [P] [US3] Update `addons/agent_runtime_harness/templates/project_root/AGENTS.runtime-harness.md` with the preferred file-broker path, blocked conditions, and manifest-first evidence workflow for autonomous runs
-- [ ] T029 [P] [US3] Implement deterministic workspace helpers in `tools/automation/get-editor-evidence-capability.ps1` and `tools/automation/request-editor-evidence-run.ps1`
-- [ ] T030 [US3] Add helper-script coverage in `tools/tests/AutomationTools.Tests.ps1` and document the supported automation surfaces in `docs/AGENT_TOOLING_FOUNDATION.md`
-- [ ] T031 [US3] Update `specs/003-editor-evidence-loop/quickstart.md` and `specs/003-editor-evidence-loop/research.md` with the implemented default path and any validated fallback findings
+- [X] T027 [P] [US3] Finalize contract docs and align schemas in `specs/003-editor-evidence-loop/contracts/editor-evidence-loop-contract.md`, `specs/003-editor-evidence-loop/contracts/automation-capability.schema.json`, `specs/003-editor-evidence-loop/contracts/automation-run-request.schema.json`, `specs/003-editor-evidence-loop/contracts/automation-lifecycle-status.schema.json`, and `specs/003-editor-evidence-loop/contracts/automation-run-result.schema.json`
+- [X] T028 [P] [US3] Update `addons/agent_runtime_harness/templates/project_root/AGENTS.runtime-harness.md` with the preferred file-broker path, blocked conditions, and manifest-first evidence workflow for autonomous runs
+- [X] T029 [P] [US3] Implement deterministic workspace helpers in `tools/automation/get-editor-evidence-capability.ps1` and `tools/automation/request-editor-evidence-run.ps1`
+- [X] T030 [US3] Add helper-script coverage in `tools/tests/AutomationTools.Tests.ps1` and document the supported automation surfaces in `docs/AGENT_TOOLING_FOUNDATION.md`
+- [X] T031 [US3] Update `specs/003-editor-evidence-loop/quickstart.md` and `specs/003-editor-evidence-loop/research.md` with the implemented default path and any validated fallback findings
 
 **Checkpoint**: User Story 3 is complete when agents and maintainers can see exactly what path is supported, what is blocked, and what alternatives remain deferred.
 
@@ -114,8 +113,8 @@
 
 **Purpose**: Final synchronization, end-to-end validation, and documentation cleanup across stories.
 
-- [ ] T032 [P] Update `README.md` and `docs/AGENT_RUNTIME_HARNESS.md` with the implemented autonomous editor evidence loop entry points, constraints, and validation flow
-- [ ] T033 [P] Run `pwsh ./tools/tests/run-tool-tests.ps1` and fix regressions in `tools/tests/ScenegraphAutomationLoop.Tests.ps1`, `tools/tests/AutomationTools.Tests.ps1`, and any touched automation helpers
+- [X] T032 [P] Update `README.md` and `docs/AGENT_RUNTIME_HARNESS.md` with the implemented autonomous editor evidence loop entry points, constraints, and validation flow
+- [X] T033 [P] Run `pwsh ./tools/tests/run-tool-tests.ps1` and fix regressions in `tools/tests/ScenegraphAutomationLoop.Tests.ps1`, `tools/tests/AutomationTools.Tests.ps1`, and any touched automation helpers
 - [ ] T034 Run the full validation flow in `specs/003-editor-evidence-loop/quickstart.md` against `examples/pong-testbed/` and record implementation notes in `specs/003-editor-evidence-loop/research.md`
 - [ ] T035 [P] Run repeated seeded autonomous runs for `examples/pong-testbed/` and record machine-readable reliability results in `examples/pong-testbed/harness/automation/results/reliability-summary.json`
 - [ ] T036 [P] Measure end-to-end request-to-stop timing for the seeded healthy flow and record the result in `examples/pong-testbed/harness/automation/results/performance-summary.json`

--- a/tools/automation/get-editor-evidence-capability.ps1
+++ b/tools/automation/get-editor-evidence-capability.ps1
@@ -1,0 +1,90 @@
+[CmdletBinding()]
+param(
+    [string]$ProjectRoot = 'examples/pong-testbed',
+    [string]$ConfigPath,
+    [string]$CapabilityPath,
+    [switch]$PassThru
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+function Get-RepoRoot {
+    return (Resolve-Path (Join-Path (Join-Path $PSScriptRoot '..') '..')).Path
+}
+
+function Resolve-RepoPath {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Path
+    )
+
+    if ([System.IO.Path]::IsPathRooted($Path)) {
+        return $Path
+    }
+
+    return (Join-Path (Get-RepoRoot) $Path)
+}
+
+function Resolve-ProjectResourcePath {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$ProjectRootPath,
+
+        [Parameter(Mandatory = $true)]
+        [string]$Path
+    )
+
+    if ([string]::IsNullOrWhiteSpace($Path)) {
+        return $null
+    }
+
+    if ([System.IO.Path]::IsPathRooted($Path)) {
+        return $Path
+    }
+
+    if ($Path.StartsWith('res://', [System.StringComparison]::OrdinalIgnoreCase)) {
+        $relativePath = $Path.Substring(6).Replace('/', [System.IO.Path]::DirectorySeparatorChar)
+        return Join-Path $ProjectRootPath $relativePath
+    }
+
+    return Resolve-RepoPath -Path $Path
+}
+
+$resolvedProjectRoot = Resolve-RepoPath -Path $ProjectRoot
+$resolvedConfigPath = if ($PSBoundParameters.ContainsKey('ConfigPath')) {
+    Resolve-ProjectResourcePath -ProjectRootPath $resolvedProjectRoot -Path $ConfigPath
+}
+else {
+    Join-Path $resolvedProjectRoot 'harness/inspection-run-config.json'
+}
+
+$config = Get-Content -LiteralPath $resolvedConfigPath -Raw | ConvertFrom-Json -Depth 100
+$capabilitySourcePath = if ($PSBoundParameters.ContainsKey('CapabilityPath')) {
+    Resolve-ProjectResourcePath -ProjectRootPath $resolvedProjectRoot -Path $CapabilityPath
+}
+else {
+    Resolve-ProjectResourcePath -ProjectRootPath $resolvedProjectRoot -Path $config.automation.capabilityResultPath
+}
+
+$result = [ordered]@{
+    projectRoot = $resolvedProjectRoot
+    configPath = $resolvedConfigPath
+    capabilityPath = $capabilitySourcePath
+    exists = [bool](Test-Path -LiteralPath $capabilitySourcePath)
+    schemaValid = $false
+    capability = $null
+}
+
+if ($result.exists) {
+    $result.capability = Get-Content -LiteralPath $capabilitySourcePath -Raw | ConvertFrom-Json -Depth 100
+    $validation = & (Join-Path $PSScriptRoot '..\validate-json.ps1') -InputPath $capabilitySourcePath -SchemaPath 'specs/003-editor-evidence-loop/contracts/automation-capability.schema.json' -PassThru -AllowInvalid
+    $result.schemaValid = [bool]$validation.valid
+}
+
+if ($PassThru) {
+    [pscustomobject]$result
+}
+else {
+    [pscustomobject]$result | ConvertTo-Json -Depth 10
+}

--- a/tools/automation/request-editor-evidence-run.ps1
+++ b/tools/automation/request-editor-evidence-run.ps1
@@ -13,6 +13,15 @@ param(
     [string[]]$ExpectationFiles = @(),
     [string]$RequestedBy = 'vscode-agent',
     [bool]$StopAfterValidation = $true,
+    [string]$BoundaryArtifactId,
+    [string]$BoundaryPath = 'tools/automation/write-boundaries.json',
+    [string]$BoundaryEditType = 'update',
+    [switch]$WriteRunRecord,
+    [string]$RunRecordArtifactId,
+    [string]$RunRecordBoundaryId,
+    [string]$RunRecordOutputPath = 'tools/automation/run-records/latest-editor-evidence-request.json',
+    [ValidateSet('autonomous', 'simulated')]
+    [string]$RunRecordMode = 'simulated',
     [switch]$PassThru
 )
 
@@ -96,6 +105,25 @@ function Convert-ToStringArray {
     return ,@($Value | ForEach-Object { [string]$_ })
 }
 
+function Get-ValidationMessage {
+    param(
+        [Parameter(Mandatory = $true)]
+        [bool]$Passed,
+
+        [Parameter(Mandatory = $true)]
+        [string]$SuccessMessage,
+
+        [Parameter(Mandatory = $true)]
+        [string]$FailureMessage
+    )
+
+    if ($Passed) {
+        return $SuccessMessage
+    }
+
+    return $FailureMessage
+}
+
 $resolvedProjectRoot = Resolve-RepoPath -Path $ProjectRoot
 $resolvedConfigPath = if ($PSBoundParameters.ContainsKey('ConfigPath')) {
     Resolve-ProjectResourcePath -ProjectRootPath $resolvedProjectRoot -Path $ConfigPath
@@ -138,8 +166,43 @@ else {
     Resolve-ProjectResourcePath -ProjectRootPath $resolvedProjectRoot -Path $config.automation.requestPath -CreateParent
 }
 
+$writeBoundaryValidation = $null
+if ($PSBoundParameters.ContainsKey('BoundaryArtifactId')) {
+    $writeBoundaryValidation = & (Join-Path $PSScriptRoot 'validate-write-boundary.ps1') -ArtifactId $BoundaryArtifactId -RequestedPath $resolvedRequestPath -RequestedEditType $BoundaryEditType -BoundaryPath $BoundaryPath -PassThru -AllowViolation
+    if (-not $writeBoundaryValidation.requestAllowed) {
+        throw "Resolved request path '$resolvedRequestPath' did not pass boundary validation for artifact '$BoundaryArtifactId'."
+    }
+}
+
 $requestDocument | ConvertTo-Json -Depth 20 | Set-Content -LiteralPath $resolvedRequestPath
 $validation = & (Join-Path $PSScriptRoot '..\validate-json.ps1') -InputPath $resolvedRequestPath -SchemaPath 'specs/003-editor-evidence-loop/contracts/automation-run-request.schema.json' -PassThru -AllowInvalid
+
+$runRecordPath = $null
+if ($WriteRunRecord) {
+    $effectiveRunRecordArtifactId = if ($PSBoundParameters.ContainsKey('RunRecordArtifactId')) { $RunRecordArtifactId } else { $BoundaryArtifactId }
+    $effectiveRunRecordBoundaryId = if ($PSBoundParameters.ContainsKey('RunRecordBoundaryId')) { $RunRecordBoundaryId } elseif ($null -ne $writeBoundaryValidation) { $writeBoundaryValidation.boundaryId } else { $null }
+    if ([string]::IsNullOrWhiteSpace($effectiveRunRecordArtifactId)) {
+        throw 'RunRecordArtifactId or BoundaryArtifactId is required when WriteRunRecord is set.'
+    }
+    if ([string]::IsNullOrWhiteSpace($effectiveRunRecordBoundaryId)) {
+        throw 'RunRecordBoundaryId is required when WriteRunRecord is set and no boundary validation was performed.'
+    }
+
+    $validationNames = @('request-schema-validation')
+    $validationStatuses = @(if ($validation.valid) { 'passed' } else { 'failed' })
+    $validationDetails = @(
+        (Get-ValidationMessage -Passed ([bool]$validation.valid) -SuccessMessage 'Generated automation request passed schema validation.' -FailureMessage 'Generated automation request failed schema validation.')
+    )
+
+    if ($null -ne $writeBoundaryValidation) {
+        $validationNames = @('write-boundary-validation') + $validationNames
+        $validationStatuses = @('passed') + $validationStatuses
+        $validationDetails = @('Resolved request path passed declared write-boundary validation.') + $validationDetails
+    }
+
+    $runRecord = & (Join-Path $PSScriptRoot 'new-autonomous-run-record.ps1') -ArtifactId $effectiveRunRecordArtifactId -WriteBoundaryId $effectiveRunRecordBoundaryId -RequestSummary "Write automation request artifact to $resolvedRequestPath" -OutputPath $RunRecordOutputPath -Mode $RunRecordMode -Status $(if ($validation.valid) { 'success' } else { 'failed' }) -OperationPath $resolvedRequestPath -OperationEditType $BoundaryEditType -OperationStatus 'performed' -ValidationName $validationNames -ValidationStatus $validationStatuses -ValidationDetails $validationDetails -PassThru
+    $runRecordPath = $runRecord.recordPath
+}
 
 $result = [ordered]@{
     projectRoot = $resolvedProjectRoot
@@ -148,6 +211,9 @@ $result = [ordered]@{
     requestId = $requestDocument.requestId
     runId = $requestDocument.runId
     schemaValid = [bool]$validation.valid
+    writeBoundaryValidated = [bool]($null -ne $writeBoundaryValidation -and $writeBoundaryValidation.requestAllowed)
+    writeBoundaryId = if ($null -ne $writeBoundaryValidation) { $writeBoundaryValidation.boundaryId } else { $null }
+    runRecordPath = $runRecordPath
 }
 
 if (-not $result.schemaValid) {

--- a/tools/automation/request-editor-evidence-run.ps1
+++ b/tools/automation/request-editor-evidence-run.ps1
@@ -1,0 +1,162 @@
+[CmdletBinding()]
+param(
+    [string]$ProjectRoot = 'examples/pong-testbed',
+    [string]$ConfigPath,
+    [string]$RequestPath,
+    [string]$RequestFixturePath,
+    [string]$RequestId,
+    [string]$ScenarioId,
+    [string]$RunId,
+    [string]$TargetScene,
+    [string]$OutputDirectory,
+    [string]$ArtifactRoot,
+    [string[]]$ExpectationFiles = @(),
+    [string]$RequestedBy = 'vscode-agent',
+    [bool]$StopAfterValidation = $true,
+    [switch]$PassThru
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+function Get-RepoRoot {
+    return (Resolve-Path (Join-Path (Join-Path $PSScriptRoot '..') '..')).Path
+}
+
+function Resolve-RepoPath {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Path,
+
+        [switch]$CreateParent
+    )
+
+    if ([System.IO.Path]::IsPathRooted($Path)) {
+        $resolvedPath = $Path
+    }
+    else {
+        $resolvedPath = Join-Path (Get-RepoRoot) $Path
+    }
+
+    if ($CreateParent) {
+        $parentPath = Split-Path -Parent $resolvedPath
+        if (-not (Test-Path -LiteralPath $parentPath)) {
+            New-Item -ItemType Directory -Path $parentPath -Force | Out-Null
+        }
+    }
+
+    return $resolvedPath
+}
+
+function Resolve-ProjectResourcePath {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$ProjectRootPath,
+
+        [Parameter(Mandatory = $true)]
+        [string]$Path,
+
+        [switch]$CreateParent
+    )
+
+    if ([System.IO.Path]::IsPathRooted($Path)) {
+        $resolvedPath = $Path
+    }
+    elseif ($Path.StartsWith('res://', [System.StringComparison]::OrdinalIgnoreCase)) {
+        $relativePath = $Path.Substring(6).Replace('/', [System.IO.Path]::DirectorySeparatorChar)
+        $resolvedPath = Join-Path $ProjectRootPath $relativePath
+    }
+    else {
+        $resolvedPath = Resolve-RepoPath -Path $Path
+    }
+
+    if ($CreateParent) {
+        $parentPath = Split-Path -Parent $resolvedPath
+        if (-not (Test-Path -LiteralPath $parentPath)) {
+            New-Item -ItemType Directory -Path $parentPath -Force | Out-Null
+        }
+    }
+
+    return $resolvedPath
+}
+
+function Convert-ToStringArray {
+    param(
+        $Value
+    )
+
+    if ($null -eq $Value) {
+        return ,@()
+    }
+
+    if ($Value -is [string]) {
+        return ,@($Value)
+    }
+
+    return ,@($Value | ForEach-Object { [string]$_ })
+}
+
+$resolvedProjectRoot = Resolve-RepoPath -Path $ProjectRoot
+$resolvedConfigPath = if ($PSBoundParameters.ContainsKey('ConfigPath')) {
+    Resolve-ProjectResourcePath -ProjectRootPath $resolvedProjectRoot -Path $ConfigPath
+}
+else {
+    Join-Path $resolvedProjectRoot 'harness/inspection-run-config.json'
+}
+
+$config = Get-Content -LiteralPath $resolvedConfigPath -Raw | ConvertFrom-Json -Depth 100
+$defaultRequest = if ($PSBoundParameters.ContainsKey('RequestFixturePath')) {
+    $fixturePath = Resolve-RepoPath -Path $RequestFixturePath
+    Get-Content -LiteralPath $fixturePath -Raw | ConvertFrom-Json -Depth 100
+}
+else {
+    [pscustomobject]@{}
+}
+
+$requestDocument = [ordered]@{
+    requestId = if ($PSBoundParameters.ContainsKey('RequestId')) { $RequestId } elseif ($defaultRequest.requestId) { $defaultRequest.requestId } else { [guid]::NewGuid().Guid }
+    scenarioId = if ($PSBoundParameters.ContainsKey('ScenarioId')) { $ScenarioId } elseif ($defaultRequest.scenarioId) { $defaultRequest.scenarioId } else { $config.scenarioId }
+    runId = if ($PSBoundParameters.ContainsKey('RunId')) { $RunId } elseif ($defaultRequest.runId) { $defaultRequest.runId } else { ('run-' + [guid]::NewGuid().Guid) }
+    targetScene = if ($PSBoundParameters.ContainsKey('TargetScene')) { $TargetScene } elseif ($defaultRequest.targetScene) { $defaultRequest.targetScene } else { $config.targetScene }
+    outputDirectory = if ($PSBoundParameters.ContainsKey('OutputDirectory')) { $OutputDirectory } elseif ($defaultRequest.outputDirectory) { $defaultRequest.outputDirectory } else { $config.outputDirectory }
+    artifactRoot = if ($PSBoundParameters.ContainsKey('ArtifactRoot')) { $ArtifactRoot } elseif ($defaultRequest.artifactRoot) { $defaultRequest.artifactRoot } else { $config.artifactRoot }
+    expectationFiles = if ($ExpectationFiles.Count -gt 0) { Convert-ToStringArray $ExpectationFiles } elseif ($defaultRequest.expectationFiles) { Convert-ToStringArray $defaultRequest.expectationFiles } else { Convert-ToStringArray $config.expectationFiles }
+    capturePolicy = if ($defaultRequest.capturePolicy) { $defaultRequest.capturePolicy } else { $config.capturePolicy }
+    stopPolicy = [ordered]@{ stopAfterValidation = $StopAfterValidation }
+    requestedBy = $RequestedBy
+    createdAt = [DateTime]::UtcNow.ToString('o')
+}
+
+if ($defaultRequest.PSObject.Properties.Name -contains 'overrides') {
+    $requestDocument.overrides = $defaultRequest.overrides
+}
+
+$resolvedRequestPath = if ($PSBoundParameters.ContainsKey('RequestPath')) {
+    Resolve-ProjectResourcePath -ProjectRootPath $resolvedProjectRoot -Path $RequestPath -CreateParent
+}
+else {
+    Resolve-ProjectResourcePath -ProjectRootPath $resolvedProjectRoot -Path $config.automation.requestPath -CreateParent
+}
+
+$requestDocument | ConvertTo-Json -Depth 20 | Set-Content -LiteralPath $resolvedRequestPath
+$validation = & (Join-Path $PSScriptRoot '..\validate-json.ps1') -InputPath $resolvedRequestPath -SchemaPath 'specs/003-editor-evidence-loop/contracts/automation-run-request.schema.json' -PassThru -AllowInvalid
+
+$result = [ordered]@{
+    projectRoot = $resolvedProjectRoot
+    configPath = $resolvedConfigPath
+    requestPath = $resolvedRequestPath
+    requestId = $requestDocument.requestId
+    runId = $requestDocument.runId
+    schemaValid = [bool]$validation.valid
+}
+
+if (-not $result.schemaValid) {
+    throw 'Generated automation run request did not pass schema validation.'
+}
+
+if ($PassThru) {
+    [pscustomobject]$result
+}
+else {
+    [pscustomobject]$result | ConvertTo-Json -Depth 10
+}

--- a/tools/automation/write-boundaries.json
+++ b/tools/automation/write-boundaries.json
@@ -24,6 +24,31 @@
         "Task requires expanding the boundary contract."
       ],
       "logOutputPath": "tools/automation/run-records/"
+    },
+    {
+      "id": "editor-evidence-run-request-helper",
+      "artifactId": "editor-evidence-run-request.helper",
+      "description": "Boundary for deterministic editor-evidence run-request artifacts and audit records.",
+      "allowedPaths": [
+        "examples/pong-testbed/harness/automation/requests/",
+        "tools/tests/.tmp/",
+        "tools/automation/run-records/"
+      ],
+      "allowedEditTypes": [
+        "create",
+        "update"
+      ],
+      "stopConditions": [
+        "Requested request artifact path falls outside the declared automation request or test-sandbox locations.",
+        "Requested edit type is destructive or not explicitly allowed.",
+        "The helper is asked to bypass the declared workspace write boundary."
+      ],
+      "escalationConditions": [
+        "The request needs to write into a project path that is not yet declared in the boundary contract.",
+        "The helper must support delete operations or non-file-broker automation surfaces.",
+        "A workflow needs broader auditing than the helper can record with the existing run-record schema."
+      ],
+      "logOutputPath": "tools/automation/run-records/"
     }
   ]
 }

--- a/tools/deploy-game-harness.ps1
+++ b/tools/deploy-game-harness.ps1
@@ -288,6 +288,14 @@ function Get-TriageAgentContent {
     return (Get-TemplateContent -RelativePath '.github/agents/godot-evidence-triage.agent.md')
 }
 
+function Get-RuntimeVerificationPromptContent {
+    return (Get-TemplateContent -RelativePath '.github/prompts/godot-runtime-verification.prompt.md')
+}
+
+function Get-RuntimeVerificationAgentContent {
+    return (Get-TemplateContent -RelativePath '.github/agents/godot-runtime-verification.agent.md')
+}
+
 function Get-InspectionRunConfigContent {
     return (Get-TemplateContent -RelativePath 'harness/inspection-run-config.json')
 }
@@ -393,6 +401,16 @@ if (-not $SkipAgentAssets) {
     }
     Add-Operation -Operations $operations -Path $promptPath -Action $promptAction
 
+    $runtimePromptPath = Join-Path $resolvedGameRoot '.github/prompts/godot-runtime-verification.prompt.md'
+    if ($PSCmdlet.ShouldProcess($runtimePromptPath, 'Write Godot runtime verification prompt')) {
+        Set-FileContent -Path $runtimePromptPath -Content (Get-RuntimeVerificationPromptContent)
+        $runtimePromptAction = 'wrote-runtime-prompt'
+    }
+    else {
+        $runtimePromptAction = 'skipped-write-runtime-prompt'
+    }
+    Add-Operation -Operations $operations -Path $runtimePromptPath -Action $runtimePromptAction
+
     $agentPath = Join-Path $resolvedGameRoot '.github/agents/godot-evidence-triage.agent.md'
     if ($PSCmdlet.ShouldProcess($agentPath, 'Write Godot evidence triage agent')) {
         Set-FileContent -Path $agentPath -Content (Get-TriageAgentContent)
@@ -402,6 +420,16 @@ if (-not $SkipAgentAssets) {
         $agentAction = 'skipped-write-agent'
     }
     Add-Operation -Operations $operations -Path $agentPath -Action $agentAction
+
+    $runtimeAgentPath = Join-Path $resolvedGameRoot '.github/agents/godot-runtime-verification.agent.md'
+    if ($PSCmdlet.ShouldProcess($runtimeAgentPath, 'Write Godot runtime verification agent')) {
+        Set-FileContent -Path $runtimeAgentPath -Content (Get-RuntimeVerificationAgentContent)
+        $runtimeAgentAction = 'wrote-runtime-agent'
+    }
+    else {
+        $runtimeAgentAction = 'skipped-write-runtime-agent'
+    }
+    Add-Operation -Operations $operations -Path $runtimeAgentPath -Action $runtimeAgentAction
 }
 
 $result = [ordered]@{

--- a/tools/evals/001-agent-tooling-foundation/final-validation-results.json
+++ b/tools/evals/001-agent-tooling-foundation/final-validation-results.json
@@ -9,7 +9,8 @@
     "fixturePaths": [
       "tools/evals/001-agent-tooling-foundation/us1-orientation-results.json",
       "tools/evals/001-agent-tooling-foundation/us2-bundle-results.json",
-      "tools/evals/001-agent-tooling-foundation/us3-validation-results.json"
+      "tools/evals/001-agent-tooling-foundation/us3-validation-results.json",
+      "tools/evals/001-agent-tooling-foundation/us4-routing-results.json"
     ],
     "guidancePaths": [
       "README.md",
@@ -20,8 +21,8 @@
     "outputPath": "tools/evals/001-agent-tooling-foundation/final-validation-results.json"
   },
   "summary": {
-    "headline": "The agent tooling foundation is fully scaffolded, validated, and recorded in machine-readable outputs.",
-    "details": "Setup directories, shared schemas, evidence tooling, automation boundaries, Copilot guidance assets, and story-level result files are all present and synchronized with the quickstart flow."
+    "headline": "The agent tooling foundation is scaffolded, validated, and now routes runtime verification explicitly.",
+    "details": "Setup directories, shared schemas, evidence tooling, automation boundaries, runtime-verification guidance assets, and story-level result files are present and synchronized with the quickstart flow."
   },
   "checks": [
     {
@@ -37,12 +38,17 @@
     {
       "id": "story-results-recorded",
       "status": "pass",
-      "details": "US1, US2, and US3 each have seeded fixtures and machine-readable result files in `tools/evals/001-agent-tooling-foundation/`."
+      "details": "US1, US2, US3, and US4 each have seeded fixtures and machine-readable result files in `tools/evals/001-agent-tooling-foundation/`."
     },
     {
       "id": "quickstart-synced",
       "status": "pass",
       "details": "The quickstart now references the implemented commands, result files, and validation loop used in this repo."
+    },
+    {
+      "id": "runtime-routing-documented",
+      "status": "pass",
+      "details": "The guidance stack and reusable assets consistently distinguish ordinary tests, Scenegraph Harness runtime verification, combined validation, and post-run evidence triage."
     }
   ],
   "metrics": {

--- a/tools/evals/001-agent-tooling-foundation/us4-expected-results.json
+++ b/tools/evals/001-agent-tooling-foundation/us4-expected-results.json
@@ -1,0 +1,18 @@
+{
+  "routing": {
+    "run-unit-tests-request": "ordinary-tests",
+    "verify-node-in-game-request": "scenegraph-runtime-verification",
+    "prove-gameplay-change-request": "combined-validation",
+    "inspect-existing-manifest-request": "evidence-triage"
+  },
+  "runtimeVerificationWorkflow": [
+    "read-capability-first",
+    "request-brokered-run",
+    "inspect-persisted-manifest-first",
+    "report-blocked-or-missing-runtime-artifacts-explicitly"
+  ],
+  "combinedValidationPolicy": {
+    "requiresExistingDeterministicTestSurface": true,
+    "forbidInventingNewOrdinaryTestsOnlyToSatisfyRule": true
+  }
+}

--- a/tools/evals/001-agent-tooling-foundation/us4-routing-results.json
+++ b/tools/evals/001-agent-tooling-foundation/us4-routing-results.json
@@ -1,0 +1,57 @@
+{
+  "schemaVersion": "1.0.0",
+  "evaluationId": "us4-runtime-routing-2026-04-12",
+  "storyId": "US4",
+  "surface": "combined",
+  "executionMode": "repo-local",
+  "status": "pass",
+  "artifacts": {
+    "fixturePaths": [
+      "tools/evals/001-agent-tooling-foundation/us4-runtime-routing.md",
+      "tools/evals/001-agent-tooling-foundation/us4-expected-results.json"
+    ],
+    "guidancePaths": [
+      ".github/copilot-instructions.md",
+      "AGENTS.md",
+      "docs/AGENT_TOOLING_FOUNDATION.md",
+      "docs/AI_TOOLING_AUTOMATION_MATRIX.md",
+      ".github/prompts/godot-runtime-verification.prompt.md",
+      ".github/agents/godot-runtime-verification.agent.md",
+      ".github/prompts/godot-evidence-triage.prompt.md",
+      ".github/agents/godot-evidence-triage.agent.md"
+    ],
+    "outputPath": "tools/evals/001-agent-tooling-foundation/us4-routing-results.json"
+  },
+  "summary": {
+    "headline": "Ambiguous testing language now routes to the correct validation workflow.",
+    "details": "The guidance stack distinguishes ordinary tests, Scenegraph Harness runtime verification, combined validation, and manifest-centered evidence triage, and the reusable artifacts preserve that split."
+  },
+  "checks": [
+    {
+      "id": "ordinary-tests-routing-defined",
+      "status": "pass",
+      "details": "Requests to add helpers and run unit tests stay on ordinary test surfaces instead of invoking the runtime harness."
+    },
+    {
+      "id": "runtime-verification-routing-defined",
+      "status": "pass",
+      "details": "Runtime-visible requests now route through capability check, brokered run request, and manifest-first Scenegraph Harness evidence review."
+    },
+    {
+      "id": "combined-validation-routing-defined",
+      "status": "pass",
+      "details": "Gameplay changes with an existing deterministic test surface require both ordinary tests and runtime verification, without fabricating new tests solely to satisfy the rule."
+    },
+    {
+      "id": "evidence-triage-scope-preserved",
+      "status": "pass",
+      "details": "Requests that already provide an evidence manifest stay in the evidence-triage workflow instead of launching a fresh runtime-verification run."
+    }
+  ],
+  "metrics": {
+    "firstPassRoutingAccurate": true,
+    "pluginFirstRespected": true,
+    "evidenceFirstRespected": true
+  },
+  "recordedAt": "2026-04-12T00:00:00Z"
+}

--- a/tools/evals/001-agent-tooling-foundation/us4-runtime-routing.md
+++ b/tools/evals/001-agent-tooling-foundation/us4-runtime-routing.md
@@ -1,0 +1,22 @@
+# US4 Runtime Routing Eval
+
+## Goal
+
+Verify that the guidance stack routes ambiguous testing language to ordinary tests, Scenegraph Harness runtime verification, combined validation, or post-run evidence triage.
+
+## Prompt
+
+Classify the correct validation path for each request and briefly justify it:
+
+1. "Add a helper method and run unit tests."
+2. "Verify at runtime that the pause menu node appears in game when the scene starts."
+3. "Change the enemy chase behavior and prove it works in the running game; there is already a deterministic scoring test for the chase path."
+4. "Here is `evidence/scenegraph/latest/evidence-manifest.json`; tell me the next artifact to inspect."
+
+## Expected behavior
+
+- Routes item 1 to **ordinary tests** only.
+- Routes item 2 to **Scenegraph Harness runtime verification**.
+- Routes item 3 to **combined validation** because it needs both runtime proof and an existing deterministic test surface.
+- Routes item 4 to **evidence triage** instead of launching a fresh runtime-verification run.
+- Notes that runtime verification should check capability first, request a brokered run, and inspect the persisted manifest before raw artifacts.

--- a/tools/tests/AutomationTools.Tests.ps1
+++ b/tools/tests/AutomationTools.Tests.ps1
@@ -228,3 +228,64 @@ Describe 'tools/automation/new-autonomous-run-record.ps1' {
         } | Should -Throw '*ValidationDetails must contain 2 entries*'
     }
 }
+
+Describe 'tools/automation/get-editor-evidence-capability.ps1' {
+    BeforeAll {
+        . (Join-Path $PSScriptRoot 'TestHelpers.ps1')
+    }
+
+    It 'reads and validates a capability artifact for a sandbox project' {
+        $sandboxPath = New-RepoSandboxDirectory
+
+        try {
+            $harnessPath = Join-Path $sandboxPath 'harness'
+            $resultsPath = Join-Path $harnessPath 'automation\results'
+            New-Item -ItemType Directory -Path $resultsPath -Force | Out-Null
+            Copy-Item -LiteralPath (Get-RepoPath -Path 'examples/pong-testbed/harness/inspection-run-config.json') -Destination (Join-Path $harnessPath 'inspection-run-config.json')
+            Copy-Item -LiteralPath (Get-RepoPath -Path 'examples/pong-testbed/harness/automation/results/capability-ready.expected.json') -Destination (Join-Path $resultsPath 'capability.json')
+
+            $result = Invoke-RepoScriptPassThru -ScriptPath 'tools/automation/get-editor-evidence-capability.ps1' -Parameters @{
+                ProjectRoot = $sandboxPath
+                PassThru = $true
+            }
+
+            $result.exists | Should -BeTrue
+            $result.schemaValid | Should -BeTrue
+            $result.capability.recommendedControlPath | Should -Be 'file_broker'
+        }
+        finally {
+            Remove-Item -LiteralPath $sandboxPath -Recurse -Force -ErrorAction SilentlyContinue
+        }
+    }
+}
+
+Describe 'tools/automation/request-editor-evidence-run.ps1' {
+    BeforeAll {
+        . (Join-Path $PSScriptRoot 'TestHelpers.ps1')
+    }
+
+    It 'writes a schema-valid request artifact for a sandbox project' {
+        $sandboxPath = New-RepoSandboxDirectory
+
+        try {
+            $harnessPath = Join-Path $sandboxPath 'harness'
+            New-Item -ItemType Directory -Path $harnessPath -Force | Out-Null
+            Copy-Item -LiteralPath (Get-RepoPath -Path 'examples/pong-testbed/harness/inspection-run-config.json') -Destination (Join-Path $harnessPath 'inspection-run-config.json')
+
+            $result = Invoke-RepoScriptPassThru -ScriptPath 'tools/automation/request-editor-evidence-run.ps1' -Parameters @{
+                ProjectRoot = $sandboxPath
+                RequestFixturePath = 'examples/pong-testbed/harness/automation/requests/run-request.healthy.json'
+                RequestedBy = 'automation-tools-test'
+                PassThru = $true
+            }
+
+            $result.schemaValid | Should -BeTrue
+            $request = Get-Content -LiteralPath $result.requestPath -Raw | ConvertFrom-Json -Depth 100
+            $request.requestedBy | Should -Be 'automation-tools-test'
+            $request.stopPolicy.stopAfterValidation | Should -BeTrue
+        }
+        finally {
+            Remove-Item -LiteralPath $sandboxPath -Recurse -Force -ErrorAction SilentlyContinue
+        }
+    }
+}

--- a/tools/tests/AutomationTools.Tests.ps1
+++ b/tools/tests/AutomationTools.Tests.ps1
@@ -288,4 +288,39 @@ Describe 'tools/automation/request-editor-evidence-run.ps1' {
             Remove-Item -LiteralPath $sandboxPath -Recurse -Force -ErrorAction SilentlyContinue
         }
     }
+
+    It 'optionally validates the write boundary and emits an audit record' {
+        $sandboxPath = New-RepoSandboxDirectory
+        $runRecordPath = Join-Path $TestDrive 'editor-evidence-run-request-record.json'
+
+        try {
+            $harnessPath = Join-Path $sandboxPath 'harness'
+            New-Item -ItemType Directory -Path $harnessPath -Force | Out-Null
+            Copy-Item -LiteralPath (Get-RepoPath -Path 'examples/pong-testbed/harness/inspection-run-config.json') -Destination (Join-Path $harnessPath 'inspection-run-config.json')
+
+            $result = Invoke-RepoScriptPassThru -ScriptPath 'tools/automation/request-editor-evidence-run.ps1' -Parameters @{
+                ProjectRoot = $sandboxPath
+                RequestFixturePath = 'examples/pong-testbed/harness/automation/requests/run-request.healthy.json'
+                BoundaryArtifactId = 'editor-evidence-run-request.helper'
+                WriteRunRecord = $true
+                RunRecordArtifactId = 'editor-evidence-run-request.helper'
+                RunRecordBoundaryId = 'editor-evidence-run-request-helper'
+                RunRecordOutputPath = $runRecordPath
+                PassThru = $true
+            }
+
+            $result.writeBoundaryValidated | Should -BeTrue
+            $result.writeBoundaryId | Should -Be 'editor-evidence-run-request-helper'
+            $result.runRecordPath | Should -Be $runRecordPath
+
+            $runRecord = Get-Content -LiteralPath $runRecordPath -Raw | ConvertFrom-Json -Depth 100
+            $runRecord.artifactId | Should -Be 'editor-evidence-run-request.helper'
+            $runRecord.writeBoundaryId | Should -Be 'editor-evidence-run-request-helper'
+            $runRecord.validations.name | Should -Contain 'write-boundary-validation'
+            $runRecord.validations.name | Should -Contain 'request-schema-validation'
+        }
+        finally {
+            Remove-Item -LiteralPath $sandboxPath -Recurse -Force -ErrorAction SilentlyContinue
+        }
+    }
 }

--- a/tools/tests/DeployGameHarness.Tests.ps1
+++ b/tools/tests/DeployGameHarness.Tests.ps1
@@ -25,7 +25,9 @@ config/name="Sandbox Game"
         (Join-Path $gameRoot 'addons/agent_runtime_harness/plugin.cfg') | Should -Exist
         (Join-Path $gameRoot 'harness/inspection-run-config.json') | Should -Exist
         (Join-Path $gameRoot '.github/prompts/godot-evidence-triage.prompt.md') | Should -Exist
+        (Join-Path $gameRoot '.github/prompts/godot-runtime-verification.prompt.md') | Should -Exist
         (Join-Path $gameRoot '.github/agents/godot-evidence-triage.agent.md') | Should -Exist
+        (Join-Path $gameRoot '.github/agents/godot-runtime-verification.agent.md') | Should -Exist
         (Join-Path $gameRoot 'AGENTS.md') | Should -Exist
 
         $projectContent = Get-Content -LiteralPath $projectPath -Raw
@@ -75,11 +77,15 @@ config/name="Sandbox Game"
         $actions | Should -Contain 'copilot-instructions-skipped'
         $actions | Should -Contain 'agents-skipped'
         $actions | Should -Contain 'skipped-write-prompt'
+        $actions | Should -Contain 'skipped-write-runtime-prompt'
         $actions | Should -Contain 'skipped-write-agent'
+        $actions | Should -Contain 'skipped-write-runtime-agent'
 
         (Join-Path $gameRoot 'addons/agent_runtime_harness/plugin.cfg') | Should -Not -Exist
         (Join-Path $gameRoot 'harness/inspection-run-config.json') | Should -Not -Exist
         (Join-Path $gameRoot '.github/prompts/godot-evidence-triage.prompt.md') | Should -Not -Exist
+        (Join-Path $gameRoot '.github/prompts/godot-runtime-verification.prompt.md') | Should -Not -Exist
         (Join-Path $gameRoot '.github/agents/godot-evidence-triage.agent.md') | Should -Not -Exist
+        (Join-Path $gameRoot '.github/agents/godot-runtime-verification.agent.md') | Should -Not -Exist
     }
 }

--- a/tools/tests/ScenegraphAutomationLoop.Tests.ps1
+++ b/tools/tests/ScenegraphAutomationLoop.Tests.ps1
@@ -1,0 +1,227 @@
+BeforeAll {
+    . (Join-Path $PSScriptRoot 'TestHelpers.ps1')
+}
+
+
+Describe 'specs/003-editor-evidence-loop automation schemas' {
+    It 'accepts a ready automation capability payload' {
+        $payloadPath = Join-Path $TestDrive 'automation-capability.json'
+        @{
+            checkedAt = '2026-04-12T12:00:00Z'
+            projectIdentifier = 'examples/pong-testbed'
+            singleTargetReady = $true
+            launchControlAvailable = $true
+            runtimeBridgeAvailable = $true
+            captureControlAvailable = $true
+            persistenceAvailable = $true
+            validationAvailable = $true
+            shutdownControlAvailable = $true
+            blockedReasons = @()
+            recommendedControlPath = 'file_broker'
+            notes = @('Ready for autonomous editor evidence runs.')
+        } | ConvertTo-Json -Depth 20 | Set-Content -LiteralPath $payloadPath
+
+        $result = Invoke-RepoJsonScript -ScriptPath 'tools/validate-json.ps1' -Arguments @(
+            '-InputPath', $payloadPath,
+            '-SchemaPath', 'specs/003-editor-evidence-loop/contracts/automation-capability.schema.json'
+        )
+
+        $result.ExitCode | Should -Be 0
+        $result.ParsedOutput.valid | Should -BeTrue
+    }
+
+    It 'accepts a run request payload with request-scoped overrides' {
+        $payloadPath = Join-Path $TestDrive 'automation-run-request.json'
+        @{
+            requestId = 'pong-request-001'
+            scenarioId = 'pong-scenegraph-happy-path'
+            runId = 'pong-run-001'
+            targetScene = 'res://scenes/main.tscn'
+            outputDirectory = 'res://evidence/automation/pong-run-001'
+            artifactRoot = 'examples/pong-testbed/evidence/automation/pong-run-001'
+            expectationFiles = @('res://harness/expectations/common.json')
+            capturePolicy = @{
+                startup = $true
+                manual = $true
+                failure = $true
+            }
+            stopPolicy = @{
+                stopAfterValidation = $true
+            }
+            requestedBy = 'scenegraph-automation-test'
+            createdAt = '2026-04-12T12:01:00Z'
+            overrides = @{
+                outputDirectory = 'res://evidence/automation/pong-run-override'
+            }
+        } | ConvertTo-Json -Depth 20 | Set-Content -LiteralPath $payloadPath
+
+        $result = Invoke-RepoJsonScript -ScriptPath 'tools/validate-json.ps1' -Arguments @(
+            '-InputPath', $payloadPath,
+            '-SchemaPath', 'specs/003-editor-evidence-loop/contracts/automation-run-request.schema.json'
+        )
+
+        $result.ExitCode | Should -Be 0
+        $result.ParsedOutput.valid | Should -BeTrue
+    }
+
+    It 'accepts a lifecycle status payload' {
+        $payloadPath = Join-Path $TestDrive 'automation-lifecycle-status.json'
+        @{
+            requestId = 'pong-request-001'
+            runId = 'pong-run-001'
+            status = 'awaiting_runtime'
+            details = 'Waiting for the runtime debugger session to attach.'
+            timestamp = '2026-04-12T12:02:00Z'
+            sessionId = 'automation-session-001'
+            controlPath = 'file_broker'
+            evidenceRefs = @('examples/pong-testbed/harness/automation/results/lifecycle-status.json')
+        } | ConvertTo-Json -Depth 20 | Set-Content -LiteralPath $payloadPath
+
+        $result = Invoke-RepoJsonScript -ScriptPath 'tools/validate-json.ps1' -Arguments @(
+            '-InputPath', $payloadPath,
+            '-SchemaPath', 'specs/003-editor-evidence-loop/contracts/automation-lifecycle-status.schema.json'
+        )
+
+        $result.ExitCode | Should -Be 0
+        $result.ParsedOutput.valid | Should -BeTrue
+    }
+
+    It 'accepts a completed run result payload' {
+        $payloadPath = Join-Path $TestDrive 'automation-run-result.json'
+        @{
+            requestId = 'pong-request-001'
+            runId = 'pong-run-001'
+            finalStatus = 'completed'
+            failureKind = $null
+            manifestPath = 'examples/pong-testbed/evidence/automation/pong-run-001/evidence-manifest.json'
+            outputDirectory = 'res://evidence/automation/pong-run-001'
+            validationResult = @{
+                manifestExists = $true
+                artifactRefsChecked = 3
+                missingArtifacts = @()
+                bundleValid = $true
+                notes = @('Manifest and referenced scenegraph artifacts passed validation.')
+                validatedAt = '2026-04-12T12:03:00Z'
+            }
+            terminationStatus = 'stopped_cleanly'
+            blockedReasons = @()
+            controlPath = 'file_broker'
+            completedAt = '2026-04-12T12:03:30Z'
+        } | ConvertTo-Json -Depth 20 | Set-Content -LiteralPath $payloadPath
+
+        $result = Invoke-RepoJsonScript -ScriptPath 'tools/validate-json.ps1' -Arguments @(
+            '-InputPath', $payloadPath,
+            '-SchemaPath', 'specs/003-editor-evidence-loop/contracts/automation-run-result.schema.json'
+        )
+
+        $result.ExitCode | Should -Be 0
+        $result.ParsedOutput.valid | Should -BeTrue
+    }
+}
+
+Describe 'examples/pong-testbed automation fixtures' {
+    It 'accepts the ready capability fixture' {
+        $result = Invoke-RepoJsonScript -ScriptPath 'tools/validate-json.ps1' -Arguments @(
+            '-InputPath', 'examples/pong-testbed/harness/automation/results/capability-ready.expected.json',
+            '-SchemaPath', 'specs/003-editor-evidence-loop/contracts/automation-capability.schema.json'
+        )
+
+        $result.ExitCode | Should -Be 0
+        $result.ParsedOutput.valid | Should -BeTrue
+    }
+
+    It 'accepts the blocked capability fixture' {
+        $result = Invoke-RepoJsonScript -ScriptPath 'tools/validate-json.ps1' -Arguments @(
+            '-InputPath', 'examples/pong-testbed/harness/automation/results/capability-blocked.expected.json',
+            '-SchemaPath', 'specs/003-editor-evidence-loop/contracts/automation-capability.schema.json'
+        )
+
+        $result.ExitCode | Should -Be 0
+        $result.ParsedOutput.valid | Should -BeTrue
+    }
+
+    It 'accepts the healthy run request fixture' {
+        $result = Invoke-RepoJsonScript -ScriptPath 'tools/validate-json.ps1' -Arguments @(
+            '-InputPath', 'examples/pong-testbed/harness/automation/requests/run-request.healthy.json',
+            '-SchemaPath', 'specs/003-editor-evidence-loop/contracts/automation-run-request.schema.json'
+        )
+
+        $result.ExitCode | Should -Be 0
+        $result.ParsedOutput.valid | Should -BeTrue
+    }
+
+    It 'accepts the blocked run request fixture' {
+        $result = Invoke-RepoJsonScript -ScriptPath 'tools/validate-json.ps1' -Arguments @(
+            '-InputPath', 'examples/pong-testbed/harness/automation/requests/run-request.blocked.json',
+            '-SchemaPath', 'specs/003-editor-evidence-loop/contracts/automation-run-request.schema.json'
+        )
+
+        $result.ExitCode | Should -Be 0
+        $result.ParsedOutput.valid | Should -BeTrue
+    }
+
+    It 'accepts the capability options fixture' {
+        $result = Invoke-RepoJsonScript -ScriptPath 'tools/validate-json.ps1' -Arguments @(
+            '-InputPath', 'examples/pong-testbed/harness/automation/results/capability-options.expected.json',
+            '-SchemaPath', 'specs/003-editor-evidence-loop/contracts/automation-capability.schema.json'
+        )
+
+        $result.ExitCode | Should -Be 0
+        $result.ParsedOutput.valid | Should -BeTrue
+    }
+
+    It 'accepts the success run result fixture and its referenced manifest' {
+        $result = Invoke-RepoJsonScript -ScriptPath 'tools/validate-json.ps1' -Arguments @(
+            '-InputPath', 'examples/pong-testbed/harness/automation/results/run-result.success.expected.json',
+            '-SchemaPath', 'specs/003-editor-evidence-loop/contracts/automation-run-result.schema.json'
+        )
+        $manifestValidation = Invoke-RepoJsonScript -ScriptPath 'tools/evidence/validate-evidence-manifest.ps1' -Arguments @(
+            '-ManifestPath', 'examples/pong-testbed/harness/expected-evidence-manifest.json'
+        )
+
+        $result.ExitCode | Should -Be 0
+        $result.ParsedOutput.valid | Should -BeTrue
+        $manifestValidation.ExitCode | Should -Be 0
+        $manifestValidation.ParsedOutput.bundleValid | Should -BeTrue
+    }
+
+    It 'accepts each failure and blocked run result fixture' {
+        $fixturePaths = @(
+            'examples/pong-testbed/harness/automation/results/run-result.attachment-failure.expected.json',
+            'examples/pong-testbed/harness/automation/results/run-result.capture-failure.expected.json',
+            'examples/pong-testbed/harness/automation/results/run-result.validation-failure.expected.json',
+            'examples/pong-testbed/harness/automation/results/run-result.shutdown-failure.expected.json',
+            'examples/pong-testbed/harness/automation/results/run-result.gameplay-failure.expected.json',
+            'examples/pong-testbed/harness/automation/results/run-result.blocked.expected.json'
+        )
+
+        foreach ($fixturePath in $fixturePaths) {
+            $result = Invoke-RepoJsonScript -ScriptPath 'tools/validate-json.ps1' -Arguments @(
+                '-InputPath', $fixturePath,
+                '-SchemaPath', 'specs/003-editor-evidence-loop/contracts/automation-run-result.schema.json'
+            )
+
+            $result.ExitCode | Should -Be 0
+            $result.ParsedOutput.valid | Should -BeTrue
+        }
+    }
+}
+
+Describe 'inspection-run config automation defaults' {
+    It 'defines automation paths and target-scene defaults for the example project' {
+        $config = Get-Content -LiteralPath (Get-RepoPath -Path 'examples/pong-testbed/harness/inspection-run-config.json') -Raw | ConvertFrom-Json -Depth 20
+
+        $config.targetScene | Should -Be 'res://scenes/main.tscn'
+        $config.automation.requestPath | Should -Be 'res://harness/automation/requests/run-request.json'
+        $config.automation.resultsDirectory | Should -Be 'res://harness/automation/results'
+        $config.defaultRequestOverrides.stopPolicy.stopAfterValidation | Should -BeTrue
+    }
+
+    It 'defines automation paths in the template harness config' {
+        $config = Get-Content -LiteralPath (Get-RepoPath -Path 'addons/agent_runtime_harness/templates/project_root/harness/inspection-run-config.json') -Raw | ConvertFrom-Json -Depth 20
+
+        $config.automation.requestPath | Should -Be 'res://harness/automation/requests/run-request.json'
+        $config.automation.capabilityResultPath | Should -Be 'res://harness/automation/results/capability.json'
+        $config.defaultRequestOverrides.capturePolicy.startup | Should -BeTrue
+    }
+}

--- a/tools/tests/run-tool-tests.ps1
+++ b/tools/tests/run-tool-tests.ps1
@@ -5,7 +5,15 @@ Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
 $repoRoot = (Resolve-Path (Join-Path (Join-Path $PSScriptRoot '..') '..')).Path
-$testPath = Join-Path (Join-Path $repoRoot 'tools') 'tests/*.Tests.ps1'
+$testsRoot = Join-Path (Join-Path $repoRoot 'tools') 'tests'
+$preferredTests = @(
+    (Join-Path $testsRoot 'ScenegraphAutomationLoop.Tests.ps1')
+)
+$discoveredTests = Get-ChildItem -LiteralPath $testsRoot -Filter '*.Tests.ps1' -File |
+    Where-Object { $_.FullName -notin $preferredTests } |
+    Sort-Object Name |
+    ForEach-Object { $_.FullName }
+$testPath = @($preferredTests + $discoveredTests)
 $pesterModule = Get-Module -ListAvailable Pester | Sort-Object Version -Descending | Select-Object -First 1
 
 if ($null -eq $pesterModule) {


### PR DESCRIPTION
## Summary
Implement the autonomous editor evidence loop on top of the existing scenegraph harness.

This adds:
- a plugin-owned file broker and run coordinator for editor-driven automation requests
- automation capability, lifecycle, request, and result contracts plus example fixtures
- workspace helper scripts for reading capability artifacts and submitting run requests
- example and template wiring for automation request and result paths
- task-level docs and coverage updates for the 003-editor-evidence-loop spec

## Validation
- `pwsh ./tools/tests/run-tool-tests.ps1`

## Notes
- Live Godot editor execution, repeated reliability runs, and timing capture remain follow-up tasks in the spec because they require an active editor session.
