### PR TITLE
Implement behavior watch sampling

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/004-report-build-errors"
+  "feature_directory": "specs/005-behavior-watch-sampling"
 }

--- a/addons/agent_runtime_harness/editor/scenegraph_automation_artifact_store.gd
+++ b/addons/agent_runtime_harness/editor/scenegraph_automation_artifact_store.gd
@@ -105,6 +105,38 @@ func build_validation_result(manifest: Dictionary, missing_artifacts: Array, bun
 	}
 
 
+func build_behavior_watch_failure_status_extras(validation_result: Dictionary) -> Dictionary:
+	return {
+		"failureKind": InspectionConstants.AUTOMATION_FAILURE_KIND_VALIDATION,
+		"evidenceRefs": build_behavior_watch_validation_refs(validation_result),
+	}
+
+
+func build_behavior_watch_validation_refs(validation_result: Dictionary) -> Array:
+	var refs: Array = []
+	for error_value in validation_result.get("errors", []):
+		if typeof(error_value) != TYPE_DICTIONARY:
+			continue
+		refs.append(
+			"behavior-watch:%s:%s" % [
+				String(error_value.get("code", "invalid_request")),
+				String(error_value.get("field", "behaviorWatchRequest")),
+			]
+		)
+	return refs
+
+
+func build_behavior_watch_validation_notes(validation_result: Dictionary) -> Array:
+	var notes: Array = [
+		"Behavior watch request was rejected before the playtest started.",
+	]
+	for error_value in validation_result.get("errors", []):
+		if typeof(error_value) != TYPE_DICTIONARY:
+			continue
+		notes.append(String(error_value.get("message", "Behavior watch request validation failed.")))
+	return notes
+
+
 func build_build_diagnostic(resource_path, message: String, severity: String, line = null, column = null, source_kind: String = InspectionConstants.BUILD_DIAGNOSTIC_SOURCE_KIND_UNKNOWN, code = null, raw_excerpt = null) -> Dictionary:
 	return {
 		"resourcePath": _normalize_optional_string(resource_path),

--- a/addons/agent_runtime_harness/editor/scenegraph_automation_broker.gd
+++ b/addons/agent_runtime_harness/editor/scenegraph_automation_broker.gd
@@ -37,6 +37,7 @@ func configure(plugin: EditorPlugin, bridge: Object, config_path: String = "res:
 		_bridge.session_state_changed.connect(_run_coordinator.handle_session_state_changed)
 		_bridge.capture_updated.connect(_run_coordinator.handle_capture_updated)
 		_bridge.manifest_persisted.connect(_run_coordinator.handle_manifest_persisted)
+		_bridge.automation_session_configured.connect(_run_coordinator.handle_runtime_session_configured)
 		_bridge.transport_error.connect(_run_coordinator.handle_transport_error)
 
 	if _poll_timer == null:

--- a/addons/agent_runtime_harness/editor/scenegraph_run_coordinator.gd
+++ b/addons/agent_runtime_harness/editor/scenegraph_run_coordinator.gd
@@ -4,6 +4,7 @@ class_name ScenegraphRunCoordinator
 
 const InspectionConstants = preload("res://addons/agent_runtime_harness/shared/inspection_constants.gd")
 const ScenegraphAutomationArtifactStore = preload("res://addons/agent_runtime_harness/editor/scenegraph_automation_artifact_store.gd")
+const BehaviorWatchRequestValidator = preload("res://addons/agent_runtime_harness/shared/behavior_watch_request_validator.gd")
 
 signal lifecycle_status_written(payload)
 signal run_completed(result)
@@ -26,6 +27,7 @@ var _awaiting_stop := false
 var _stop_requested := false
 var _launch_started_at_usec := 0
 var _active_config_path := ""
+var _watch_request_validator := BehaviorWatchRequestValidator.new()
 
 
 func configure(plugin: EditorPlugin, bridge: Object, artifact_store: ScenegraphAutomationArtifactStore) -> void:
@@ -57,6 +59,10 @@ func start_run(config: Dictionary, request: Dictionary, capability: Dictionary, 
 	_pending_failure_message = ""
 	_stop_requested = false
 	_awaiting_stop = false
+
+	var watch_validation := _active_request.get("behaviorWatchValidation", {})
+	if not watch_validation.is_empty() and not bool(watch_validation.get("accepted", false)):
+		return _finish_invalid_request(watch_validation)
 
 	var blocked_reasons := _collect_blocked_reasons(capability)
 	if not blocked_reasons.is_empty():
@@ -167,6 +173,13 @@ func handle_manifest_persisted(manifest: Dictionary) -> void:
 	_finalize_run("completed", null, InspectionConstants.AUTOMATION_TERMINATION_RUNNING)
 
 
+func handle_runtime_session_configured(session_context: Dictionary) -> void:
+	if not _active:
+		return
+	if session_context.has("appliedWatch") and typeof(session_context.get("appliedWatch")) == TYPE_DICTIONARY:
+		_active_request["appliedWatch"] = session_context.get("appliedWatch", {}).duplicate(true)
+
+
 func handle_transport_error(message: String) -> void:
 	if not _active:
 		return
@@ -265,6 +278,38 @@ func _finish_blocked_run(blocked_reasons: Array) -> Dictionary:
 	return result
 
 
+func _finish_invalid_request(validation_result: Dictionary) -> Dictionary:
+	var request_id := String(_active_request.get("requestId", "request-invalid"))
+	var run_id := String(_active_request.get("runId", "run-invalid"))
+	var notes := _artifact_store.build_behavior_watch_validation_notes(validation_result)
+	_emit_status(
+		InspectionConstants.AUTOMATION_STATUS_FAILED,
+		"Behavior watch request was rejected before playtest launch.",
+		_artifact_store.build_behavior_watch_failure_status_extras(validation_result)
+	)
+	var result := {
+		"requestId": request_id,
+		"runId": run_id,
+		"finalStatus": "failed",
+		"failureKind": InspectionConstants.AUTOMATION_FAILURE_KIND_VALIDATION,
+		"manifestPath": null,
+		"outputDirectory": String(_active_request.get("outputDirectory", "")),
+		"validationResult": _build_validation_result(false, 0, [], false, notes),
+		"terminationStatus": InspectionConstants.AUTOMATION_TERMINATION_NOT_STARTED,
+		"blockedReasons": [],
+		"controlPath": InspectionConstants.AUTOMATION_CONTROL_PATH_FILE_BROKER,
+		"completedAt": InspectionConstants.utc_timestamp_now(),
+	}
+	_artifact_store.write_run_result(_active_config, result)
+	emit_signal("run_completed", result)
+	_reset_state()
+	return {
+		"ok": false,
+		"requestId": request_id,
+		"runId": run_id,
+	}
+
+
 func _fail_run(failure_kind: String, message: String) -> void:
 	_emit_status(InspectionConstants.AUTOMATION_STATUS_FAILED, message, {
 		"failureKind": failure_kind,
@@ -342,7 +387,7 @@ func _resolve_active_config_path() -> String:
 
 
 func _build_session_context() -> Dictionary:
-	return {
+	var context := {
 		"config_path": _resolve_active_config_path(),
 		"session_id": String(_active_request.get("requestId", "")),
 		"request_id": String(_active_request.get("requestId", "")),
@@ -354,6 +399,9 @@ func _build_session_context() -> Dictionary:
 		"capture_policy": _active_request.get("capturePolicy", {}).duplicate(true),
 		"stop_policy": _active_request.get("stopPolicy", {}).duplicate(true),
 	}
+	if _active_request.has("appliedWatch"):
+		context["applied_watch"] = _active_request.get("appliedWatch", {}).duplicate(true)
+	return context
 
 
 func _collect_blocked_reasons(capability: Dictionary) -> Array:
@@ -416,6 +464,36 @@ func _resolve_request(config: Dictionary, request: Dictionary) -> Dictionary:
 	_merge_nested_override(resolved, "capturePolicy", overrides.get("capturePolicy", {}))
 	_merge_nested_override(resolved, "stopPolicy", overrides.get("stopPolicy", {}))
 
+	var behavior_watch_request := _resolve_behavior_watch_request(default_overrides, request, overrides)
+	if not behavior_watch_request.is_empty():
+		var watch_validation := _watch_request_validator.normalize_request(behavior_watch_request, String(resolved.get("runId", "")))
+		resolved["behaviorWatchValidation"] = watch_validation
+		if bool(watch_validation.get("accepted", false)):
+			resolved["behaviorWatchRequest"] = watch_validation.get("request", {}).duplicate(true)
+			resolved["appliedWatch"] = watch_validation.get("appliedWatch", {}).duplicate(true)
+
+	return resolved
+
+
+func _resolve_behavior_watch_request(default_overrides: Dictionary, request: Dictionary, overrides: Dictionary) -> Dictionary:
+	var resolved := {}
+	for source_value in [
+		default_overrides.get("behaviorWatchRequest", null),
+		request.get("behaviorWatchRequest", null),
+		overrides.get("behaviorWatchRequest", null),
+	]:
+		if typeof(source_value) != TYPE_DICTIONARY:
+			continue
+		var source: Dictionary = source_value
+		for key_value in source.keys():
+			var key := String(key_value)
+			if key == "cadence" and typeof(source.get(key)) == TYPE_DICTIONARY:
+				var cadence: Dictionary = resolved.get("cadence", {}).duplicate(true)
+				for cadence_key in source.get(key, {}).keys():
+					cadence[cadence_key] = source.get(key, {}).get(cadence_key)
+				resolved["cadence"] = cadence
+				continue
+			resolved[key] = source.get(key)
 	return resolved
 
 
@@ -491,6 +569,31 @@ func _validate_manifest(manifest: Dictionary) -> Dictionary:
 	if missing_artifacts.is_empty():
 		notes.append("Manifest and referenced scenegraph artifacts exist for the active run.")
 
+	if not _active_request.get("appliedWatch", {}).is_empty():
+		var trace_path := _resolve_trace_repo_path()
+		var trace_artifact_ref := _find_artifact_ref(manifest.get("artifactRefs", []), InspectionConstants.ARTIFACT_KIND_TRACE)
+		var manifest_applied_watch: Dictionary = manifest.get("appliedWatch", {})
+		var applied_watch_valid := true
+		if trace_artifact_ref.is_empty():
+			applied_watch_valid = false
+			notes.append("Manifest did not include a trace artifact reference for the active behavior watch.")
+		elif String(trace_artifact_ref.get("path", "")) != trace_path:
+			applied_watch_valid = false
+			notes.append("Manifest trace artifact path did not match the active run's trace.jsonl path.")
+		if manifest_applied_watch.is_empty():
+			applied_watch_valid = false
+			notes.append("Manifest did not include the applied behavior-watch summary for the active run.")
+		elif String(manifest_applied_watch.get("runId", "")) != String(_active_request.get("runId", "")):
+			applied_watch_valid = false
+			notes.append("Manifest appliedWatch.runId did not match the active automation request.")
+		for manifest_note_value in manifest.get("validation", {}).get("notes", []):
+			var manifest_note := String(manifest_note_value)
+			if manifest_note.is_empty() or manifest_note in notes:
+				continue
+			notes.append(manifest_note)
+		var bundle_valid := run_id_matches and scenario_matches and missing_artifacts.is_empty() and bool(manifest.get("validation", {}).get("bundleValid", false)) and applied_watch_valid
+		return _build_validation_result(true, artifact_refs.size(), missing_artifacts, bundle_valid, notes)
+
 	var bundle_valid := run_id_matches and scenario_matches and missing_artifacts.is_empty() and bool(manifest.get("validation", {}).get("bundleValid", false))
 	return _build_validation_result(true, artifact_refs.size(), missing_artifacts, bundle_valid, notes)
 
@@ -533,6 +636,13 @@ func _resolve_manifest_repo_path() -> String:
 	return artifact_root.path_join("evidence-manifest.json")
 
 
+func _resolve_trace_repo_path() -> String:
+	var artifact_root := String(_active_request.get("artifactRoot", ""))
+	if artifact_root.is_empty():
+		artifact_root = String(_active_request.get("outputDirectory", InspectionConstants.DEFAULT_OUTPUT_DIRECTORY)).trim_prefix("res://")
+	return artifact_root.path_join(InspectionConstants.DEFAULT_BEHAVIOR_WATCH_TRACE_FILE)
+
+
 func _resolve_expected_manifest_resource_path() -> String:
 	var output_directory := String(_active_request.get("outputDirectory", InspectionConstants.DEFAULT_OUTPUT_DIRECTORY))
 	if not output_directory.is_empty():
@@ -553,6 +663,14 @@ func _dedupe_strings(values: Array) -> Array:
 			continue
 		deduped.append(text)
 	return deduped
+
+
+func _find_artifact_ref(artifact_refs: Array, kind: String) -> Dictionary:
+	for artifact_ref_value in artifact_refs:
+		var artifact_ref: Dictionary = artifact_ref_value
+		if String(artifact_ref.get("kind", "")) == kind:
+			return artifact_ref
+	return {}
 
 
 func _get_editor_interface():

--- a/addons/agent_runtime_harness/runtime/behavior_trace_writer.gd
+++ b/addons/agent_runtime_harness/runtime/behavior_trace_writer.gd
@@ -1,0 +1,49 @@
+extends RefCounted
+class_name BehaviorTraceWriter
+
+const InspectionConstants = preload("res://addons/agent_runtime_harness/shared/inspection_constants.gd")
+
+
+func persist_trace(rows: Array, session_context: Dictionary) -> Dictionary:
+	var output_directory := String(session_context.get("output_directory", InspectionConstants.DEFAULT_OUTPUT_DIRECTORY))
+	var artifact_root := String(session_context.get("artifact_root", InspectionConstants.DEFAULT_MANIFEST_ARTIFACT_ROOT))
+	if artifact_root.is_empty():
+		artifact_root = output_directory.trim_prefix("res://")
+
+	_ensure_directory(output_directory)
+
+	var trace_path := output_directory.path_join(InspectionConstants.DEFAULT_BEHAVIOR_WATCH_TRACE_FILE)
+	var temp_path := "%s.%s.tmp" % [trace_path, str(Time.get_ticks_usec())]
+	var handle := FileAccess.open(temp_path, FileAccess.WRITE)
+	if handle == null:
+		return {
+			"error": "Could not open %s for writing (%s)." % [trace_path, error_string(FileAccess.get_open_error())],
+		}
+
+	for row_value in rows:
+		handle.store_string("%s\n" % JSON.stringify(row_value))
+	handle.close()
+
+	var absolute_temp := ProjectSettings.globalize_path(temp_path)
+	var absolute_target := ProjectSettings.globalize_path(trace_path)
+	if FileAccess.file_exists(trace_path):
+		DirAccess.remove_absolute(absolute_target)
+
+	var rename_error := DirAccess.rename_absolute(absolute_temp, absolute_target)
+	if rename_error != OK:
+		DirAccess.remove_absolute(absolute_temp)
+		return {
+			"error": "Could not move %s into place (%s)." % [trace_path, error_string(rename_error)],
+		}
+
+	return {
+		"resourcePath": trace_path,
+		"artifactPath": artifact_root.path_join(InspectionConstants.DEFAULT_BEHAVIOR_WATCH_TRACE_FILE),
+		"sampleCount": rows.size(),
+	}
+
+
+func _ensure_directory(path: String) -> void:
+	if path.is_empty():
+		return
+	DirAccess.make_dir_recursive_absolute(ProjectSettings.globalize_path(path))

--- a/addons/agent_runtime_harness/runtime/behavior_watch_sampler.gd
+++ b/addons/agent_runtime_harness/runtime/behavior_watch_sampler.gd
@@ -3,19 +3,33 @@ class_name BehaviorWatchSampler
 
 var _applied_watch := {}
 var _rows: Array = []
-var _missing_targets: Array = []
-var _missing_properties := {}
 var _sampled_frames := {}
 var _target_state := {}
+var _target_observations := {}
 
 
 func configure(applied_watch: Dictionary) -> void:
 	_applied_watch = applied_watch.duplicate(true)
 	_rows.clear()
-	_missing_targets.clear()
-	_missing_properties.clear()
 	_sampled_frames.clear()
 	_target_state.clear()
+	_target_observations.clear()
+
+	for target_value in _applied_watch.get("targets", []):
+		if typeof(target_value) != TYPE_DICTIONARY:
+			continue
+		var target: Dictionary = target_value
+		var node_path := String(target.get("nodePath", ""))
+		if node_path.is_empty():
+			continue
+		var properties: Array = []
+		for property_name_value in target.get("properties", []):
+			properties.append(String(property_name_value))
+		_target_observations[node_path] = {
+			"sampleCount": 0,
+			"properties": properties,
+			"propertyHits": _build_property_hits(properties),
+		}
 
 
 func is_enabled() -> bool:
@@ -37,9 +51,8 @@ func capture_frame(context_node: Node, frame: int, timestamp_ms: int) -> void:
 		var node_path := String(target.get("nodePath", ""))
 		var target_node := context_node.get_node_or_null(NodePath(node_path))
 		if target_node == null:
-			if not node_path in _missing_targets:
-				_missing_targets.append(node_path)
 			continue
+		_record_target_sample(node_path)
 		_rows.append(_build_row_for_target(target_node, target, frame, timestamp_ms))
 
 
@@ -52,7 +65,7 @@ func build_outcomes() -> Dictionary:
 		"sampleCount": _rows.size(),
 		"sampledFrameCount": _sampled_frames.size(),
 		"noSamples": _rows.is_empty(),
-		"missingTargets": _missing_targets.duplicate(true),
+		"missingTargets": _serialize_missing_targets(),
 		"missingProperties": _serialize_missing_properties(),
 	}
 
@@ -82,39 +95,45 @@ func _build_row_for_target(node: Node, target: Dictionary, frame: int, timestamp
 		match property_name:
 			"position":
 				var position_value = _extract_position(node)
-				row[property_name] = position_value
-				if position_value == null:
-					_record_missing_property(node_path, property_name)
+				_assign_sampled_property(row, node_path, property_name, position_value, position_value != null)
 			"velocity":
-				row[property_name] = velocity_value
-				if velocity_value == null:
-					_record_missing_property(node_path, property_name)
+				_assign_sampled_property(row, node_path, property_name, velocity_value, velocity_value != null)
 			"intendedVelocity":
-				row[property_name] = intended_velocity_value
-				if intended_velocity_value == null:
-					_record_missing_property(node_path, property_name)
+				_assign_sampled_property(row, node_path, property_name, intended_velocity_value, intended_velocity_value != null)
 			"collisionState":
-				row[property_name] = collision.get("collisionState", null)
-				if not bool(collision.get("available", false)):
-					_record_missing_property(node_path, property_name)
+				var collision_available := bool(collision.get("available", false))
+				_assign_sampled_property(
+					row,
+					node_path,
+					property_name,
+					collision.get("collisionState", null),
+					collision_available
+				)
 			"lastCollider":
-				row[property_name] = collision.get("lastCollider", null)
-				if not bool(collision.get("available", false)):
-					_record_missing_property(node_path, property_name)
+				var collider_available := bool(collision.get("available", false))
+				_assign_sampled_property(
+					row,
+					node_path,
+					property_name,
+					collision.get("lastCollider", null),
+					collider_available
+				)
 			"movementVector":
-				row[property_name] = movement_vector_value
-				if movement_vector_value == null:
-					_record_missing_property(node_path, property_name)
+				_assign_sampled_property(row, node_path, property_name, movement_vector_value, movement_vector_value != null)
 			"speed":
 				if velocity_value == null:
-					row[property_name] = null
-					_record_missing_property(node_path, property_name)
+					_assign_sampled_property(row, node_path, property_name, null, false)
 				else:
-					row[property_name] = _vector_length(velocity_value)
+					_assign_sampled_property(row, node_path, property_name, _vector_length(velocity_value), true)
 			"overlapFrames":
-				row[property_name] = collision.get("overlapFrames", null)
-				if not bool(collision.get("available", false)):
-					_record_missing_property(node_path, property_name)
+				var overlap_available := bool(collision.get("available", false))
+				_assign_sampled_property(
+					row,
+					node_path,
+					property_name,
+					collision.get("overlapFrames", null),
+					overlap_available
+				)
 
 	return row
 
@@ -173,8 +192,6 @@ func _extract_collider_identity(collision) -> Variant:
 func _extract_position(node: Node) -> Variant:
 	if node is Node2D:
 		return [node.position.x, node.position.y]
-	if node is Node3D:
-		return [node.position.x, node.position.y, node.position.z]
 	return null
 
 
@@ -186,8 +203,6 @@ func _extract_vector2_property(node: Object, property_names: Array) -> Variant:
 		var property_value = node.get(property_name)
 		if typeof(property_value) == TYPE_VECTOR2:
 			return [property_value.x, property_value.y]
-		if typeof(property_value) == TYPE_VECTOR3:
-			return [property_value.x, property_value.y, property_value.z]
 		return null
 	return null
 
@@ -208,27 +223,74 @@ func _vector_length(vector_value: Variant) -> Variant:
 	return sqrt(pow(float(values[0]), 2.0) + pow(float(values[1]), 2.0))
 
 
-func _record_missing_property(node_path: String, property_name: String) -> void:
-	var properties: Array = _missing_properties.get(node_path, [])
-	if property_name in properties:
-		return
-	properties.append(property_name)
-	_missing_properties[node_path] = properties
+func _assign_sampled_property(
+	row: Dictionary,
+	node_path: String,
+	property_name: String,
+	value: Variant,
+	sampled: bool
+) -> void:
+	row[property_name] = value
+	if sampled:
+		_record_property_hit(node_path, property_name)
 
 
 func _serialize_missing_properties() -> Array:
 	var serialized: Array = []
-	var node_paths: Array = _missing_properties.keys()
+	var node_paths: Array = _target_observations.keys()
 	node_paths.sort()
 	for node_path_value in node_paths:
 		var node_path := String(node_path_value)
-		var properties: Array = _missing_properties.get(node_path, []).duplicate(true)
+		var observation: Dictionary = _target_observations.get(node_path, {})
+		var property_hits: Dictionary = observation.get("propertyHits", {})
+		var properties: Array = []
+		for property_name_value in observation.get("properties", []):
+			var property_name := String(property_name_value)
+			if bool(property_hits.get(property_name, false)):
+				continue
+			properties.append(property_name)
+		if properties.is_empty():
+			continue
 		properties.sort()
 		serialized.append({
 			"nodePath": node_path,
 			"properties": properties,
 		})
 	return serialized
+
+
+func _serialize_missing_targets() -> Array:
+	var missing_targets: Array = []
+	var node_paths: Array = _target_observations.keys()
+	node_paths.sort()
+	for node_path_value in node_paths:
+		var node_path := String(node_path_value)
+		var observation: Dictionary = _target_observations.get(node_path, {})
+		if int(observation.get("sampleCount", 0)) > 0:
+			continue
+		missing_targets.append(node_path)
+	return missing_targets
+
+
+func _build_property_hits(properties: Array) -> Dictionary:
+	var property_hits := {}
+	for property_name_value in properties:
+		property_hits[String(property_name_value)] = false
+	return property_hits
+
+
+func _record_target_sample(node_path: String) -> void:
+	var observation: Dictionary = _target_observations.get(node_path, {})
+	observation["sampleCount"] = int(observation.get("sampleCount", 0)) + 1
+	_target_observations[node_path] = observation
+
+
+func _record_property_hit(node_path: String, property_name: String) -> void:
+	var observation: Dictionary = _target_observations.get(node_path, {})
+	var property_hits: Dictionary = observation.get("propertyHits", {})
+	property_hits[property_name] = true
+	observation["propertyHits"] = property_hits
+	_target_observations[node_path] = observation
 
 
 func _is_before_window(frame: int) -> bool:

--- a/addons/agent_runtime_harness/runtime/behavior_watch_sampler.gd
+++ b/addons/agent_runtime_harness/runtime/behavior_watch_sampler.gd
@@ -1,0 +1,255 @@
+extends RefCounted
+class_name BehaviorWatchSampler
+
+var _applied_watch := {}
+var _rows: Array = []
+var _missing_targets: Array = []
+var _missing_properties := {}
+var _sampled_frames := {}
+var _target_state := {}
+
+
+func configure(applied_watch: Dictionary) -> void:
+	_applied_watch = applied_watch.duplicate(true)
+	_rows.clear()
+	_missing_targets.clear()
+	_missing_properties.clear()
+	_sampled_frames.clear()
+	_target_state.clear()
+
+
+func is_enabled() -> bool:
+	return not _applied_watch.is_empty() and not _applied_watch.get("targets", []).is_empty()
+
+
+func capture_frame(context_node: Node, frame: int, timestamp_ms: int) -> void:
+	if not is_enabled():
+		return
+	if _is_before_window(frame) or _is_after_window(frame):
+		return
+	if not _should_sample_frame(frame):
+		return
+
+	_sampled_frames[str(frame)] = true
+	var targets: Array = _applied_watch.get("targets", [])
+	for target_value in targets:
+		var target: Dictionary = target_value
+		var node_path := String(target.get("nodePath", ""))
+		var target_node := context_node.get_node_or_null(NodePath(node_path))
+		if target_node == null:
+			if not node_path in _missing_targets:
+				_missing_targets.append(node_path)
+			continue
+		_rows.append(_build_row_for_target(target_node, target, frame, timestamp_ms))
+
+
+func get_rows() -> Array:
+	return _rows.duplicate(true)
+
+
+func build_outcomes() -> Dictionary:
+	return {
+		"sampleCount": _rows.size(),
+		"sampledFrameCount": _sampled_frames.size(),
+		"noSamples": _rows.is_empty(),
+		"missingTargets": _missing_targets.duplicate(true),
+		"missingProperties": _serialize_missing_properties(),
+	}
+
+
+func _build_row_for_target(node: Node, target: Dictionary, frame: int, timestamp_ms: int) -> Dictionary:
+	var node_path := String(target.get("nodePath", ""))
+	var row := {
+		"frame": frame,
+		"timestampMs": timestamp_ms,
+		"nodePath": node_path,
+	}
+	var target_state: Dictionary = _target_state.get(node_path, {
+		"lastCollider": "",
+		"overlapFrames": 0,
+	})
+	var collision := _build_collision_observation(node, target_state)
+	_target_state[node_path] = collision.get("state", target_state)
+
+	var velocity_value = _extract_vector2_property(node, ["velocity"])
+	var intended_velocity_value = _extract_vector2_property(node, ["intended_velocity", "intendedVelocity"])
+	var movement_vector_value = _extract_vector2_property(node, ["movement_vector", "movementVector"])
+	if movement_vector_value == null:
+		movement_vector_value = velocity_value
+
+	for property_name_value in target.get("properties", []):
+		var property_name := String(property_name_value)
+		match property_name:
+			"position":
+				var position_value = _extract_position(node)
+				row[property_name] = position_value
+				if position_value == null:
+					_record_missing_property(node_path, property_name)
+			"velocity":
+				row[property_name] = velocity_value
+				if velocity_value == null:
+					_record_missing_property(node_path, property_name)
+			"intendedVelocity":
+				row[property_name] = intended_velocity_value
+				if intended_velocity_value == null:
+					_record_missing_property(node_path, property_name)
+			"collisionState":
+				row[property_name] = collision.get("collisionState", null)
+				if not bool(collision.get("available", false)):
+					_record_missing_property(node_path, property_name)
+			"lastCollider":
+				row[property_name] = collision.get("lastCollider", null)
+				if not bool(collision.get("available", false)):
+					_record_missing_property(node_path, property_name)
+			"movementVector":
+				row[property_name] = movement_vector_value
+				if movement_vector_value == null:
+					_record_missing_property(node_path, property_name)
+			"speed":
+				if velocity_value == null:
+					row[property_name] = null
+					_record_missing_property(node_path, property_name)
+				else:
+					row[property_name] = _vector_length(velocity_value)
+			"overlapFrames":
+				row[property_name] = collision.get("overlapFrames", null)
+				if not bool(collision.get("available", false)):
+					_record_missing_property(node_path, property_name)
+
+	return row
+
+
+func _build_collision_observation(node: Node, target_state: Dictionary) -> Dictionary:
+	if not node.has_method("get_slide_collision_count"):
+		return {
+			"available": false,
+			"collisionState": null,
+			"lastCollider": null,
+			"overlapFrames": null,
+			"state": target_state.duplicate(true),
+		}
+
+	var collision_count := int(node.call("get_slide_collision_count"))
+	var collision_state := "none"
+	var last_collider: Variant = null
+	var overlap_frames := 0
+	var next_state: Dictionary = target_state.duplicate(true)
+
+	if collision_count > 0:
+		collision_state = "contact"
+		if node.has_method("get_last_slide_collision"):
+			var collision = node.call("get_last_slide_collision")
+			last_collider = _extract_collider_identity(collision)
+		if last_collider != null and String(last_collider) == String(target_state.get("lastCollider", "")):
+			overlap_frames = int(target_state.get("overlapFrames", 0)) + 1
+		else:
+			overlap_frames = 1
+
+	next_state["lastCollider"] = String(last_collider) if last_collider != null else ""
+	next_state["overlapFrames"] = overlap_frames
+	return {
+		"available": true,
+		"collisionState": collision_state,
+		"lastCollider": last_collider,
+		"overlapFrames": overlap_frames,
+		"state": next_state,
+	}
+
+
+func _extract_collider_identity(collision) -> Variant:
+	if collision == null:
+		return null
+	if not collision.has_method("get_collider"):
+		return null
+
+	var collider = collision.call("get_collider")
+	if collider is Node:
+		return String(collider.get_path())
+	if collider == null:
+		return null
+	return String(collider)
+
+
+func _extract_position(node: Node) -> Variant:
+	if node is Node2D:
+		return [node.position.x, node.position.y]
+	if node is Node3D:
+		return [node.position.x, node.position.y, node.position.z]
+	return null
+
+
+func _extract_vector2_property(node: Object, property_names: Array) -> Variant:
+	for property_name_value in property_names:
+		var property_name := String(property_name_value)
+		if not _has_property(node, property_name):
+			continue
+		var property_value = node.get(property_name)
+		if typeof(property_value) == TYPE_VECTOR2:
+			return [property_value.x, property_value.y]
+		if typeof(property_value) == TYPE_VECTOR3:
+			return [property_value.x, property_value.y, property_value.z]
+		return null
+	return null
+
+
+func _has_property(target: Object, property_name: String) -> bool:
+	for property_info in target.get_property_list():
+		if String(property_info.get("name", "")) == property_name:
+			return true
+	return false
+
+
+func _vector_length(vector_value: Variant) -> Variant:
+	if typeof(vector_value) != TYPE_ARRAY:
+		return null
+	var values: Array = vector_value
+	if values.size() < 2:
+		return null
+	return sqrt(pow(float(values[0]), 2.0) + pow(float(values[1]), 2.0))
+
+
+func _record_missing_property(node_path: String, property_name: String) -> void:
+	var properties: Array = _missing_properties.get(node_path, [])
+	if property_name in properties:
+		return
+	properties.append(property_name)
+	_missing_properties[node_path] = properties
+
+
+func _serialize_missing_properties() -> Array:
+	var serialized: Array = []
+	var node_paths: Array = _missing_properties.keys()
+	node_paths.sort()
+	for node_path_value in node_paths:
+		var node_path := String(node_path_value)
+		var properties: Array = _missing_properties.get(node_path, []).duplicate(true)
+		properties.sort()
+		serialized.append({
+			"nodePath": node_path,
+			"properties": properties,
+		})
+	return serialized
+
+
+func _is_before_window(frame: int) -> bool:
+	return frame < int(_applied_watch.get("startFrameOffset", 0))
+
+
+func _is_after_window(frame: int) -> bool:
+	return frame >= _window_end_frame()
+
+
+func _window_end_frame() -> int:
+	return int(_applied_watch.get("startFrameOffset", 0)) + int(_applied_watch.get("frameCount", 0))
+
+
+func _should_sample_frame(frame: int) -> bool:
+	var start_frame := int(_applied_watch.get("startFrameOffset", 0))
+	var cadence: Dictionary = _applied_watch.get("cadence", {})
+	var mode := String(cadence.get("mode", "every_frame"))
+	if mode != "every_n_frames":
+		return true
+	var every_n_frames := int(cadence.get("everyNFrames", 1))
+	if every_n_frames <= 1:
+		return true
+	return ((frame - start_frame) % every_n_frames) == 0

--- a/addons/agent_runtime_harness/runtime/scenegraph_artifact_writer.gd
+++ b/addons/agent_runtime_harness/runtime/scenegraph_artifact_writer.gd
@@ -11,6 +11,16 @@ func persist_bundle(snapshot: Dictionary, diagnostics: Array, session_context: D
 	var output_directory := String(session_context.get("output_directory", InspectionConstants.DEFAULT_OUTPUT_DIRECTORY))
 	var artifact_root := _resolve_artifact_root(session_context, output_directory)
 	var summary := _summary_builder.build_summary(snapshot, diagnostics)
+	var behavior_watch: Dictionary = session_context.get("behavior_watch", {})
+	var applied_watch: Dictionary = behavior_watch.get("appliedWatch", {})
+	var validation_notes: Array = [
+		"Persisted artifact references were written successfully. Validate the manifest schema and paths with tools/evidence/validate-evidence-manifest.ps1 after the editor run.",
+	]
+	if not applied_watch.is_empty():
+		var key_findings: Array = summary.get("keyFindings", []).duplicate(true)
+		var watch_outcomes: Dictionary = applied_watch.get("outcomes", {})
+		key_findings.append("Behavior watch samples: %d" % int(watch_outcomes.get("sampleCount", 0)))
+		summary["keyFindings"] = key_findings
 
 	_ensure_directory(output_directory)
 
@@ -18,6 +28,7 @@ func persist_bundle(snapshot: Dictionary, diagnostics: Array, session_context: D
 	var diagnostics_path := output_directory.path_join("scenegraph-diagnostics.json")
 	var summary_path := output_directory.path_join("scenegraph-summary.json")
 	var manifest_path := output_directory.path_join("evidence-manifest.json")
+	var trace_path := output_directory.path_join(InspectionConstants.DEFAULT_BEHAVIOR_WATCH_TRACE_FILE)
 
 	var snapshot_error := _write_json(snapshot_path, snapshot)
 	if not snapshot_error.is_empty():
@@ -39,6 +50,39 @@ func persist_bundle(snapshot: Dictionary, diagnostics: Array, session_context: D
 		return {"error": summary_error}
 
 	var bundle_valid := _has_persisted_bundle(snapshot_path, diagnostics_path, summary_path)
+	var artifact_refs: Array = [
+		_build_artifact_ref(InspectionConstants.ARTIFACT_KIND_SCENEGRAPH_SNAPSHOT, artifact_root, "scenegraph-snapshot.json", "application/json", "Latest scenegraph snapshot for the session."),
+		_build_artifact_ref(InspectionConstants.ARTIFACT_KIND_SCENEGRAPH_DIAGNOSTICS, artifact_root, "scenegraph-diagnostics.json", "application/json", "Structured missing-node and hierarchy diagnostics for the session."),
+		_build_artifact_ref(InspectionConstants.ARTIFACT_KIND_SCENEGRAPH_SUMMARY, artifact_root, "scenegraph-summary.json", "application/json", "Agent-readable scenegraph summary entry point."),
+	]
+
+	if not applied_watch.is_empty():
+		artifact_refs.append(_build_artifact_ref(
+			InspectionConstants.ARTIFACT_KIND_TRACE,
+			artifact_root,
+			String(applied_watch.get("traceArtifact", InspectionConstants.DEFAULT_BEHAVIOR_WATCH_TRACE_FILE)),
+			"application/jsonl",
+			"Bounded behavior-watch trace for the current automation run."
+		))
+		bundle_valid = bundle_valid and FileAccess.file_exists(trace_path)
+
+		var watch_outcomes: Dictionary = applied_watch.get("outcomes", {})
+		if bool(watch_outcomes.get("noSamples", false)):
+			validation_notes.append("Behavior watch completed without producing any trace rows for the configured window.")
+		var missing_targets: Array = watch_outcomes.get("missingTargets", [])
+		if not missing_targets.is_empty():
+			validation_notes.append("Behavior watch did not resolve requested targets: %s." % _join_strings(missing_targets))
+		var missing_properties: Array = watch_outcomes.get("missingProperties", [])
+		for missing_property_value in missing_properties:
+			var missing_property: Dictionary = missing_property_value
+			validation_notes.append(
+				"Behavior watch could not sample %s from %s." % [
+					_join_strings(missing_property.get("properties", [])),
+					String(missing_property.get("nodePath", "")),
+				]
+			)
+		if not FileAccess.file_exists(trace_path):
+			validation_notes.append("Behavior watch trace artifact was requested but trace.jsonl was not written.")
 
 	var manifest := {
 		"schemaVersion": "1.0.0",
@@ -51,20 +95,16 @@ func persist_bundle(snapshot: Dictionary, diagnostics: Array, session_context: D
 			"outcome": String(summary.get("outcome", "")),
 			"keyFindings": summary.get("keyFindings", []),
 		},
-		"artifactRefs": [
-			_build_artifact_ref(InspectionConstants.ARTIFACT_KIND_SCENEGRAPH_SNAPSHOT, artifact_root, "scenegraph-snapshot.json", "application/json", "Latest scenegraph snapshot for the session."),
-			_build_artifact_ref(InspectionConstants.ARTIFACT_KIND_SCENEGRAPH_DIAGNOSTICS, artifact_root, "scenegraph-diagnostics.json", "application/json", "Structured missing-node and hierarchy diagnostics for the session."),
-			_build_artifact_ref(InspectionConstants.ARTIFACT_KIND_SCENEGRAPH_SUMMARY, artifact_root, "scenegraph-summary.json", "application/json", "Agent-readable scenegraph summary entry point."),
-		],
+		"artifactRefs": artifact_refs,
 		"validation": {
 			"bundleValid": bundle_valid,
-			"notes": [
-				"Persisted artifact references were written successfully. Validate the manifest schema and paths with tools/evidence/validate-evidence-manifest.ps1 after the editor run.",
-			],
+			"notes": validation_notes,
 		},
 		"producer": _build_producer(session_context),
 		"createdAt": InspectionConstants.utc_timestamp_now(),
 	}
+	if not applied_watch.is_empty():
+		manifest["appliedWatch"] = applied_watch.duplicate(true)
 
 	var manifest_error := _write_json(manifest_path, manifest)
 	if not manifest_error.is_empty():
@@ -122,3 +162,10 @@ func _build_producer(session_context: Dictionary) -> Dictionary:
 	if not request_id.is_empty():
 		producer["toolingArtifactId"] = "scenegraph_automation_broker"
 	return producer
+
+
+func _join_strings(values: Array) -> String:
+	var parts: Array = []
+	for value in values:
+		parts.append(String(value))
+	return ", ".join(parts)

--- a/addons/agent_runtime_harness/runtime/scenegraph_runtime.gd
+++ b/addons/agent_runtime_harness/runtime/scenegraph_runtime.gd
@@ -9,19 +9,26 @@ const InspectionConstants = preload("res://addons/agent_runtime_harness/shared/i
 const ScenegraphCaptureService = preload("res://addons/agent_runtime_harness/runtime/scenegraph_capture_service.gd")
 const ScenegraphDiagnosticSerializer = preload("res://addons/agent_runtime_harness/runtime/scenegraph_diagnostic_serializer.gd")
 const ScenegraphArtifactWriter = preload("res://addons/agent_runtime_harness/runtime/scenegraph_artifact_writer.gd")
+const BehaviorWatchSampler = preload("res://addons/agent_runtime_harness/runtime/behavior_watch_sampler.gd")
+const BehaviorTraceWriter = preload("res://addons/agent_runtime_harness/runtime/behavior_trace_writer.gd")
 
 var _capture_service := ScenegraphCaptureService.new()
 var _diagnostic_serializer := ScenegraphDiagnosticSerializer.new()
 var _artifact_writer := ScenegraphArtifactWriter.new()
+var _behavior_watch_sampler := BehaviorWatchSampler.new()
+var _behavior_trace_writer := BehaviorTraceWriter.new()
 
 var _session_context := {}
 var _expectations: Array = []
 var _latest_snapshot := {}
 var _latest_diagnostics: Array = []
 var _identifier_sequence := 0
+var _applied_watch := {}
+var _run_started_at_msec := 0
 
 
 func _ready() -> void:
+	set_physics_process(true)
 	if _session_context.is_empty():
 		configure_session({})
 	_register_debugger_transport()
@@ -34,6 +41,7 @@ func _exit_tree() -> void:
 
 
 func configure_session(session_context: Dictionary) -> void:
+	_run_started_at_msec = Time.get_ticks_msec()
 	_session_context = {
 		"session_id": session_context.get("session_id", _build_identifier("session")),
 		"request_id": session_context.get("request_id", _build_identifier("request")),
@@ -51,6 +59,14 @@ func configure_session(session_context: Dictionary) -> void:
 			"stopAfterValidation": true,
 		}),
 	}
+	_applied_watch = {}
+
+	if session_context.has("applied_watch") and typeof(session_context.get("applied_watch")) == TYPE_DICTIONARY:
+		_applied_watch = session_context.get("applied_watch", {}).duplicate(true)
+	elif session_context.has("behavior_watch") and typeof(session_context.get("behavior_watch")) == TYPE_DICTIONARY:
+		_applied_watch = session_context.get("behavior_watch", {}).get("appliedWatch", {}).duplicate(true)
+
+	_behavior_watch_sampler.configure(_applied_watch)
 
 	if session_context.has("config_path"):
 		_load_session_config(String(session_context.get("config_path")))
@@ -93,7 +109,22 @@ func persist_latest_bundle() -> Dictionary:
 	if _latest_snapshot.is_empty():
 		return {}
 
-	var result := _artifact_writer.persist_bundle(_latest_snapshot, _latest_diagnostics, _session_context)
+	var session_context := _session_context.duplicate(true)
+	if not _applied_watch.is_empty():
+		var trace_result := _behavior_trace_writer.persist_trace(_behavior_watch_sampler.get_rows(), session_context)
+		if trace_result.has("error"):
+			_emit_runtime_error(String(trace_result.get("error", "Behavior trace persistence failed.")))
+			return trace_result
+
+		var applied_watch := _applied_watch.duplicate(true)
+		applied_watch["traceArtifact"] = String(trace_result.get("artifactPath", InspectionConstants.DEFAULT_BEHAVIOR_WATCH_TRACE_FILE)).get_file()
+		applied_watch["outcomes"] = _behavior_watch_sampler.build_outcomes()
+		session_context["behavior_watch"] = {
+			"appliedWatch": applied_watch,
+			"traceArtifactPath": trace_result.get("artifactPath", ""),
+		}
+
+	var result := _artifact_writer.persist_bundle(_latest_snapshot, _latest_diagnostics, session_context)
 	if result.has("error"):
 		_emit_runtime_error(String(result.get("error", "Scenegraph bundle persistence failed.")))
 		return result
@@ -107,6 +138,12 @@ func _capture_startup_if_enabled() -> void:
 	var capture_policy: Dictionary = _session_context.get("capture_policy", {})
 	if capture_policy.get("startup", false):
 		capture_scenegraph(InspectionConstants.TRIGGER_STARTUP, "session_started")
+
+
+func _physics_process(_delta: float) -> void:
+	if _applied_watch.is_empty():
+		return
+	_behavior_watch_sampler.capture_frame(self, Engine.get_process_frames(), _elapsed_run_time_msec())
 
 
 func _resolve_root_node() -> Node:
@@ -192,13 +229,20 @@ func _send_debugger_message(message_name: String, data: Array) -> void:
 
 
 func _build_session_configuration_event() -> Dictionary:
-	return {
+	var event := {
 		"request_id": String(_session_context.get("request_id", "")),
 		"session_id": String(_session_context.get("session_id", "")),
 		"run_id": String(_session_context.get("run_id", "")),
 		"scenario_id": String(_session_context.get("scenario_id", "")),
 		"stop_policy": _session_context.get("stop_policy", {}).duplicate(true),
 	}
+	if not _applied_watch.is_empty():
+		event["appliedWatch"] = _applied_watch.duplicate(true)
+	return event
+
+
+func _elapsed_run_time_msec() -> int:
+	return max(Time.get_ticks_msec() - _run_started_at_msec, 0)
 
 
 func _emit_runtime_error(message: String) -> void:

--- a/addons/agent_runtime_harness/runtime/scenegraph_runtime.gd
+++ b/addons/agent_runtime_harness/runtime/scenegraph_runtime.gd
@@ -28,7 +28,7 @@ var _run_started_at_msec := 0
 
 
 func _ready() -> void:
-	set_physics_process(true)
+	set_physics_process(false)
 	if _session_context.is_empty():
 		configure_session({})
 	_register_debugger_transport()
@@ -67,6 +67,7 @@ func configure_session(session_context: Dictionary) -> void:
 		_applied_watch = session_context.get("behavior_watch", {}).get("appliedWatch", {}).duplicate(true)
 
 	_behavior_watch_sampler.configure(_applied_watch)
+	set_physics_process(_behavior_watch_sampler.is_enabled())
 
 	if session_context.has("config_path"):
 		_load_session_config(String(session_context.get("config_path")))
@@ -141,7 +142,7 @@ func _capture_startup_if_enabled() -> void:
 
 
 func _physics_process(_delta: float) -> void:
-	if _applied_watch.is_empty():
+	if not _behavior_watch_sampler.is_enabled():
 		return
 	_behavior_watch_sampler.capture_frame(self, Engine.get_process_frames(), _elapsed_run_time_msec())
 

--- a/addons/agent_runtime_harness/shared/behavior_watch_request_validator.gd
+++ b/addons/agent_runtime_harness/shared/behavior_watch_request_validator.gd
@@ -1,0 +1,282 @@
+extends RefCounted
+class_name BehaviorWatchRequestValidator
+
+const InspectionConstants = preload("res://addons/agent_runtime_harness/shared/inspection_constants.gd")
+
+const SUPPORTED_TARGET_KEYS := PackedStringArray(["nodePath", "properties"])
+const SUPPORTED_CADENCE_KEYS := PackedStringArray(["mode", "everyNFrames"])
+const SUPPORTED_REQUEST_KEYS := PackedStringArray(["targets", "cadence", "startFrameOffset", "frameCount"])
+const SUPPORTED_PROPERTIES := PackedStringArray([
+	"position",
+	"velocity",
+	"intendedVelocity",
+	"collisionState",
+	"lastCollider",
+	"movementVector",
+	"speed",
+	"overlapFrames",
+])
+const LATER_SLICE_KEYS := PackedStringArray([
+	"triggers",
+	"invariants",
+	"scriptProbes",
+	"probeScripts",
+	"fullSceneCapture",
+	"fullSceneLogging",
+])
+
+
+func normalize_request(request_value: Variant, run_id: String) -> Dictionary:
+	if typeof(request_value) != TYPE_DICTIONARY:
+		return _build_rejection([
+			_build_error("invalid_request", "behaviorWatchRequest", "Behavior watch request must be an object."),
+		])
+
+	var request: Dictionary = request_value.duplicate(true)
+	var errors: Array = []
+	_collect_unknown_keys(errors, request.keys(), SUPPORTED_REQUEST_KEYS, "")
+
+	var normalized_targets := _normalize_targets(request.get("targets", []), errors)
+	var normalized_cadence := _normalize_cadence(request.get("cadence", null), errors)
+	var start_frame_offset := _normalize_non_negative_int(
+		request.get("startFrameOffset", 0),
+		"startFrameOffset",
+		"invalid_start_frame_offset",
+		"Behavior watch startFrameOffset must be a non-negative integer.",
+		errors
+	)
+	var frame_count := _normalize_positive_int(
+		request.get("frameCount", null),
+		"frameCount",
+		"zero_sample_window",
+		"Behavior watch frameCount must be a positive integer.",
+		errors
+	)
+
+	if not errors.is_empty():
+		return _build_rejection(errors)
+
+	var normalized_request := {
+		"targets": normalized_targets,
+		"cadence": normalized_cadence,
+		"startFrameOffset": start_frame_offset,
+		"frameCount": frame_count,
+	}
+	var applied_watch := {
+		"runId": run_id,
+		"targets": normalized_targets.duplicate(true),
+		"cadence": normalized_cadence.duplicate(true),
+		"startFrameOffset": start_frame_offset,
+		"frameCount": frame_count,
+		"traceArtifact": InspectionConstants.DEFAULT_BEHAVIOR_WATCH_TRACE_FILE,
+	}
+	return {
+		"accepted": true,
+		"request": normalized_request,
+		"appliedWatch": applied_watch,
+		"errors": [],
+		"rejectedFields": [],
+	}
+
+
+func _normalize_targets(targets_value: Variant, errors: Array) -> Array:
+	var normalized_targets: Array = []
+	if typeof(targets_value) != TYPE_ARRAY or targets_value.is_empty():
+		errors.append(_build_error("missing_targets", "targets", "Behavior watch request must include at least one target."))
+		return normalized_targets
+
+	for index in range(targets_value.size()):
+		var target_value = targets_value[index]
+		if typeof(target_value) != TYPE_DICTIONARY:
+			errors.append(_build_error("invalid_target", "targets[%d]" % index, "Each behavior watch target must be an object."))
+			continue
+
+		var target: Dictionary = target_value
+		_collect_unknown_keys(errors, target.keys(), SUPPORTED_TARGET_KEYS, "targets[%d]." % index)
+
+		var node_path := String(target.get("nodePath", "")).strip_edges()
+		if node_path.is_empty() or not node_path.begins_with("/root/"):
+			errors.append(_build_error(
+				"unsupported_selector",
+				"targets[%d].nodePath" % index,
+				"Behavior watch targets must use absolute runtime node paths under /root/."
+			))
+
+		var normalized_properties: Array = []
+		var seen_properties := {}
+		var properties_value = target.get("properties", [])
+		if typeof(properties_value) != TYPE_ARRAY or properties_value.is_empty():
+			errors.append(_build_error(
+				"missing_properties",
+				"targets[%d].properties" % index,
+				"Behavior watch targets must list at least one supported property."
+			))
+		else:
+			for property_value in properties_value:
+				var property_name := String(property_value).strip_edges()
+				if property_name.is_empty():
+					errors.append(_build_error(
+						"unsupported_property",
+						"targets[%d].properties" % index,
+						"Behavior watch target properties must be non-empty strings."
+					))
+					continue
+				if not property_name in SUPPORTED_PROPERTIES:
+					errors.append(_build_error(
+						"unsupported_property",
+						"targets[%d].properties" % index,
+						"Behavior watch property '%s' is not supported in slice 1 or slice 2." % property_name
+					))
+					continue
+				if seen_properties.has(property_name):
+					continue
+				seen_properties[property_name] = true
+				normalized_properties.append(property_name)
+
+		if node_path.is_empty() or normalized_properties.is_empty():
+			continue
+
+		normalized_targets.append({
+			"nodePath": node_path,
+			"properties": normalized_properties,
+		})
+
+	if normalized_targets.is_empty() and errors.is_empty():
+		errors.append(_build_error("missing_targets", "targets", "Behavior watch request did not resolve any valid targets."))
+	return normalized_targets
+
+
+func _normalize_cadence(cadence_value: Variant, errors: Array) -> Dictionary:
+	if cadence_value == null:
+		return {
+			"mode": "every_frame",
+			"everyNFrames": null,
+		}
+
+	if typeof(cadence_value) != TYPE_DICTIONARY:
+		errors.append(_build_error("invalid_cadence", "cadence", "Behavior watch cadence must be an object."))
+		return {
+			"mode": "every_frame",
+			"everyNFrames": null,
+		}
+
+	var cadence: Dictionary = cadence_value
+	_collect_unknown_keys(errors, cadence.keys(), SUPPORTED_CADENCE_KEYS, "cadence.")
+
+	var mode := String(cadence.get("mode", "every_frame")).strip_edges()
+	if mode.is_empty():
+		mode = "every_frame"
+
+	if mode == "every_frame":
+		if cadence.has("everyNFrames") and cadence.get("everyNFrames") != null:
+			errors.append(_build_error(
+				"invalid_cadence",
+				"cadence.everyNFrames",
+				"Behavior watch cadence everyNFrames is only supported when mode is every_n_frames."
+			))
+		return {
+			"mode": mode,
+			"everyNFrames": null,
+		}
+
+	if mode != "every_n_frames":
+		errors.append(_build_error(
+			"invalid_cadence",
+			"cadence.mode",
+			"Behavior watch cadence mode must be every_frame or every_n_frames."
+		))
+		return {
+			"mode": "every_frame",
+			"everyNFrames": null,
+		}
+
+	var every_n_frames := _normalize_positive_int(
+		cadence.get("everyNFrames", null),
+		"cadence.everyNFrames",
+		"invalid_cadence",
+		"Behavior watch cadence everyNFrames must be an integer greater than or equal to 2.",
+		errors,
+		2
+	)
+	return {
+		"mode": mode,
+		"everyNFrames": every_n_frames if every_n_frames > 0 else 2,
+	}
+
+
+func _normalize_non_negative_int(
+	value: Variant,
+	field: String,
+	code: String,
+	message: String,
+	errors: Array
+) -> int:
+	if value == null:
+		return 0
+	if typeof(value) not in [TYPE_INT, TYPE_FLOAT]:
+		errors.append(_build_error(code, field, message))
+		return 0
+	var normalized_value := int(value)
+	if normalized_value < 0:
+		errors.append(_build_error(code, field, message))
+		return 0
+	return normalized_value
+
+
+func _normalize_positive_int(
+	value: Variant,
+	field: String,
+	code: String,
+	message: String,
+	errors: Array,
+	minimum := 1
+) -> int:
+	if value == null or typeof(value) not in [TYPE_INT, TYPE_FLOAT]:
+		errors.append(_build_error(code, field, message))
+		return 0
+	var normalized_value := int(value)
+	if normalized_value < minimum:
+		errors.append(_build_error(code, field, message))
+		return 0
+	return normalized_value
+
+
+func _collect_unknown_keys(errors: Array, keys: Array, supported_keys: PackedStringArray, field_prefix: String) -> void:
+	for key_value in keys:
+		var key := String(key_value)
+		if key in supported_keys:
+			continue
+		var code := "unsupported_field"
+		if key in LATER_SLICE_KEYS:
+			code = "later_slice_field"
+		errors.append(_build_error(
+			code,
+			"%s%s" % [field_prefix, key],
+			"Behavior watch field '%s' is not supported in slice 1 or slice 2." % key
+		))
+
+
+func _build_rejection(errors: Array) -> Dictionary:
+	var rejected_fields: Array = []
+	for error_value in errors:
+		if typeof(error_value) != TYPE_DICTIONARY:
+			continue
+		var field_name := String(error_value.get("field", "")).strip_edges()
+		if field_name.is_empty() or field_name in rejected_fields:
+			continue
+		rejected_fields.append(field_name)
+	return {
+		"accepted": false,
+		"request": {},
+		"appliedWatch": {},
+		"errors": errors.duplicate(true),
+		"rejectedFields": rejected_fields,
+	}
+
+
+func _build_error(code: String, field: String, message: String) -> Dictionary:
+	return {
+		"code": code,
+		"field": field,
+		"message": message,
+	}

--- a/addons/agent_runtime_harness/shared/behavior_watch_request_validator.gd
+++ b/addons/agent_runtime_harness/shared/behavior_watch_request_validator.gd
@@ -213,7 +213,7 @@ func _normalize_non_negative_int(
 ) -> int:
 	if value == null:
 		return 0
-	if typeof(value) not in [TYPE_INT, TYPE_FLOAT]:
+	if not _is_integral_numeric(value):
 		errors.append(_build_error(code, field, message))
 		return 0
 	var normalized_value := int(value)
@@ -231,7 +231,7 @@ func _normalize_positive_int(
 	errors: Array,
 	minimum := 1
 ) -> int:
-	if value == null or typeof(value) not in [TYPE_INT, TYPE_FLOAT]:
+	if value == null or not _is_integral_numeric(value):
 		errors.append(_build_error(code, field, message))
 		return 0
 	var normalized_value := int(value)
@@ -239,6 +239,14 @@ func _normalize_positive_int(
 		errors.append(_build_error(code, field, message))
 		return 0
 	return normalized_value
+
+
+func _is_integral_numeric(value: Variant) -> bool:
+	if typeof(value) == TYPE_INT:
+		return true
+	if typeof(value) != TYPE_FLOAT:
+		return false
+	return is_equal_approx(float(value), round(float(value)))
 
 
 func _collect_unknown_keys(errors: Array, keys: Array, supported_keys: PackedStringArray, field_prefix: String) -> void:

--- a/addons/agent_runtime_harness/shared/inspection_constants.gd
+++ b/addons/agent_runtime_harness/shared/inspection_constants.gd
@@ -8,6 +8,7 @@ const RUNTIME_TO_EDITOR_CHANNEL := "agent_runtime_harness/scenegraph/capture"
 const ARTIFACT_KIND_SCENEGRAPH_SNAPSHOT := "scenegraph-snapshot"
 const ARTIFACT_KIND_SCENEGRAPH_DIAGNOSTICS := "scenegraph-diagnostics"
 const ARTIFACT_KIND_SCENEGRAPH_SUMMARY := "scenegraph-summary"
+const ARTIFACT_KIND_TRACE := "trace"
 const ARTIFACT_KIND_AUTOMATION_CAPABILITY := "automation-capability"
 const ARTIFACT_KIND_AUTOMATION_LIFECYCLE_STATUS := "automation-lifecycle-status"
 const ARTIFACT_KIND_AUTOMATION_RUN_RESULT := "automation-run-result"
@@ -85,6 +86,7 @@ const DEFAULT_AUTOMATION_RESULTS_DIRECTORY := "res://harness/automation/results"
 const DEFAULT_AUTOMATION_CAPABILITY_RESULT_PATH := "res://harness/automation/results/capability.json"
 const DEFAULT_AUTOMATION_LIFECYCLE_STATUS_PATH := "res://harness/automation/results/lifecycle-status.json"
 const DEFAULT_AUTOMATION_RUN_RESULT_PATH := "res://harness/automation/results/run-result.json"
+const DEFAULT_BEHAVIOR_WATCH_TRACE_FILE := "trace.jsonl"
 
 
 static func supported_artifact_kinds() -> PackedStringArray:
@@ -92,6 +94,7 @@ static func supported_artifact_kinds() -> PackedStringArray:
 		ARTIFACT_KIND_SCENEGRAPH_SNAPSHOT,
 		ARTIFACT_KIND_SCENEGRAPH_DIAGNOSTICS,
 		ARTIFACT_KIND_SCENEGRAPH_SUMMARY,
+		ARTIFACT_KIND_TRACE,
 		ARTIFACT_KIND_AUTOMATION_CAPABILITY,
 		ARTIFACT_KIND_AUTOMATION_LIFECYCLE_STATUS,
 		ARTIFACT_KIND_AUTOMATION_RUN_RESULT,

--- a/docs/AGENT_RUNTIME_HARNESS.md
+++ b/docs/AGENT_RUNTIME_HARNESS.md
@@ -281,6 +281,11 @@ Recommended flow:
 4. Follow `artifactRefs` only for the specific files needed to explain or validate the reported outcome.
 5. Preserve the raw artifacts unchanged so later runs can replay, diff, or revalidate the same bundle.
 
+For first-release behavior-watch runs, keep the same manifest-first flow and expect two additional runtime-facing details:
+
+- `appliedWatch` records the normalized watch request the harness actually used for the run.
+- `artifactRefs` includes a `trace` entry that points to the run-scoped `trace.jsonl` file for that same run.
+
 The first-release contract for this repository is captured in `specs/001-agent-tooling-foundation/contracts/evidence-manifest.schema.json`.
 Seeded examples live under `tools/evals/fixtures/001-agent-tooling-foundation/` and are intended to show the minimum artifact set an agent should expect:
 

--- a/docs/AGENT_TOOLING_FOUNDATION.md
+++ b/docs/AGENT_TOOLING_FOUNDATION.md
@@ -69,6 +69,7 @@ pwsh ./tools/automation/request-editor-evidence-run.ps1 -ProjectRoot <game-root>
 ```
 
 Use this when you want to submit a machine-readable request into the plugin-owned file broker without editing the request JSON by hand. Use it after a ready capability check when a task needs Scenegraph Harness runtime verification.
+When you want to layer a behavior-watch fragment onto an existing run request fixture, pass `-BehaviorWatchRequestFixturePath <fixture-path>` and the helper will emit `overrides.behaviorWatchRequest` in the generated request artifact.
 
 ### Run the automated PowerShell tool tests
 
@@ -208,6 +209,8 @@ That keeps the plugin self-sufficient after it has been copied into another game
 5. If the run completed and reported a manifest, read the persisted `evidence-manifest.json`; if `failureKind = build`, use the run result instead, surfacing `details`, `resourcePath`, and `line`/`column` when available alongside the raw build output.
 6. Read summary, diagnostics, and snapshot artifacts only as needed.
 7. Report blocked capability, blocked runs, build-failed runs without manifests, or missing persisted bundles explicitly instead of guessing from editor narration.
+
+For behavior-watch runs, the persisted manifest now carries an `appliedWatch` summary plus a `trace` artifact reference. Agents should still read `run-result.json` first, then the manifest, and only then open `trace.jsonl`.
 
 ### When authoring a new prompt or agent artifact
 

--- a/docs/BEHAVIOR_CAPTURE_SLICES.md
+++ b/docs/BEHAVIOR_CAPTURE_SLICES.md
@@ -1,0 +1,348 @@
+# Runtime Behavior Capture Slices
+
+## Purpose
+
+This document breaks runtime behavior capture into small, testable slices for the Godot Agent Harness.
+It is focused on debugging time-based gameplay behavior such as a Pong ball that sticks to a wall, slides along it, or fails to reverse velocity after contact.
+
+The design stays plugin-first and extends the existing manifest-centered evidence bundle instead of introducing a second runtime diagnostics system.
+
+## Design guardrails
+
+- Keep capture bounded and agent-directed. Do not log everything every frame by default.
+- Reuse the existing evidence bundle flow: manifest first, then only the raw artifacts needed for diagnosis.
+- Prefer deterministic capture windows over open-ended streaming.
+- Treat runtime-visible behavior as evidence, not prose.
+- Keep the first implementation editor-launched and addon-first.
+
+## Recommended ship order
+
+| Slice | Name | Why it ships now | Depends on |
+| --- | --- | --- | --- |
+| 1 | Runtime query contract | Defines what an agent can ask for | None |
+| 2 | Targeted watch sampling | Produces useful time-series data with low overhead | 1 |
+| 3 | Triggered capture windows | Captures the right frames without full-run logging | 1, 2 |
+| 4 | Invariant-driven persistence | Turns behavior bugs into machine-readable pass or fail outcomes | 2, 3 |
+| 5 | Script probes | Explains custom movement logic when node state is not enough | 1, 2 |
+| 6 | Manifest and triage integration | Makes the evidence easy for agents to consume | 2, 3, 4 |
+| 7 | Live editor stream (optional) | Nice exploratory UX, not required for the core agent loop | 2 |
+
+## Slice 1 - Runtime query contract
+
+**Feature request**
+
+As an agent, I want to declare exactly which runtime behavior data to capture so the harness records only the nodes, properties, cadence, triggers, and invariants relevant to my debugging question.
+
+**What it does**
+
+This slice defines the machine-readable request shape for behavior capture. It is the control surface that later slices execute.
+
+Suggested query fields:
+
+- target nodes or selectors
+- sampled properties
+- frame cadence
+- capture duration or frame budget
+- trigger conditions
+- ring-buffer size
+- invariant list
+- persistence policy
+
+**How it fits**
+
+This is the foundation for every later slice. Without it, the harness has no stable, agent-friendly way to request bounded runtime behavior evidence.
+
+**Implementation instructions**
+
+1. Add a behavior-capture request contract that can be passed through session config or per-run override data.
+2. Normalize the request at runtime so missing values become explicit defaults instead of implicit behavior.
+3. Keep the request independent from one specific game so the same contract works for Pong and later projects.
+4. Reject unsupported selectors, properties, or trigger types with explicit machine-readable errors.
+
+**Testable deliverables**
+
+- A documented request schema for behavior capture.
+- One valid fixture request for a Pong wall-bounce investigation.
+- One invalid fixture request that proves schema or validation rejection.
+- A normalized runtime echo or summary that shows what query the harness actually applied.
+
+**Definition of done**
+
+1. A valid query can be loaded and normalized without starting a run.
+2. An invalid query fails decisively with a machine-readable reason.
+3. The normalized query can be associated with a run and persisted in run metadata.
+
+---
+
+## Slice 2 - Targeted watch sampling
+
+**Feature request**
+
+As an agent, I want the harness to sample a selected set of properties for selected nodes over a bounded frame window so I can inspect how state changes over time without paying the cost of full-scene per-frame logging.
+
+**What it does**
+
+This slice records a bounded trace for watched nodes. For Pong, that likely means `Ball` position, velocity, intended velocity, collision state, last collider, and overlap counters.
+
+**How it fits**
+
+This is the first slice that produces the time-series evidence needed to explain sticky or sliding collisions. It should write the trace artifact that later invariants and summaries reference.
+
+**Implementation instructions**
+
+1. Add a sampler that records only requested properties for requested nodes.
+2. Support `every_frame` and `every_n_frames` modes.
+3. Cap total frames or duration so traces stay bounded.
+4. Write the result as a stable machine-readable trace artifact, ideally `trace.jsonl`.
+5. Keep serialization flat and agent-readable. Prefer explicit fields over opaque blobs.
+
+**Testable deliverables**
+
+- A seeded run that writes `trace.jsonl` for a watched ball.
+- Trace rows that include frame and timestamp plus the selected watched properties.
+- A manifest artifact reference for the trace output.
+
+**Definition of done**
+
+1. A seeded run can capture a bounded trace without logging unrelated nodes.
+2. The trace contains the watched properties for the expected frame window.
+3. The manifest references the trace artifact successfully.
+
+---
+
+## Slice 3 - Triggered capture windows
+
+**Feature request**
+
+As an agent, I want the harness to keep a small rolling history and persist only the frames around important behavior events so I can see what happened before and after a collision without storing every frame of the whole run.
+
+**What it does**
+
+This slice introduces a ring buffer plus event-triggered persistence. It captures a failure window around events such as:
+
+- wall contact
+- overlap start
+- overlap persisting beyond N frames
+- velocity failing to reverse after contact
+- ball speed dropping to zero unexpectedly
+
+**How it fits**
+
+This is the main overhead-control mechanism. It turns continuous sampling into compact, diagnosis-ready windows.
+
+**Implementation instructions**
+
+1. Keep a bounded in-memory ring buffer of recent sampled frames.
+2. Add trigger definitions that can request persistence of pre-trigger and post-trigger frames.
+3. Record structured events in `events.json` when a trigger fires.
+4. Allow manual trigger requests in addition to automatic ones.
+5. Include the relevant frame window in artifact metadata when possible.
+
+**Testable deliverables**
+
+- A ring buffer implementation with configurable pre/post frame counts.
+- A seeded overlap or wall-contact run that emits `events.json`.
+- A persisted trace window showing frames before and after the triggering event.
+- Manifest entries that point to the relevant trace and event artifacts.
+
+**Definition of done**
+
+1. A trigger can persist a bounded pre/post frame window without full-run trace retention.
+2. The event artifact names the trigger type, source node, frame, and payload.
+3. The persisted trace clearly includes the requested pre-trigger and post-trigger frames.
+
+---
+
+## Slice 4 - Invariant-driven persistence
+
+**Feature request**
+
+As an agent, I want the harness to evaluate behavior invariants during runtime and automatically persist the relevant evidence when one fails so I can debug from a small failure bundle instead of a vague report that the run looked wrong.
+
+**What it does**
+
+This slice turns known behavior expectations into machine-readable outcomes. For Pong, likely first invariants are:
+
+- ball clears a wall within N frames after contact
+- horizontal velocity reverses after wall contact
+- ball speed stays within configured bounds
+- ball does not remain overlapping a collider longer than N frames
+
+**How it fits**
+
+This slice transforms raw behavior capture into agent-friendly diagnosis. It is the point where the harness stops being just telemetry and becomes a runtime proof system.
+
+**Implementation instructions**
+
+1. Evaluate invariants against sampled frames and event windows.
+2. Persist `invariants.json` with pass, fail, or unknown results.
+3. On invariant failure, persist the relevant trace window and any point-in-time snapshot needed for context.
+4. Surface the failed invariant in the manifest summary so an agent can route immediately to the right raw artifact.
+
+**Testable deliverables**
+
+- At least two seeded invariant checks for Pong wall behavior.
+- A failing fixture where the ball sticks or slides and the invariant report fails correctly.
+- A passing fixture where the ball bounces correctly and the invariant report passes.
+- Manifest summary output that references the failed invariant and linked artifacts.
+
+**Definition of done**
+
+1. A known sticky-wall scenario produces a deterministic invariant failure.
+2. A good bounce scenario passes the same invariant set.
+3. The failure report links directly to the trace and event artifacts that explain the result.
+
+---
+
+## Slice 5 - Script probes
+
+**Feature request**
+
+As an agent, I want the movement script to expose selected before-and-after internal values around its update logic so I can see why custom code made the wrong bounce decision when node state alone is not enough.
+
+**What it does**
+
+This slice adds opt-in probe hooks for logic-driven movement. It is specifically meant for cases where the ball is not using Godot physics and the important failure cause lives inside script-local variables or branch decisions.
+
+Examples:
+
+- intended velocity before resolution
+- collision candidate list
+- chosen bounce normal
+- branch outcome such as `reflect_x = false`
+- corrected position before and after wall resolution
+
+**How it fits**
+
+This is not the default path. It is a deeper layer used when watch sampling plus invariants still do not explain the failure.
+
+**Implementation instructions**
+
+1. Provide a small probe API that game scripts can call explicitly.
+2. Keep probes request-scoped and opt-in so normal runs do not pay the cost.
+3. Route probe output into existing behavior evidence artifacts rather than inventing a separate opaque log.
+4. Distinguish probe data from observed node-state data in the output shape.
+
+**Testable deliverables**
+
+- A minimal probe helper API callable from a custom movement script.
+- A seeded custom Pong script that emits before/after values for wall-bounce resolution.
+- Persisted probe entries tied to the same run and frame window as the sampled trace.
+
+**Definition of done**
+
+1. A scripted movement fixture can emit probe data only when requested.
+2. Probe output is correlated to frame numbers and source script or node path.
+3. The evidence explains at least one failure cause that is not visible from node state alone.
+
+---
+
+## Slice 6 - Manifest and triage integration
+
+**Feature request**
+
+As an agent, I want behavior-capture runs to arrive as the same kind of manifest-centered evidence bundle used elsewhere in the harness so I can read the manifest first, then open only the trace, events, invariants, or snapshot files needed to explain the failure.
+
+**What it does**
+
+This slice wires the new behavior artifacts into the current evidence handoff model.
+
+Expected artifacts for a behavior-focused run:
+
+- `trace.jsonl`
+- `events.json`
+- `invariants.json`
+- `scene-snapshot.json` when a point-in-time snapshot is useful
+- manifest summary fields that call out the failing behavior
+
+**How it fits**
+
+This slice keeps behavior capture aligned with the existing scenegraph and automation workflow instead of creating a second agent-consumption path.
+
+**Implementation instructions**
+
+1. Extend artifact registration and manifest-writing logic to include behavior-capture artifacts.
+2. Add summary-builder logic that can highlight behavior failures, not just scenegraph outcomes.
+3. Preserve manifest-first triage expectations: the summary should tell the agent which artifact to open next.
+4. Add eval fixtures that prove another agent can diagnose a failure from the bundle.
+
+**Testable deliverables**
+
+- Manifest support for trace, events, and invariant artifacts from a real behavior run.
+- A summary entry that points to the failing invariant and failure window.
+- One eval fixture bundle for a sticky-ball failure and one for a successful bounce.
+
+**Definition of done**
+
+1. A behavior run produces a valid manifest-centered bundle.
+2. The manifest summary identifies the key failure without reading every raw file.
+3. The referenced artifacts are sufficient for post-run diagnosis.
+
+---
+
+## Slice 7 - Live editor stream (optional)
+
+**Feature request**
+
+As a maintainer or operator, I want an optional live stream of the currently watched behavior fields in the editor so I can inspect a run interactively while keeping persisted artifacts as the primary agent contract.
+
+**What it does**
+
+This slice adds an editor UX for active runs. It is useful for manual debugging and fast iteration, but it is not required for the core agent workflow.
+
+**How it fits**
+
+This is a convenience layer on top of the same sampled and triggered data model built in earlier slices.
+
+**Implementation instructions**
+
+1. Reuse the existing debugger transport rather than creating a separate live socket path.
+2. Keep the live stream bounded to the active watch list.
+3. Do not make persisted diagnosis depend on the live view.
+4. Make it clear that saved artifacts remain the source of truth after the run.
+
+**Testable deliverables**
+
+- An editor-side live view for currently watched fields.
+- A seeded run where the live view updates during playtesting.
+- Confirmation that the same run still persists the expected post-run evidence bundle.
+
+**Definition of done**
+
+1. The live stream reflects the active watch query during a run.
+2. The run remains diagnosable from persisted artifacts even if nobody watches the live stream.
+3. Live UX failures do not block bundle persistence.
+
+## Suggested MVP boundary
+
+If the goal is to debug Pong-like bounce failures quickly with minimal overhead, the first MVP should include:
+
+1. Slice 1 - Runtime query contract
+2. Slice 2 - Targeted watch sampling
+3. Slice 3 - Triggered capture windows
+4. Slice 4 - Invariant-driven persistence
+5. Slice 6 - Manifest and triage integration
+
+Slice 5 should be added when the game uses custom script-driven motion and the sampled node state is not enough to explain the bug.
+Slice 7 should remain optional until the persisted evidence workflow is proven.
+
+## First seeded scenario to implement
+
+Use a deterministic Pong fixture that asks for:
+
+- watch target: `/root/Main/Ball`
+- properties: `position`, `velocity`, `intended_velocity`, `collision_state`, `last_collider`, `overlap_frames`
+- cadence: every frame
+- ring buffer: 20 frames
+- triggers: `wall_contact`, `overlap_persisted`, `velocity_not_reversed`
+- invariants:
+  - `ball-clears-wall-within-two-frames`
+  - `horizontal-velocity-reverses-after-wall-contact`
+
+Expected persisted bundle:
+
+- manifest summary says the ball remained overlapped or failed to reverse velocity
+- `trace.jsonl` shows the failure window
+- `events.json` shows collision and trigger events
+- `invariants.json` records the failing rule
+- `scene-snapshot.json` is included only if the failure needs point-in-time hierarchy or property context

--- a/docs/BEHAVIOR_CAPTURE_SLICES.md
+++ b/docs/BEHAVIOR_CAPTURE_SLICES.md
@@ -55,7 +55,7 @@ This is the foundation for every later slice. Without it, the harness has no sta
 **Implementation instructions**
 
 1. Add a behavior-capture request contract that can be passed through session config or per-run override data.
-2. Normalize the request at runtime so missing values become explicit defaults instead of implicit behavior.
+2. Normalize the request at runtime so missing values become explicit defaults instead of implicit behavior. In the first release, omitted cadence defaults to `every_frame` and omitted `startFrameOffset` defaults to `0`.
 3. Keep the request independent from one specific game so the same contract works for Pong and later projects.
 4. Reject unsupported selectors, properties, or trigger types with explicit machine-readable errors.
 
@@ -94,7 +94,7 @@ This is the first slice that produces the time-series evidence needed to explain
 2. Support `every_frame` and `every_n_frames` modes.
 3. Cap total frames or duration so traces stay bounded.
 4. Write the result as a stable machine-readable trace artifact, ideally `trace.jsonl`.
-5. Keep serialization flat and agent-readable. Prefer explicit fields over opaque blobs.
+5. Keep serialization flat and agent-readable. Prefer explicit fields over opaque blobs, and keep the normalized `appliedWatch` summary in the persisted manifest so the trace contract stays self-describing.
 
 **Testable deliverables**
 

--- a/examples/pong-testbed/evidence/automation/pong-behavior-watch-wall-bounce-every-frame/evidence-manifest.json
+++ b/examples/pong-testbed/evidence/automation/pong-behavior-watch-wall-bounce-every-frame/evidence-manifest.json
@@ -1,0 +1,76 @@
+{
+  "schemaVersion": "1.0.0",
+  "manifestId": "scenegraph-pong-behavior-watch-wall-bounce-every-frame-run-01",
+  "runId": "pong-behavior-watch-wall-bounce-every-frame-run-01",
+  "scenarioId": "pong-behavior-watch-wall-bounce-every-frame",
+  "status": "pass",
+  "summary": {
+    "headline": "Behavior watch captured the Pong ball across the requested frame window.",
+    "outcome": "The bounded watch trace recorded only the requested Ball fields for the current run.",
+    "keyFindings": [
+      "Behavior watch samples: 4",
+      "Targeted node: /root/Main/Ball",
+      "Window: frames 12 through 15"
+    ]
+  },
+  "appliedWatch": {
+    "runId": "pong-behavior-watch-wall-bounce-every-frame-run-01",
+    "targets": [
+      {
+        "nodePath": "/root/Main/Ball",
+        "properties": ["position", "velocity", "collisionState", "lastCollider"]
+      }
+    ],
+    "cadence": {
+      "mode": "every_frame",
+      "everyNFrames": null
+    },
+    "startFrameOffset": 12,
+    "frameCount": 4,
+    "traceArtifact": "trace.jsonl",
+    "outcomes": {
+      "sampleCount": 4,
+      "sampledFrameCount": 4,
+      "noSamples": false,
+      "missingTargets": [],
+      "missingProperties": []
+    }
+  },
+  "artifactRefs": [
+    {
+      "kind": "scenegraph-snapshot",
+      "path": "examples/pong-testbed/evidence/automation/pong-behavior-watch-wall-bounce-every-frame/scenegraph-snapshot.json",
+      "mediaType": "application/json",
+      "description": "Latest scenegraph snapshot for the behavior-watch run."
+    },
+    {
+      "kind": "scenegraph-diagnostics",
+      "path": "examples/pong-testbed/evidence/automation/pong-behavior-watch-wall-bounce-every-frame/scenegraph-diagnostics.json",
+      "mediaType": "application/json",
+      "description": "Structured diagnostics for the behavior-watch run."
+    },
+    {
+      "kind": "scenegraph-summary",
+      "path": "examples/pong-testbed/evidence/automation/pong-behavior-watch-wall-bounce-every-frame/scenegraph-summary.json",
+      "mediaType": "application/json",
+      "description": "Agent-readable summary for the behavior-watch run."
+    },
+    {
+      "kind": "trace",
+      "path": "examples/pong-testbed/evidence/automation/pong-behavior-watch-wall-bounce-every-frame/trace.jsonl",
+      "mediaType": "application/jsonl",
+      "description": "Bounded behavior-watch trace for the Pong ball."
+    }
+  ],
+  "producer": {
+    "toolingArtifactId": "scenegraph_automation_broker",
+    "surface": "scenegraph_harness_runtime"
+  },
+  "validation": {
+    "bundleValid": true,
+    "notes": [
+      "Persisted artifact references were written successfully. Validate the manifest schema and paths with tools/evidence/validate-evidence-manifest.ps1 after the editor run."
+    ]
+  },
+  "createdAt": "2026-04-14T00:30:00Z"
+}

--- a/examples/pong-testbed/evidence/automation/pong-behavior-watch-wall-bounce-every-frame/scenegraph-diagnostics.json
+++ b/examples/pong-testbed/evidence/automation/pong-behavior-watch-wall-bounce-every-frame/scenegraph-diagnostics.json
@@ -1,0 +1,8 @@
+{
+  "schema_version": "1.0.0",
+  "snapshot_id": "pong-behavior-watch-wall-bounce-every-frame-snapshot-01",
+  "session_id": "pong-request-watch-every-frame-001",
+  "run_id": "pong-behavior-watch-wall-bounce-every-frame-run-01",
+  "scenario_id": "pong-behavior-watch-wall-bounce-every-frame",
+  "diagnostics": []
+}

--- a/examples/pong-testbed/evidence/automation/pong-behavior-watch-wall-bounce-every-frame/scenegraph-snapshot.json
+++ b/examples/pong-testbed/evidence/automation/pong-behavior-watch-wall-bounce-every-frame/scenegraph-snapshot.json
@@ -1,0 +1,48 @@
+{
+  "schema_version": "1.0.0",
+  "snapshot_id": "pong-behavior-watch-wall-bounce-every-frame-snapshot-01",
+  "session_id": "pong-request-watch-every-frame-001",
+  "run_id": "pong-behavior-watch-wall-bounce-every-frame-run-01",
+  "scenario_id": "pong-behavior-watch-wall-bounce-every-frame",
+  "trigger": {
+    "trigger_type": "manual",
+    "requested_by": "behavior-watch-fixture",
+    "reason": "manual_request",
+    "frame": 15,
+    "timestamp": "2026-04-14T00:30:00Z"
+  },
+  "root_scene": {
+    "name": "Main",
+    "path": "/root/Main"
+  },
+  "frame": 15,
+  "captured_at": "2026-04-14T00:30:00Z",
+  "node_count": 4,
+  "nodes": [
+    {
+      "path": "/root/Main/Ball",
+      "type": "CharacterBody2D",
+      "parent_path": "/root/Main",
+      "owner_path": "/root/Main",
+      "groups": [],
+      "script_class": "",
+      "visibility_state": {
+        "visible": true
+      },
+      "processing_state": {
+        "process": true,
+        "physics_process": true
+      },
+      "transform_state": {
+        "position": [30, 64],
+        "rotation": 0,
+        "scale": [1, 1]
+      },
+      "properties": {
+        "name": "Ball",
+        "child_count": 0
+      }
+    }
+  ],
+  "capture_status": "complete"
+}

--- a/examples/pong-testbed/evidence/automation/pong-behavior-watch-wall-bounce-every-frame/scenegraph-summary.json
+++ b/examples/pong-testbed/evidence/automation/pong-behavior-watch-wall-bounce-every-frame/scenegraph-summary.json
@@ -1,0 +1,12 @@
+{
+  "status": "pass",
+  "headline": "Behavior watch captured the Pong ball across the requested frame window.",
+  "outcome": "The bounded watch trace recorded only the requested Ball fields for the current run.",
+  "keyFindings": [
+    "Behavior watch samples: 4",
+    "Targeted node: /root/Main/Ball",
+    "Window: frames 12 through 15"
+  ],
+  "latestSnapshotId": "pong-behavior-watch-wall-bounce-every-frame-snapshot-01",
+  "diagnosticCount": 0
+}

--- a/examples/pong-testbed/evidence/automation/pong-behavior-watch-wall-bounce-every-frame/trace.jsonl
+++ b/examples/pong-testbed/evidence/automation/pong-behavior-watch-wall-bounce-every-frame/trace.jsonl
@@ -1,0 +1,4 @@
+{"frame":12,"timestampMs":192,"nodePath":"/root/Main/Ball","position":[18.0,64.0],"velocity":[220.0,0.0],"collisionState":"none","lastCollider":null}
+{"frame":13,"timestampMs":208,"nodePath":"/root/Main/Ball","position":[22.0,64.0],"velocity":[220.0,0.0],"collisionState":"none","lastCollider":null}
+{"frame":14,"timestampMs":224,"nodePath":"/root/Main/Ball","position":[26.0,64.0],"velocity":[220.0,0.0],"collisionState":"contact","lastCollider":"/root/Main/RightWall"}
+{"frame":15,"timestampMs":240,"nodePath":"/root/Main/Ball","position":[30.0,64.0],"velocity":[-220.0,0.0],"collisionState":"none","lastCollider":null}

--- a/examples/pong-testbed/evidence/automation/pong-behavior-watch-wall-bounce-every-n/evidence-manifest.json
+++ b/examples/pong-testbed/evidence/automation/pong-behavior-watch-wall-bounce-every-n/evidence-manifest.json
@@ -1,0 +1,76 @@
+{
+  "schemaVersion": "1.0.0",
+  "manifestId": "scenegraph-pong-behavior-watch-wall-bounce-every-n-run-01",
+  "runId": "pong-behavior-watch-wall-bounce-every-n-run-01",
+  "scenarioId": "pong-behavior-watch-wall-bounce-every-n",
+  "status": "pass",
+  "summary": {
+    "headline": "Behavior watch captured the Pong ball at every-N-frame cadence.",
+    "outcome": "The bounded watch trace recorded only the requested cadence-aligned Ball fields for the current run.",
+    "keyFindings": [
+      "Behavior watch samples: 3",
+      "Targeted node: /root/Main/Ball",
+      "Window: frames 20 through 25 sampled every 2 frames"
+    ]
+  },
+  "appliedWatch": {
+    "runId": "pong-behavior-watch-wall-bounce-every-n-run-01",
+    "targets": [
+      {
+        "nodePath": "/root/Main/Ball",
+        "properties": ["position", "velocity", "speed"]
+      }
+    ],
+    "cadence": {
+      "mode": "every_n_frames",
+      "everyNFrames": 2
+    },
+    "startFrameOffset": 20,
+    "frameCount": 6,
+    "traceArtifact": "trace.jsonl",
+    "outcomes": {
+      "sampleCount": 3,
+      "sampledFrameCount": 3,
+      "noSamples": false,
+      "missingTargets": [],
+      "missingProperties": []
+    }
+  },
+  "artifactRefs": [
+    {
+      "kind": "scenegraph-snapshot",
+      "path": "examples/pong-testbed/evidence/automation/pong-behavior-watch-wall-bounce-every-n/scenegraph-snapshot.json",
+      "mediaType": "application/json",
+      "description": "Latest scenegraph snapshot for the behavior-watch run."
+    },
+    {
+      "kind": "scenegraph-diagnostics",
+      "path": "examples/pong-testbed/evidence/automation/pong-behavior-watch-wall-bounce-every-n/scenegraph-diagnostics.json",
+      "mediaType": "application/json",
+      "description": "Structured diagnostics for the behavior-watch run."
+    },
+    {
+      "kind": "scenegraph-summary",
+      "path": "examples/pong-testbed/evidence/automation/pong-behavior-watch-wall-bounce-every-n/scenegraph-summary.json",
+      "mediaType": "application/json",
+      "description": "Agent-readable summary for the behavior-watch run."
+    },
+    {
+      "kind": "trace",
+      "path": "examples/pong-testbed/evidence/automation/pong-behavior-watch-wall-bounce-every-n/trace.jsonl",
+      "mediaType": "application/jsonl",
+      "description": "Cadence-controlled behavior-watch trace for the Pong ball."
+    }
+  ],
+  "producer": {
+    "toolingArtifactId": "scenegraph_automation_broker",
+    "surface": "scenegraph_harness_runtime"
+  },
+  "validation": {
+    "bundleValid": true,
+    "notes": [
+      "Persisted artifact references were written successfully. Validate the manifest schema and paths with tools/evidence/validate-evidence-manifest.ps1 after the editor run."
+    ]
+  },
+  "createdAt": "2026-04-14T00:31:00Z"
+}

--- a/examples/pong-testbed/evidence/automation/pong-behavior-watch-wall-bounce-every-n/scenegraph-diagnostics.json
+++ b/examples/pong-testbed/evidence/automation/pong-behavior-watch-wall-bounce-every-n/scenegraph-diagnostics.json
@@ -1,0 +1,8 @@
+{
+  "schema_version": "1.0.0",
+  "snapshot_id": "pong-behavior-watch-wall-bounce-every-n-snapshot-01",
+  "session_id": "pong-request-watch-every-n-001",
+  "run_id": "pong-behavior-watch-wall-bounce-every-n-run-01",
+  "scenario_id": "pong-behavior-watch-wall-bounce-every-n",
+  "diagnostics": []
+}

--- a/examples/pong-testbed/evidence/automation/pong-behavior-watch-wall-bounce-every-n/scenegraph-snapshot.json
+++ b/examples/pong-testbed/evidence/automation/pong-behavior-watch-wall-bounce-every-n/scenegraph-snapshot.json
@@ -1,0 +1,48 @@
+{
+  "schema_version": "1.0.0",
+  "snapshot_id": "pong-behavior-watch-wall-bounce-every-n-snapshot-01",
+  "session_id": "pong-request-watch-every-n-001",
+  "run_id": "pong-behavior-watch-wall-bounce-every-n-run-01",
+  "scenario_id": "pong-behavior-watch-wall-bounce-every-n",
+  "trigger": {
+    "trigger_type": "manual",
+    "requested_by": "behavior-watch-fixture",
+    "reason": "manual_request",
+    "frame": 24,
+    "timestamp": "2026-04-14T00:31:00Z"
+  },
+  "root_scene": {
+    "name": "Main",
+    "path": "/root/Main"
+  },
+  "frame": 24,
+  "captured_at": "2026-04-14T00:31:00Z",
+  "node_count": 4,
+  "nodes": [
+    {
+      "path": "/root/Main/Ball",
+      "type": "CharacterBody2D",
+      "parent_path": "/root/Main",
+      "owner_path": "/root/Main",
+      "groups": [],
+      "script_class": "",
+      "visibility_state": {
+        "visible": true
+      },
+      "processing_state": {
+        "process": true,
+        "physics_process": true
+      },
+      "transform_state": {
+        "position": [56, 64],
+        "rotation": 0,
+        "scale": [1, 1]
+      },
+      "properties": {
+        "name": "Ball",
+        "child_count": 0
+      }
+    }
+  ],
+  "capture_status": "complete"
+}

--- a/examples/pong-testbed/evidence/automation/pong-behavior-watch-wall-bounce-every-n/scenegraph-summary.json
+++ b/examples/pong-testbed/evidence/automation/pong-behavior-watch-wall-bounce-every-n/scenegraph-summary.json
@@ -1,0 +1,12 @@
+{
+  "status": "pass",
+  "headline": "Behavior watch captured the Pong ball at every-N-frame cadence.",
+  "outcome": "The bounded watch trace recorded only the requested cadence-aligned Ball fields for the current run.",
+  "keyFindings": [
+    "Behavior watch samples: 3",
+    "Targeted node: /root/Main/Ball",
+    "Window: frames 20 through 25 sampled every 2 frames"
+  ],
+  "latestSnapshotId": "pong-behavior-watch-wall-bounce-every-n-snapshot-01",
+  "diagnosticCount": 0
+}

--- a/examples/pong-testbed/evidence/automation/pong-behavior-watch-wall-bounce-every-n/trace.jsonl
+++ b/examples/pong-testbed/evidence/automation/pong-behavior-watch-wall-bounce-every-n/trace.jsonl
@@ -1,0 +1,3 @@
+{"frame":20,"timestampMs":320,"nodePath":"/root/Main/Ball","position":[40.0,64.0],"velocity":[220.0,0.0],"speed":220.0}
+{"frame":22,"timestampMs":352,"nodePath":"/root/Main/Ball","position":[48.0,64.0],"velocity":[220.0,0.0],"speed":220.0}
+{"frame":24,"timestampMs":384,"nodePath":"/root/Main/Ball","position":[56.0,64.0],"velocity":[-220.0,0.0],"speed":220.0}

--- a/examples/pong-testbed/harness/automation/requests/behavior-watch-invalid-selector.json
+++ b/examples/pong-testbed/harness/automation/requests/behavior-watch-invalid-selector.json
@@ -1,0 +1,9 @@
+{
+  "targets": [
+    {
+      "nodePath": "Main/Ball",
+      "properties": ["position", "velocity"]
+    }
+  ],
+  "frameCount": 4
+}

--- a/examples/pong-testbed/harness/automation/requests/behavior-watch-invalid-window.json
+++ b/examples/pong-testbed/harness/automation/requests/behavior-watch-invalid-window.json
@@ -1,0 +1,9 @@
+{
+  "targets": [
+    {
+      "nodePath": "/root/Main/Ball",
+      "properties": ["position", "velocity"]
+    }
+  ],
+  "frameCount": 0
+}

--- a/examples/pong-testbed/harness/automation/requests/behavior-watch-valid.json
+++ b/examples/pong-testbed/harness/automation/requests/behavior-watch-valid.json
@@ -1,0 +1,9 @@
+{
+  "targets": [
+    {
+      "nodePath": "/root/Main/Ball",
+      "properties": ["position", "velocity", "collisionState", "lastCollider"]
+    }
+  ],
+  "frameCount": 4
+}

--- a/examples/pong-testbed/harness/automation/requests/behavior-watch-wall-bounce.every-frame.json
+++ b/examples/pong-testbed/harness/automation/requests/behavior-watch-wall-bounce.every-frame.json
@@ -1,0 +1,33 @@
+{
+  "requestId": "pong-request-watch-every-frame-001",
+  "scenarioId": "pong-behavior-watch-wall-bounce-every-frame",
+  "runId": "pong-behavior-watch-wall-bounce-every-frame-run-01",
+  "targetScene": "res://scenes/main.tscn",
+  "outputDirectory": "res://evidence/automation/pong-behavior-watch-wall-bounce-every-frame",
+  "artifactRoot": "examples/pong-testbed/evidence/automation/pong-behavior-watch-wall-bounce-every-frame",
+  "expectationFiles": [
+    "res://harness/expectations/common.json"
+  ],
+  "capturePolicy": {
+    "startup": true,
+    "manual": true,
+    "failure": true
+  },
+  "stopPolicy": {
+    "stopAfterValidation": true
+  },
+  "requestedBy": "behavior-watch-fixture",
+  "createdAt": "2026-04-14T00:10:00Z",
+  "overrides": {
+    "behaviorWatchRequest": {
+      "targets": [
+        {
+          "nodePath": "/root/Main/Ball",
+          "properties": ["position", "velocity", "collisionState", "lastCollider"]
+        }
+      ],
+      "startFrameOffset": 12,
+      "frameCount": 4
+    }
+  }
+}

--- a/examples/pong-testbed/harness/automation/requests/behavior-watch-wall-bounce.every-n.json
+++ b/examples/pong-testbed/harness/automation/requests/behavior-watch-wall-bounce.every-n.json
@@ -1,0 +1,37 @@
+{
+  "requestId": "pong-request-watch-every-n-001",
+  "scenarioId": "pong-behavior-watch-wall-bounce-every-n",
+  "runId": "pong-behavior-watch-wall-bounce-every-n-run-01",
+  "targetScene": "res://scenes/main.tscn",
+  "outputDirectory": "res://evidence/automation/pong-behavior-watch-wall-bounce-every-n",
+  "artifactRoot": "examples/pong-testbed/evidence/automation/pong-behavior-watch-wall-bounce-every-n",
+  "expectationFiles": [
+    "res://harness/expectations/common.json"
+  ],
+  "capturePolicy": {
+    "startup": true,
+    "manual": true,
+    "failure": true
+  },
+  "stopPolicy": {
+    "stopAfterValidation": true
+  },
+  "requestedBy": "behavior-watch-fixture",
+  "createdAt": "2026-04-14T00:11:00Z",
+  "overrides": {
+    "behaviorWatchRequest": {
+      "targets": [
+        {
+          "nodePath": "/root/Main/Ball",
+          "properties": ["position", "velocity", "speed"]
+        }
+      ],
+      "cadence": {
+        "mode": "every_n_frames",
+        "everyNFrames": 2
+      },
+      "startFrameOffset": 20,
+      "frameCount": 6
+    }
+  }
+}

--- a/examples/pong-testbed/harness/automation/results/run-result.behavior-watch.every-frame.expected.json
+++ b/examples/pong-testbed/harness/automation/results/run-result.behavior-watch.every-frame.expected.json
@@ -1,0 +1,22 @@
+{
+  "requestId": "pong-request-watch-every-frame-001",
+  "runId": "pong-behavior-watch-wall-bounce-every-frame-run-01",
+  "finalStatus": "completed",
+  "failureKind": null,
+  "manifestPath": "examples/pong-testbed/evidence/automation/pong-behavior-watch-wall-bounce-every-frame/evidence-manifest.json",
+  "outputDirectory": "res://evidence/automation/pong-behavior-watch-wall-bounce-every-frame",
+  "validationResult": {
+    "manifestExists": true,
+    "artifactRefsChecked": 4,
+    "missingArtifacts": [],
+    "bundleValid": true,
+    "notes": [
+      "Manifest and behavior-watch trace artifacts passed validation."
+    ],
+    "validatedAt": "2026-04-14T00:30:05Z"
+  },
+  "terminationStatus": "stopped_cleanly",
+  "blockedReasons": [],
+  "controlPath": "file_broker",
+  "completedAt": "2026-04-14T00:30:10Z"
+}

--- a/examples/pong-testbed/harness/automation/results/run-result.behavior-watch.every-n.expected.json
+++ b/examples/pong-testbed/harness/automation/results/run-result.behavior-watch.every-n.expected.json
@@ -1,0 +1,22 @@
+{
+  "requestId": "pong-request-watch-every-n-001",
+  "runId": "pong-behavior-watch-wall-bounce-every-n-run-01",
+  "finalStatus": "completed",
+  "failureKind": null,
+  "manifestPath": "examples/pong-testbed/evidence/automation/pong-behavior-watch-wall-bounce-every-n/evidence-manifest.json",
+  "outputDirectory": "res://evidence/automation/pong-behavior-watch-wall-bounce-every-n",
+  "validationResult": {
+    "manifestExists": true,
+    "artifactRefsChecked": 4,
+    "missingArtifacts": [],
+    "bundleValid": true,
+    "notes": [
+      "Manifest and behavior-watch trace artifacts passed validation."
+    ],
+    "validatedAt": "2026-04-14T00:31:05Z"
+  },
+  "terminationStatus": "stopped_cleanly",
+  "blockedReasons": [],
+  "controlPath": "file_broker",
+  "completedAt": "2026-04-14T00:31:10Z"
+}

--- a/specs/001-agent-tooling-foundation/contracts/evidence-manifest.schema.json
+++ b/specs/001-agent-tooling-foundation/contracts/evidence-manifest.schema.json
@@ -85,6 +85,120 @@
         }
       }
     },
+    "appliedWatch": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "runId",
+        "targets",
+        "cadence",
+        "startFrameOffset",
+        "frameCount",
+        "traceArtifact"
+      ],
+      "properties": {
+        "runId": {
+          "type": "string",
+          "minLength": 1
+        },
+        "targets": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["nodePath", "properties"],
+            "properties": {
+              "nodePath": {
+                "type": "string",
+                "pattern": "^/.*",
+                "minLength": 2
+              },
+              "properties": {
+                "type": "array",
+                "minItems": 1,
+                "items": {
+                  "type": "string",
+                  "minLength": 1
+                }
+              }
+            }
+          }
+        },
+        "cadence": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["mode", "everyNFrames"],
+          "properties": {
+            "mode": {
+              "type": "string",
+              "enum": ["every_frame", "every_n_frames"]
+            },
+            "everyNFrames": {
+              "type": ["integer", "null"],
+              "minimum": 2
+            }
+          }
+        },
+        "startFrameOffset": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "frameCount": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "traceArtifact": {
+          "type": "string",
+          "minLength": 1
+        },
+        "outcomes": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "sampleCount": {
+              "type": "integer",
+              "minimum": 0
+            },
+            "sampledFrameCount": {
+              "type": "integer",
+              "minimum": 0
+            },
+            "noSamples": {
+              "type": "boolean"
+            },
+            "missingTargets": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "minLength": 1
+              }
+            },
+            "missingProperties": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "additionalProperties": false,
+                "required": ["nodePath", "properties"],
+                "properties": {
+                  "nodePath": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "properties": {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "minLength": 1
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "artifactRefs": {
       "type": "array",
       "minItems": 1,

--- a/specs/003-editor-evidence-loop/contracts/automation-run-request.schema.json
+++ b/specs/003-editor-evidence-loop/contracts/automation-run-request.schema.json
@@ -88,6 +88,9 @@
         },
         "stopPolicy": {
           "$ref": "#/$defs/stopPolicy"
+        },
+        "behaviorWatchRequest": {
+          "$ref": "#/$defs/behaviorWatchRequest"
         }
       }
     }
@@ -118,6 +121,119 @@
           "type": "boolean"
         }
       }
+    },
+    "behaviorWatchRequest": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "targets",
+        "frameCount"
+      ],
+      "properties": {
+        "targets": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/$defs/watchTarget"
+          }
+        },
+        "cadence": {
+          "$ref": "#/$defs/watchCadence"
+        },
+        "startFrameOffset": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "frameCount": {
+          "type": "integer",
+          "minimum": 1
+        }
+      }
+    },
+    "watchTarget": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "nodePath",
+        "properties"
+      ],
+      "properties": {
+        "nodePath": {
+          "type": "string",
+          "pattern": "^/.*",
+          "minLength": 2
+        },
+        "properties": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {
+            "type": "string",
+            "enum": [
+              "position",
+              "velocity",
+              "intendedVelocity",
+              "collisionState",
+              "lastCollider",
+              "movementVector",
+              "speed",
+              "overlapFrames"
+            ]
+          }
+        }
+      }
+    },
+    "watchCadence": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "mode"
+      ],
+      "properties": {
+        "mode": {
+          "type": "string",
+          "enum": [
+            "every_frame",
+            "every_n_frames"
+          ]
+        },
+        "everyNFrames": {
+          "type": "integer",
+          "minimum": 2
+        }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "mode": {
+                "const": "every_frame"
+              }
+            }
+          },
+          "then": {
+            "not": {
+              "required": [
+                "everyNFrames"
+              ]
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "mode": {
+                "const": "every_n_frames"
+              }
+            }
+          },
+          "then": {
+            "required": [
+              "everyNFrames"
+            ]
+          }
+        }
+      ]
     }
   }
 }

--- a/specs/005-behavior-watch-sampling/checklists/requirements.md
+++ b/specs/005-behavior-watch-sampling/checklists/requirements.md
@@ -1,0 +1,35 @@
+# Specification Quality Checklist: Behavior Watch Sampling
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-04-14
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Validated on the initial pass.
+- Scope is explicitly limited to slices 1 and 2, with later behavior-capture slices rejected as unsupported for this feature.

--- a/specs/005-behavior-watch-sampling/contracts/behavior-trace-row.schema.json
+++ b/specs/005-behavior-watch-sampling/contracts/behavior-trace-row.schema.json
@@ -1,0 +1,77 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://godot-agent-harness.local/specs/005-behavior-watch-sampling/contracts/behavior-trace-row.schema.json",
+  "title": "Behavior Trace Row",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "frame",
+    "timestampMs",
+    "nodePath"
+  ],
+  "properties": {
+    "frame": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "timestampMs": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "nodePath": {
+      "type": "string",
+      "pattern": "^/.*",
+      "minLength": 2
+    },
+    "position": {
+      "$ref": "#/$defs/vector2"
+    },
+    "velocity": {
+      "$ref": "#/$defs/vector2"
+    },
+    "intendedVelocity": {
+      "$ref": "#/$defs/vector2"
+    },
+    "collisionState": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "lastCollider": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "movementVector": {
+      "$ref": "#/$defs/vector2"
+    },
+    "speed": {
+      "type": [
+        "number",
+        "null"
+      ]
+    },
+    "overlapFrames": {
+      "type": [
+        "integer",
+        "null"
+      ],
+      "minimum": 0
+    }
+  },
+  "$defs": {
+    "vector2": {
+      "type": [
+        "array",
+        "null"
+      ],
+      "items": {
+        "type": "number"
+      },
+      "minItems": 2,
+      "maxItems": 2
+    }
+  }
+}

--- a/specs/005-behavior-watch-sampling/contracts/behavior-watch-contract.md
+++ b/specs/005-behavior-watch-sampling/contracts/behavior-watch-contract.md
@@ -21,9 +21,10 @@ The implemented v1 control surface remains the plugin-owned file broker and the 
 - **Embedded in**: Existing automation run request under `overrides.behaviorWatchRequest`.
 - **Minimum fields**:
   - `targets`
-  - `cadence`
-  - `startFrameOffset`
   - `frameCount`
+- **Defaults when omitted**:
+  - `cadence.mode = every_frame`
+  - `startFrameOffset = 0`
 
 ### Applied Watch Summary
 

--- a/specs/005-behavior-watch-sampling/contracts/behavior-watch-contract.md
+++ b/specs/005-behavior-watch-sampling/contracts/behavior-watch-contract.md
@@ -1,0 +1,70 @@
+# Contract: Behavior Watch Sampling
+
+## Purpose
+
+Define the planned machine-readable contract for slice 1 and slice 2 behavior-watch requests and their bounded `trace.jsonl` output within the existing editor-evidence loop.
+
+## Contract Surfaces
+
+The implemented v1 control surface remains the plugin-owned file broker and the current manifest-centered evidence bundle:
+
+- Run request: `harness/automation/requests/run-request.json`
+- Run result: `harness/automation/results/run-result.json`
+- Persisted manifest: current run `evidence-manifest.json`
+- Persisted trace artifact: current run `trace.jsonl`
+
+### Behavior Watch Request
+
+- **Role**: Tells the current run which runtime node paths and properties to sample during a bounded watch window.
+- **Produced by**: VS Code agent or deterministic fixture workflow.
+- **Consumed by**: Editor-owned run coordinator and runtime addon.
+- **Embedded in**: Existing automation run request under `overrides.behaviorWatchRequest`.
+- **Minimum fields**:
+  - `targets`
+  - `cadence`
+  - `startFrameOffset`
+  - `frameCount`
+
+### Applied Watch Summary
+
+- **Role**: Records the normalized watch request the harness actually used for the active run.
+- **Produced by**: Runtime session configuration and validation flow.
+- **Consumed by**: Agents inspecting the current run metadata and manifest.
+- **Minimum fields**:
+  - `runId`
+  - normalized `targets`
+  - normalized `cadence`
+  - `startFrameOffset`
+  - `frameCount`
+  - `traceArtifact`
+
+### Trace Artifact
+
+- **Role**: Flat per-sample time-series data for watched node paths only.
+- **Produced by**: Runtime watch sampler.
+- **Consumed by**: Agents after reading the manifest.
+- **File**: Fixed `trace.jsonl`
+- **Artifact reference**:
+  - `kind = trace`
+  - `mediaType = application/jsonl`
+
+## Request Rules
+
+- Only absolute runtime node paths are supported in v1.
+- Only slice-1 and slice-2 fields are supported in v1.
+- Requests must fail before capture begins if they include unsupported selectors, unsupported properties, later-slice fields, or zero-sample windows.
+- Requests are immutable for the duration of the run.
+
+## Trace Row Rules
+
+- Rows must be flat JSON objects, one row per sampled target per sampled frame.
+- Rows must include `frame`, `timestampMs`, and `nodePath`.
+- Rows must include only the fields explicitly requested for that target.
+- Rows must not include unrelated nodes or fields.
+
+## Manifest Rules
+
+- The current run manifest remains the primary evidence entrypoint.
+- The manifest must reference the current run's `trace.jsonl` artifact.
+- The trace artifact must be attributable to the current `runId`.
+- Older trace artifacts must not satisfy a new request accidentally.

--- a/specs/005-behavior-watch-sampling/contracts/behavior-watch-contract.md
+++ b/specs/005-behavior-watch-sampling/contracts/behavior-watch-contract.md
@@ -61,6 +61,7 @@ The implemented v1 control surface remains the plugin-owned file broker and the 
 - Rows must be flat JSON objects, one row per sampled target per sampled frame.
 - Rows must include `frame`, `timestampMs`, and `nodePath`.
 - Rows must include only the fields explicitly requested for that target.
+- Vector-valued trace fields are `Vector2`-shaped in v1; `Node3D` positions and `Vector3` properties are treated as unavailable instead of widening the row schema.
 - Rows must not include unrelated nodes or fields.
 
 ## Manifest Rules

--- a/specs/005-behavior-watch-sampling/contracts/behavior-watch-request.schema.json
+++ b/specs/005-behavior-watch-sampling/contracts/behavior-watch-request.schema.json
@@ -1,0 +1,120 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://godot-agent-harness.local/specs/005-behavior-watch-sampling/contracts/behavior-watch-request.schema.json",
+  "title": "Behavior Watch Request",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "targets",
+    "cadence",
+    "startFrameOffset",
+    "frameCount"
+  ],
+  "properties": {
+    "targets": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/$defs/watchTarget"
+      }
+    },
+    "cadence": {
+      "$ref": "#/$defs/watchCadence"
+    },
+    "startFrameOffset": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "frameCount": {
+      "type": "integer",
+      "minimum": 1
+    }
+  },
+  "$defs": {
+    "watchTarget": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "nodePath",
+        "properties"
+      ],
+      "properties": {
+        "nodePath": {
+          "type": "string",
+          "pattern": "^/.*",
+          "minLength": 2
+        },
+        "properties": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {
+            "type": "string",
+            "enum": [
+              "position",
+              "velocity",
+              "intendedVelocity",
+              "collisionState",
+              "lastCollider",
+              "movementVector",
+              "speed",
+              "overlapFrames"
+            ]
+          }
+        }
+      }
+    },
+    "watchCadence": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "mode"
+      ],
+      "properties": {
+        "mode": {
+          "type": "string",
+          "enum": [
+            "every_frame",
+            "every_n_frames"
+          ]
+        },
+        "everyNFrames": {
+          "type": "integer",
+          "minimum": 2
+        }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "mode": {
+                "const": "every_frame"
+              }
+            }
+          },
+          "then": {
+            "not": {
+              "required": [
+                "everyNFrames"
+              ]
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "mode": {
+                "const": "every_n_frames"
+              }
+            }
+          },
+          "then": {
+            "required": [
+              "everyNFrames"
+            ]
+          }
+        }
+      ]
+    }
+  }
+}

--- a/specs/005-behavior-watch-sampling/contracts/behavior-watch-request.schema.json
+++ b/specs/005-behavior-watch-sampling/contracts/behavior-watch-request.schema.json
@@ -6,8 +6,6 @@
   "additionalProperties": false,
   "required": [
     "targets",
-    "cadence",
-    "startFrameOffset",
     "frameCount"
   ],
   "properties": {

--- a/specs/005-behavior-watch-sampling/data-model.md
+++ b/specs/005-behavior-watch-sampling/data-model.md
@@ -1,0 +1,115 @@
+# Data Model: Behavior Watch Sampling
+
+## Entities
+
+### Behavior Watch Request
+
+- **Purpose**: Defines the run-scoped bounded sampling contract supplied by the agent for slice 1 and slice 2.
+- **Fields**:
+  - `targets`: One or more Watch Target values.
+  - `cadence`: Watch Cadence value.
+  - `startFrameOffset`: Non-negative frame offset from playtest frame 0.
+  - `frameCount`: Positive bounded number of frames to sample.
+- **Validation Rules**:
+  - Must include at least one target.
+  - Must reject any selector form other than an absolute runtime node path.
+  - Must reject later-slice fields such as triggers, invariants, script probes, or open-ended full-scene capture requests.
+  - Must reject any configuration that would produce zero eligible samples.
+
+### Watch Target
+
+- **Purpose**: Identifies one runtime node and the exact fields to sample for that node.
+- **Fields**:
+  - `nodePath`: Absolute runtime node path, such as `/root/Main/Ball`.
+  - `properties`: Non-empty list of supported watch properties.
+- **Validation Rules**:
+  - `nodePath` must be absolute and stable for the duration of the run.
+  - `properties` must be unique within the target.
+  - Unsupported properties must reject the full request.
+
+### Watch Cadence
+
+- **Purpose**: Defines how often the runtime sampler emits rows during the active watch window.
+- **Fields**:
+  - `mode`: `every_frame` or `every_n_frames`.
+  - `everyNFrames`: Positive integer used only when `mode = every_n_frames`.
+- **Validation Rules**:
+  - `everyNFrames` must be omitted for `every_frame`.
+  - `everyNFrames` must be at least `2` for `every_n_frames`.
+
+### Applied Watch Summary
+
+- **Purpose**: Records the normalized request the harness actually applied to the current run.
+- **Fields**:
+  - `runId`: Current run identifier.
+  - `targets`: Normalized Watch Target values.
+  - `cadence`: Normalized Watch Cadence value.
+  - `startFrameOffset`: Applied start-frame offset.
+  - `frameCount`: Applied bounded frame count.
+  - `traceArtifact`: Fixed `trace.jsonl`.
+  - `rejectedFields`: Any rejected unsupported fields when validation fails.
+- **Lifecycle**:
+  - `submitted` -> request loaded from run metadata
+  - `validated` -> request accepted or rejected
+  - `normalized` -> defaults made explicit for the active run
+
+### Trace Sample Row
+
+- **Purpose**: One flat JSONL line that records the sampled state for one watched target at one sampled frame.
+- **Fields**:
+  - `frame`: Absolute sampled frame number within the playtest.
+  - `timestampMs`: Milliseconds since run start or sampling epoch used by the harness.
+  - `nodePath`: Absolute runtime node path for the sampled target.
+  - `position`: Optional 2-element numeric vector.
+  - `velocity`: Optional 2-element numeric vector.
+  - `intendedVelocity`: Optional 2-element numeric vector when exposed by the target.
+  - `collisionState`: Optional string state such as `none`, `contact`, or `overlap`.
+  - `lastCollider`: Optional absolute node path or other machine-readable collider identity.
+  - `movementVector`: Optional 2-element numeric vector when exposed.
+  - `speed`: Optional numeric scalar.
+  - `overlapFrames`: Optional non-negative integer.
+- **Validation Rules**:
+  - Must include only fields requested for the current target.
+  - Must remain flat and machine-readable with no nested opaque blobs.
+
+### Behavior Trace Artifact
+
+- **Purpose**: Represents the persisted `trace.jsonl` file and its manifest reference for the current run.
+- **Fields**:
+  - `runId`: Current run identifier.
+  - `outputDirectory`: Run-scoped output directory.
+  - `artifactPath`: Resolved path to `trace.jsonl`.
+  - `artifactKind`: Fixed `trace`.
+  - `mediaType`: Fixed `application/jsonl`.
+  - `manifestPath`: Current run manifest that references the trace.
+
+## Relationships
+
+- One Behavior Watch Request contains one or more Watch Target values.
+- One Behavior Watch Request produces one Applied Watch Summary per run.
+- One Applied Watch Summary governs zero or more Trace Sample Row values during the active watch window.
+- One current run manifest references one Behavior Trace Artifact when sampling succeeds.
+
+## State Transitions
+
+### Request Lifecycle
+
+1. `submitted` -> request is loaded from the run request.
+2. `validated` -> request is accepted or rejected with explicit machine-readable reasons.
+3. `normalized` -> defaults are applied and the summary is attached to the run.
+4. `sampling_active` -> runtime collects rows during the active window.
+5. `persisted` -> `trace.jsonl` is written and referenced from the manifest.
+
+### Watch Window Lifecycle
+
+1. `before_window` -> current frame is below `startFrameOffset`.
+2. `active_window` -> sampler records rows according to the configured cadence.
+3. `window_complete` -> configured bounded frame count has been consumed.
+
+## Invariants
+
+- The first release must use absolute runtime node paths only.
+- The first release must persist only `trace.jsonl` for the bounded watch output.
+- The sampler must never emit rows outside the configured watch window.
+- The sampler must never add unrelated nodes or unrequested fields to a row.
+- A failed or missing trace must never be satisfied by an older run's artifact.

--- a/specs/005-behavior-watch-sampling/data-model.md
+++ b/specs/005-behavior-watch-sampling/data-model.md
@@ -71,6 +71,7 @@
 - **Validation Rules**:
   - Must include only fields requested for the current target.
   - Must remain flat and machine-readable with no nested opaque blobs.
+  - Vector-valued fields remain 2-element arrays in v1; targets that expose `Node3D` positions or `Vector3` properties report those fields as unavailable rather than widening the contract.
 
 ### Behavior Trace Artifact
 

--- a/specs/005-behavior-watch-sampling/plan.md
+++ b/specs/005-behavior-watch-sampling/plan.md
@@ -1,0 +1,147 @@
+
+# Implementation Plan: Behavior Watch Sampling
+
+**Branch**: `[005-add-behavior-capture]` | **Date**: 2026-04-14 | **Spec**: [specs/005-behavior-watch-sampling/spec.md](specs/005-behavior-watch-sampling/spec.md)
+**Input**: Feature specification from `/specs/005-behavior-watch-sampling/spec.md`
+
+## Summary
+
+Extend the existing editor-launched evidence loop so an autonomous run can carry a bounded `behaviorWatchRequest` for absolute runtime node paths, normalize that request before capture begins, sample only the requested properties at every-frame or every-N-frames cadence within an explicit start-frame offset plus bounded frame-count window, and persist the result as a fixed `trace.jsonl` artifact referenced from the current run's manifest-centered evidence bundle. The preferred v1 path reuses the current automation run request, debugger-backed session configuration, runtime addon, and manifest-writing flow rather than creating a second broker, a live-only stream, or a separate evidence handoff.
+
+## Technical Context
+
+**Language/Version**: GDScript for Godot 4.x addon and runtime scripts, JSON schemas and fixtures for contract surfaces, Markdown design artifacts, and existing PowerShell helpers for request writing and validation  
+**Primary Dependencies**: Godot `EditorPlugin`, `EditorDebuggerPlugin`, `EditorDebuggerSession`, and `EngineDebugger`; the existing automation run request contract in `specs/003-editor-evidence-loop/contracts/automation-run-request.schema.json`; editor bridge flow in `addons/agent_runtime_harness/editor/scenegraph_debugger_bridge.gd`; runtime session handling in `addons/agent_runtime_harness/runtime/scenegraph_runtime.gd`; manifest persistence in `addons/agent_runtime_harness/runtime/scenegraph_artifact_writer.gd`; artifact registry support in `tools/evidence/artifact-registry.ps1`  
+**Storage**: Run-scoped automation request and result JSON under project-local `harness/automation/`; run-scoped evidence bundles under project `res://evidence/...` output directories; fixed `trace.jsonl` colocated with the current run's manifest and related artifacts; feature planning artifacts under `specs/005-behavior-watch-sampling/`  
+**Testing**: Contract-fixture validation for request normalization and rejection without launching the game; deterministic Pong editor-evidence runs through the existing automation broker for bounded trace persistence; manifest validation with `pwsh ./tools/evidence/validate-evidence-manifest.ps1`; existing PowerShell regression suite with `pwsh ./tools/tests/run-tool-tests.ps1` when tool or schema helpers change; combined validation because the feature changes runtime-visible behavior and existing deterministic tool surfaces  
+**Target Platform**: Godot 4.x editor with the example project already open on the same machine as VS Code; Windows first, while keeping file and contract choices portable across normal editor platforms  
+**Project Type**: Editor addon plus runtime addon plus debugger-integration contract extension layered onto the current plugin-owned file broker  
+**Performance Goals**: Keep v1 bounded to selected targets and properties only, avoid full-scene continuous logging, support every-frame and every-N-frame sampling for a single Pong ball watch window without materially changing the deterministic playtest flow, and emit the final trace artifact and manifest reference within the spec target of 60 seconds after run completion  
+**Constraints**: Plugin-first only; no engine fork; no GDExtension unless addon and debugger surfaces prove insufficient; slice 1 and slice 2 only; absolute runtime node path selectors only; explicit start-frame offset plus bounded frame count; fixed `trace.jsonl`; no trigger windows, invariants, script probes, or always-on full-scene logging in v1; machine-readable outputs required; no stale artifact reuse across runs  
+**Scale/Scope**: Primarily touches `addons/agent_runtime_harness/editor/`, `addons/agent_runtime_harness/runtime/`, `addons/agent_runtime_harness/shared/`, `specs/003-editor-evidence-loop/contracts/`, feature-local contracts and design artifacts under `specs/005-behavior-watch-sampling/`, deterministic Pong fixtures under `examples/pong-testbed/`, and narrow evidence or test helpers under `tools/` if the manifest or request-validation surface needs extension
+
+## Reference Inputs
+
+- **Internal Docs**: `README.md`, `AGENTS.md`, `docs/AGENT_RUNTIME_HARNESS.md`, `docs/AGENT_TOOLING_FOUNDATION.md`, `docs/GODOT_PLUGIN_REFERENCES.md`, `docs/BEHAVIOR_CAPTURE_SLICES.md`, `specs/003-editor-evidence-loop/spec.md`, `specs/003-editor-evidence-loop/contracts/editor-evidence-loop-contract.md`, `specs/003-editor-evidence-loop/contracts/automation-run-request.schema.json`, `specs/003-editor-evidence-loop/contracts/automation-run-result.schema.json`, `specs/004-report-build-errors/plan.md`, `specs/005-behavior-watch-sampling/spec.md`, `addons/agent_runtime_harness/editor/scenegraph_debugger_bridge.gd`, `addons/agent_runtime_harness/runtime/scenegraph_runtime.gd`, `addons/agent_runtime_harness/runtime/scenegraph_artifact_writer.gd`, `addons/agent_runtime_harness/shared/inspection_constants.gd`, `tools/evidence/artifact-registry.ps1`, `tools/automation/request-editor-evidence-run.ps1`, `examples/pong-testbed/harness/inspection-run-config.json`, `examples/pong-testbed/harness/automation/requests/run-request.healthy.json`, `tools/evals/fixtures/001-agent-tooling-foundation/runtime-sample/trace.jsonl`
+- **External Docs**: Godot editor plugins overview, `EditorPlugin`, `EditorDebuggerPlugin`, `EditorDebuggerSession`, `EngineDebugger`, autoload singleton guidance, and scene tree basics as cited in the feature spec and `docs/GODOT_PLUGIN_REFERENCES.md`
+- **Source References**: No `../godot` source files were inspected for this plan. The current repository docs, contracts, fixtures, and addon surfaces were sufficient to define a plugin-first implementation path.
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+- [x] Plugin-first approach preserved: the plan stays inside the editor addon, runtime addon, debugger transport, and existing manifest workflow with no engine changes or native layer planned.
+- [x] Reference coverage complete: internal docs, external Godot references, and current repo source surfaces are cited for all key design decisions.
+- [x] Runtime evidence defined: the plan names the normalized applied-watch summary, fixed `trace.jsonl` artifact, and manifest artifact reference as the machine-readable product surface.
+- [x] Test loop defined: the plan uses deterministic request-fixture validation plus deterministic Pong editor-evidence runs and manifest validation.
+- [x] Reuse justified: the preferred path extends the existing automation request, session configuration, and manifest writer instead of creating a new broker or second evidence path.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/005-behavior-watch-sampling/
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── contracts/
+└── tasks.md
+```
+
+### Source Code (repository root)
+
+```text
+addons/
+└── agent_runtime_harness/
+    ├── editor/
+    ├── runtime/
+    └── shared/
+
+docs/
+├── AGENT_RUNTIME_HARNESS.md
+├── AGENT_TOOLING_FOUNDATION.md
+├── BEHAVIOR_CAPTURE_SLICES.md
+└── GODOT_PLUGIN_REFERENCES.md
+
+examples/
+└── pong-testbed/
+
+specs/
+└── 003-editor-evidence-loop/
+
+tools/
+├── automation/
+├── evidence/
+└── tests/
+```
+
+**Structure Decision**: Keep the implementation centered in `addons/agent_runtime_harness/` because request normalization, runtime sampling, and manifest persistence all belong to the same plugin-first control path already used for scenegraph capture. Extend `specs/003-editor-evidence-loop/contracts/automation-run-request.schema.json` for run-request integration, add slice-specific request and trace-row contracts under `specs/005-behavior-watch-sampling/contracts/`, use `examples/pong-testbed/` for deterministic watch-request fixtures and expected outputs, and touch `tools/evidence/` or `tools/tests/` only where manifest or schema validation needs narrow updates.
+
+## Implementation Alternatives
+
+### Preferred V1 Path: Extend the current automation request, session configuration, and manifest flow
+
+- Carry `behaviorWatchRequest` through the existing automation run request as a run-scoped override.
+- Normalize the watch request before capture begins and expose the applied-watch summary in run metadata and the persisted evidence bundle.
+- Sample only requested targets and properties inside the runtime addon during the configured watch window.
+- Persist a fixed `trace.jsonl` next to the current run's manifest and add a `trace` artifact reference to that manifest.
+
+### Alternative 1: Create a separate behavior-capture broker or second request path
+
+- A dedicated request file or IPC path could isolate behavior capture from scenegraph automation.
+- This is rejected for v1 because it would split the autonomous run contract and create a second evidence entrypoint for the agent.
+
+### Alternative 2: Record full-scene per-frame state and filter later
+
+- Buffering the whole scene each frame would delay target selection to persistence time.
+- This is rejected for v1 because it breaks the low-overhead requirement and broadens capture far beyond slice 1 and slice 2.
+
+### Alternative 3: Stream watch samples live to the editor and treat the stream as the primary surface
+
+- A live-only debugger stream could avoid local runtime buffering.
+- This is rejected for v1 because it weakens deterministic bounded capture and makes persisted post-run evidence secondary instead of primary.
+
+### Escalation Paths Not Planned For V1
+
+- GDExtension is not planned unless addon and debugger surfaces prove unable to sample the bounded watch set with acceptable overhead.
+- Engine changes remain out of scope unless documented addon, autoload, debugger, and GDExtension options are shown insufficient with cited evidence.
+
+## Phase 0: Research Focus
+
+1. Confirm the smallest extension to the existing automation run request that can carry a behavior watch request without inventing a new command surface.
+2. Confirm where normalization should occur so unsupported selectors, fields, and zero-sample windows fail before capture begins.
+3. Confirm how `trace.jsonl` should be persisted and referenced from the current manifest-centered evidence bundle with no stale-output ambiguity.
+4. Confirm the flat trace-row contract by reusing the existing runtime-sample `trace.jsonl` fixture shape where it already fits.
+5. Confirm the deterministic validation shape for valid and invalid watch requests plus bounded Pong watch runs through the current automation flow.
+
+## Phase 1: Design Focus
+
+1. Design the `behaviorWatchRequest` contract, including absolute runtime node paths, watched property lists, cadence, start-frame offset, bounded frame count, and rejected later-slice fields.
+2. Design the normalized applied-watch summary and the validation rules that make defaults and unsupported-field failures explicit.
+3. Design the runtime sampler and the flat `trace.jsonl` row contract, including frame, timestamp, node path, and watched movement fields.
+4. Design the manifest integration, artifact registration, and stale-artifact protections needed so the current run's manifest points to the current run's trace only.
+5. Design deterministic request fixtures, Pong runtime verification fixtures, and quickstart instructions that prove slice 1 and slice 2 without depending on later-slice trigger or invariant machinery.
+
+## Post-Design Constitution Check
+
+- [x] Plugin-first approach preserved after design: the preferred path still relies on the current editor addon, runtime addon, debugger bridge, and manifest writer only.
+- [x] Reference coverage remains complete after design: plan decisions continue to map back to repo docs, contracts, fixtures, and cited Godot references.
+- [x] Runtime evidence remains the product surface: agents still read the run result and persisted manifest first, then open `trace.jsonl` from the manifest reference.
+- [x] Test loop remains defined after design: deterministic request-fixture validation and deterministic Pong watch runs remain the proof path.
+- [x] Reuse remains justified after design: the feature stays an incremental extension of the current automation request and evidence bundle instead of a parallel subsystem.
+
+## Phase 2 Preview
+
+Expected tasks will group into:
+
+1. Request contract and normalization: extend the run-request schema, add the slice-specific watch contract, and implement normalization plus rejection rules.
+2. Runtime sampling: add the bounded sampler, track watch-window progress, and collect flat per-sample rows for the requested node paths and fields only.
+3. Artifact persistence: write `trace.jsonl`, update the manifest artifact references, and expose the applied-watch summary for the current run.
+4. Deterministic validation: add valid and invalid request fixtures, add deterministic Pong watch-run fixtures, and verify bounded trace output plus manifest correctness.
+5. Supporting docs and tooling: update feature-local contracts and quickstart material, and extend narrow evidence or test helpers only where validation requires it.
+
+## Complexity Tracking
+
+No constitution violations are expected. The preferred path deliberately stays narrow: reuse the current automation request surface, extend the current manifest-centered bundle, and add only the contract and runtime pieces required for bounded watch sampling in slices 1 and 2.

--- a/specs/005-behavior-watch-sampling/quickstart.md
+++ b/specs/005-behavior-watch-sampling/quickstart.md
@@ -1,0 +1,96 @@
+# Quickstart: Behavior Watch Sampling
+
+## Goal
+
+Implement a plugin-first bounded watch-sampling flow that lets an agent request a normalized watch contract for selected runtime nodes, persist a fixed `trace.jsonl` artifact for the current run, and inspect that trace through the existing manifest-centered evidence bundle.
+
+## Implementation Outline
+
+1. Extend the current automation run request so a run-scoped `behaviorWatchRequest` can be passed without creating a second broker entrypoint.
+2. Normalize and validate that watch request before sampling begins, rejecting unsupported selectors, later-slice fields, or zero-sample windows with machine-readable errors.
+3. Sample only the requested node paths and requested properties during the bounded watch window, using every-frame or every-N-frame cadence.
+4. Persist a fixed `trace.jsonl` file in the current run's output directory and add a `trace` artifact reference to the current manifest.
+5. Reuse the current run-result and manifest-first workflow so agents can inspect the run result, then the manifest, then the trace artifact.
+
+## Primary Source Areas
+
+- `addons/agent_runtime_harness/editor/scenegraph_debugger_bridge.gd`
+- `addons/agent_runtime_harness/runtime/scenegraph_runtime.gd`
+- `addons/agent_runtime_harness/runtime/scenegraph_artifact_writer.gd`
+- `addons/agent_runtime_harness/shared/inspection_constants.gd`
+- `specs/003-editor-evidence-loop/contracts/automation-run-request.schema.json`
+- `specs/005-behavior-watch-sampling/contracts/behavior-watch-request.schema.json`
+- `specs/005-behavior-watch-sampling/contracts/behavior-trace-row.schema.json`
+- `tools/evidence/artifact-registry.ps1`
+
+## Example Request Shape
+
+Add a run-scoped watch request to an existing automation request fixture:
+
+```json
+{
+  "requestId": "pong-request-watch-001",
+  "scenarioId": "pong-behavior-watch",
+  "runId": "pong-watch-run-001",
+  "targetScene": "res://scenes/main.tscn",
+  "outputDirectory": "res://evidence/automation/pong-watch-run-001",
+  "artifactRoot": "examples/pong-testbed/evidence/automation/pong-watch-run-001",
+  "expectationFiles": [],
+  "capturePolicy": {
+    "startup": true,
+    "manual": true,
+    "failure": true
+  },
+  "stopPolicy": {
+    "stopAfterValidation": true
+  },
+  "requestedBy": "behavior-watch-fixture",
+  "createdAt": "2026-04-14T00:00:00Z",
+  "overrides": {
+    "behaviorWatchRequest": {
+      "targets": [
+        {
+          "nodePath": "/root/Main/Ball",
+          "properties": ["position", "velocity", "collisionState", "lastCollider"]
+        }
+      ],
+      "cadence": {
+        "mode": "every_frame"
+      },
+      "startFrameOffset": 0,
+      "frameCount": 180
+    }
+  }
+}
+```
+
+## Recommended Validation Flow
+
+1. Validate request fixtures for one valid Pong watch request and at least one invalid request that proves unsupported selectors or fields are rejected before a playtest starts.
+2. Run the existing capability check for the example project:
+
+```powershell
+pwsh ./tools/automation/get-editor-evidence-capability.ps1 -ProjectRoot examples/pong-testbed
+```
+
+3. Submit a run request through the existing automation helper:
+
+```powershell
+pwsh ./tools/automation/request-editor-evidence-run.ps1 -ProjectRoot examples/pong-testbed -RequestFixturePath examples/pong-testbed/harness/automation/requests/behavior-watch-wall-bounce.json
+```
+
+4. Read `harness/automation/results/run-result.json` first. If the run completed and produced a manifest, open the persisted `evidence-manifest.json`.
+5. Confirm the manifest references `trace.jsonl` for the current run and that `trace.jsonl` contains only the requested fields for `/root/Main/Ball`.
+6. Validate the manifest and referenced files:
+
+```powershell
+pwsh ./tools/evidence/validate-evidence-manifest.ps1 -ManifestPath <manifest-path>
+pwsh ./tools/tests/run-tool-tests.ps1
+```
+
+## Expected Outcomes
+
+- Valid watch requests normalize into an applied-watch summary before sampling starts.
+- Invalid watch requests fail with a machine-readable rejection and do not start capture.
+- Successful watch runs persist a fixed `trace.jsonl` file for the current run only.
+- The current run manifest references the trace artifact, and the agent can inspect it without reading unrelated full-scene logs.

--- a/specs/005-behavior-watch-sampling/quickstart.md
+++ b/specs/005-behavior-watch-sampling/quickstart.md
@@ -7,7 +7,7 @@ Implement a plugin-first bounded watch-sampling flow that lets an agent request 
 ## Implementation Outline
 
 1. Extend the current automation run request so a run-scoped `behaviorWatchRequest` can be passed without creating a second broker entrypoint.
-2. Normalize and validate that watch request before sampling begins, rejecting unsupported selectors, later-slice fields, or zero-sample windows with machine-readable errors.
+2. Normalize and validate that watch request before sampling begins, defaulting omitted cadence to `every_frame` and omitted `startFrameOffset` to `0`, while still rejecting unsupported selectors, later-slice fields, or zero-sample windows with machine-readable errors.
 3. Sample only the requested node paths and requested properties during the bounded watch window, using every-frame or every-N-frame cadence.
 4. Persist a fixed `trace.jsonl` file in the current run's output directory and add a `trace` artifact reference to the current manifest.
 5. Reuse the current run-result and manifest-first workflow so agents can inspect the run result, then the manifest, then the trace artifact.
@@ -76,11 +76,13 @@ pwsh ./tools/automation/get-editor-evidence-capability.ps1 -ProjectRoot examples
 3. Submit a run request through the existing automation helper:
 
 ```powershell
-pwsh ./tools/automation/request-editor-evidence-run.ps1 -ProjectRoot examples/pong-testbed -RequestFixturePath examples/pong-testbed/harness/automation/requests/behavior-watch-wall-bounce.json
+pwsh ./tools/automation/request-editor-evidence-run.ps1 -ProjectRoot examples/pong-testbed -RequestFixturePath examples/pong-testbed/harness/automation/requests/behavior-watch-wall-bounce.every-frame.json
 ```
 
+If you want to compose a watch fragment onto an existing healthy run fixture instead of using a precomposed request file, pass `-BehaviorWatchRequestFixturePath examples/pong-testbed/harness/automation/requests/behavior-watch-valid.json`.
+
 4. Read `harness/automation/results/run-result.json` first. If the run completed and produced a manifest, open the persisted `evidence-manifest.json`.
-5. Confirm the manifest references `trace.jsonl` for the current run and that `trace.jsonl` contains only the requested fields for `/root/Main/Ball`.
+5. Confirm the manifest references `trace.jsonl` for the current run, exposes the normalized `appliedWatch` summary for that run, and that `trace.jsonl` contains only the requested fields for `/root/Main/Ball`.
 6. Validate the manifest and referenced files:
 
 ```powershell
@@ -93,4 +95,4 @@ pwsh ./tools/tests/run-tool-tests.ps1
 - Valid watch requests normalize into an applied-watch summary before sampling starts.
 - Invalid watch requests fail with a machine-readable rejection and do not start capture.
 - Successful watch runs persist a fixed `trace.jsonl` file for the current run only.
-- The current run manifest references the trace artifact, and the agent can inspect it without reading unrelated full-scene logs.
+- The current run manifest references the trace artifact, includes the normalized `appliedWatch` summary, and lets the agent inspect the trace without reading unrelated full-scene logs.

--- a/specs/005-behavior-watch-sampling/research.md
+++ b/specs/005-behavior-watch-sampling/research.md
@@ -1,0 +1,56 @@
+# Research: Behavior Watch Sampling
+
+## Decision 1: Reuse the existing automation run request and debugger-backed session configuration
+
+- **Decision**: Carry the v1 behavior watch request through the current automation run request as a run-scoped override and deliver it through the existing `configure_session` debugger message.
+- **Rationale**: `specs/003-editor-evidence-loop/contracts/automation-run-request.schema.json` already provides a stable run-scoped override surface, and `addons/agent_runtime_harness/editor/scenegraph_debugger_bridge.gd` plus `addons/agent_runtime_harness/runtime/scenegraph_runtime.gd` already exchange session context dictionaries over the debugger bridge. Extending that path keeps the watch request aligned with the current run identity and avoids creating a second control surface.
+- **Alternatives considered**:
+  - Separate behavior-capture broker or request file: rejected because it would split the autonomous run contract.
+  - Standalone debugger command for watch setup: rejected because it separates normalization from the existing run-scoped session configuration.
+
+## Decision 2: Normalize the watch request into an applied-watch summary before sampling starts
+
+- **Decision**: Validate and normalize the watch request before sampling begins, producing an applied-watch summary with explicit defaults for cadence, start-frame offset, bounded frame count, and fixed output semantics.
+- **Rationale**: The clarified spec requires invalid selectors, unsupported later-slice fields, and zero-sample windows to fail before capture. Normalizing once per run creates the machine-readable applied-watch summary the agent must be able to inspect and avoids hidden runtime defaults.
+- **Alternatives considered**:
+  - Editor-only normalization: rejected because runtime surfaces still need the normalized contract and would duplicate validation logic.
+  - Partial acceptance of mixed valid and invalid fields: rejected because the spec requires the full request to fail decisively instead of changing the debugging question.
+
+## Decision 3: Persist a fixed `trace.jsonl` in the current run's evidence bundle and reference it from the same manifest
+
+- **Decision**: Write a fixed `trace.jsonl` file inside the current run's output directory and add a `trace` artifact reference to the same manifest-centered evidence bundle already used for runtime artifacts.
+- **Rationale**: `tools/evidence/artifact-registry.ps1` already registers `trace` with `trace.jsonl`, and the existing runtime sample fixture under `tools/evals/fixtures/001-agent-tooling-foundation/runtime-sample/trace.jsonl` shows the flat JSONL row shape the repo already expects. Reusing the current manifest path keeps the agent on one manifest-first workflow.
+- **Alternatives considered**:
+  - Separate behavior-only manifest or evidence directory: rejected because it would create a second post-run evidence path for the agent.
+  - Configurable `trace.json` versus `trace.jsonl`: rejected because the clarified spec fixes the artifact contract to `trace.jsonl`.
+
+## Decision 4: Keep the trace row format flat and agent-readable
+
+- **Decision**: Plan around flat JSONL rows with `frame`, `timestampMs`, `nodePath`, and the watched fields at the top level rather than nesting sampled properties under opaque blobs.
+- **Rationale**: The existing runtime sample trace fixture already uses this shape, and the spec explicitly prefers explicit fields over opaque blobs. Flat rows are easier for agents to inspect and for schemas or validators to reason about.
+- **Alternatives considered**:
+  - Nested `sampledProperties` objects: rejected because they add one more layer of indirection without helping bounded single-target diagnosis.
+  - Full-scene frame snapshots filtered post-run: rejected because they violate the low-overhead bounded-watch goal.
+
+## Decision 5: Validate the feature with contract fixtures plus deterministic Pong automation runs
+
+- **Decision**: Use a two-layer validation path: fixture-driven request validation without a playtest for slice 1, then deterministic Pong automation runs through the existing editor-evidence loop for slice 2.
+- **Rationale**: This preserves the constitution's test-backed loop while keeping validation aligned to the two feature slices. Valid and invalid watch-request fixtures prove normalization and rejection behavior, while deterministic Pong runs prove bounded sampling, manifest integration, and stale-artifact safety.
+- **Alternatives considered**:
+  - Manual editor checks only: rejected because they do not produce repeatable agent-readable proof.
+  - Schema-only validation without runtime runs: rejected because it would not prove the sampler or manifest flow.
+
+## Decision 6: Use run-scoped output directories and manifest validation to prevent stale trace reuse
+
+- **Decision**: Treat run-scoped output directories and manifest validation as the primary stale-artifact safety mechanism for v1.
+- **Rationale**: The existing automation request flow already uses per-run `outputDirectory` and `artifactRoot` values. Keeping `trace.jsonl` in that run-scoped output and validating the manifest against the current run keeps stale traces from satisfying a new request accidentally.
+- **Alternatives considered**:
+  - Reusing a shared `latest` trace file across runs: rejected because it risks misattributing stale output to the current run.
+  - Destructive global cleanup before every run: rejected because run-scoped output directories already provide safer provenance.
+
+## Implementation Notes
+
+- The current automation request should remain the entrypoint; the new watch contract becomes an additive extension rather than a new command surface.
+- `addons/agent_runtime_harness/runtime/scenegraph_runtime.gd` already owns session configuration and persistence handoff, making it the natural place to initialize and expose normalized watch state.
+- `addons/agent_runtime_harness/runtime/scenegraph_artifact_writer.gd` already builds artifact references into `evidence-manifest.json`, so the trace artifact should be added there rather than through a second manifest writer for v1.
+- The existing Pong testbed already provides stable `/root/Main/Ball` identity and run-request fixtures that make deterministic bounded sampling validation practical.

--- a/specs/005-behavior-watch-sampling/research.md
+++ b/specs/005-behavior-watch-sampling/research.md
@@ -54,3 +54,10 @@
 - `addons/agent_runtime_harness/runtime/scenegraph_runtime.gd` already owns session configuration and persistence handoff, making it the natural place to initialize and expose normalized watch state.
 - `addons/agent_runtime_harness/runtime/scenegraph_artifact_writer.gd` already builds artifact references into `evidence-manifest.json`, so the trace artifact should be added there rather than through a second manifest writer for v1.
 - The existing Pong testbed already provides stable `/root/Main/Ball` identity and run-request fixtures that make deterministic bounded sampling validation practical.
+
+## Validation Notes
+
+- `pwsh ./tools/tests/run-tool-tests.ps1` passed after the behavior-watch request schema, request helper, fixtures, manifests, and PowerShell regression coverage were updated.
+- `pwsh ./tools/evidence/validate-evidence-manifest.ps1 -ManifestPath examples/pong-testbed/evidence/automation/pong-behavior-watch-wall-bounce-every-frame/evidence-manifest.json` passed for the seeded behavior-watch bundle.
+- `pwsh ./tools/automation/request-editor-evidence-run.ps1 -ProjectRoot examples/pong-testbed -RequestFixturePath examples/pong-testbed/harness/automation/requests/behavior-watch-wall-bounce.every-frame.json -PassThru` wrote a schema-valid broker request artifact for the example project.
+- `pwsh ./tools/automation/get-editor-evidence-capability.ps1 -ProjectRoot examples/pong-testbed` reported that no live `harness/automation/results/capability.json` artifact was present from this checkout, so full runtime verification stayed blocked until an editor session publishes capability and run-result artifacts.

--- a/specs/005-behavior-watch-sampling/spec.md
+++ b/specs/005-behavior-watch-sampling/spec.md
@@ -1,0 +1,156 @@
+# Feature Specification: Behavior Watch Sampling
+
+**Feature Branch**: `[005-add-behavior-capture]`  
+**Created**: 2026-04-14  
+**Status**: Draft  
+**Input**: User description: "Build a plugin-first runtime behavior capture feature for the Godot Agent Harness that lets an agent request bounded watch sampling for specific runtime nodes and properties during an editor-launched playtest. Record a low-overhead time-series trace for selected targets such as the Pong ball, capturing fields like position, velocity, collision state, and related movement data every frame or every N frames over a defined window instead of logging the whole scene continuously. Persist the output as a stable machine-readable trace artifact that fits into the existing manifest-centered evidence bundle. Use docs\BEHAVIOR_CAPTURE_SLICES.md as a reference and focus on slice 1 and slice 2 only."
+
+## Clarifications
+
+### Session 2026-04-14
+
+- Q: Which watch-target selector shape should the first release support? → A: Absolute runtime node paths only.
+- Q: What should the first-release persisted trace artifact contract be? → A: A fixed `trace.jsonl` artifact referenced from the manifest.
+- Q: How should the bounded watch window be defined in the first release? → A: Use an explicit start-frame offset plus a bounded frame count.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Declare A Bounded Watch Request (Priority: P1)
+
+As a coding agent, I want to declare exactly which runtime nodes, properties, sampling cadence, and capture window to observe so the harness records only the behavior evidence relevant to my debugging question.
+
+**Why this priority**: The targeted trace cannot be trusted or kept low-overhead unless the request contract is explicit, normalized, and rejected decisively when it asks for unsupported scope.
+
+**Independent Test**: Validate one seeded Pong watch request and one invalid request without starting a playtest. Confirm the valid request is normalized into explicit defaults for cadence, start-frame offset, and bounded frame count, and the invalid request fails with a machine-readable reason that identifies the unsupported selector, property, or unbounded request field.
+
+**Acceptance Scenarios**:
+
+1. **Given** a valid watch request for `/root/Main/Ball` with selected movement properties, **When** the harness prepares the next editor-launched playtest, **Then** it records an explicit normalized request that names the watched targets, watched properties, cadence, start-frame offset, and bounded frame count for that run.
+2. **Given** a request omits optional cadence or watch-window values, **When** the request is normalized, **Then** the harness fills in explicit bounded defaults for the start-frame offset and bounded frame count instead of relying on implicit runtime behavior.
+3. **Given** a request asks for an unsupported selector, property, trigger, invariant, or unbounded full-scene capture mode, **When** the request is validated, **Then** the harness rejects it before the run begins with a machine-readable unsupported reason.
+
+---
+
+### User Story 2 - Persist A Targeted Time-Series Trace (Priority: P2)
+
+As a coding agent, I want the harness to sample only the selected properties for selected runtime nodes over a bounded frame window so I can inspect time-based behavior such as sticking, sliding, or failed bounce reversal without paying the cost of continuous whole-scene logging.
+
+**Why this priority**: The trace artifact is the first runtime evidence that can explain motion bugs over time. Without it, the harness still depends on coarse snapshots or human retellings of how gameplay evolved.
+
+**Independent Test**: Run a deterministic Pong wall-bounce playtest with a watch request for `/root/Main/Ball` that samples position, velocity, collision state, last collider, and related movement data at every frame and at every N frames in separate runs. Confirm the persisted trace artifact contains only the selected target and fields, stays within the requested start-frame offset and bounded frame-count window, and is referenced from the current evidence bundle.
+
+**Acceptance Scenarios**:
+
+1. **Given** a valid watch request is attached to an editor-launched playtest, **When** the configured capture window runs, **Then** the harness writes a machine-readable time-series trace containing frame, timestamp, target identity, and the requested watched properties for the selected nodes only.
+2. **Given** a watch request uses every N frames sampling, **When** the run completes, **Then** the trace rows reflect the requested cadence and do not exceed the configured start-frame offset and bounded frame count.
+3. **Given** a requested node never becomes available or produces no samples during the configured window, **When** the run completes, **Then** the outcome reports that gap explicitly instead of silently expanding to unrelated nodes or producing a misleading full-scene trace.
+
+---
+
+### User Story 3 - Keep Evidence Manifest-Centered (Priority: P3)
+
+As a harness maintainer, I want targeted behavior sampling to fit the existing manifest-centered evidence bundle so agents can read the manifest first and then open the trace artifact directly instead of learning a second post-run evidence path.
+
+**Why this priority**: The repository already treats the manifest as the machine-readable handoff contract. Preserving that flow keeps behavior capture additive and easier for agents to consume.
+
+**Independent Test**: Persist a completed watch-sampling run and verify the resulting evidence bundle exposes the current trace artifact as a first-class manifest entry, points to the applied watch scope, and does not report a stale trace from an earlier run as the result of the current playtest.
+
+**Acceptance Scenarios**:
+
+1. **Given** a targeted watch run completes successfully, **When** the evidence bundle is written, **Then** the manifest references the trace artifact and provides enough summary context for an agent to identify it as the next file to inspect.
+2. **Given** a targeted watch run fails before persistence, **When** the agent reads the run outcome, **Then** the missing current trace artifact is reported explicitly instead of implying that one was written.
+3. **Given** an earlier run already left a trace artifact in the output location, **When** a new watched run executes, **Then** the harness reports only the trace produced for the current run and never attributes stale trace output to the new run.
+
+### Edge Cases
+
+- A request mixes valid and invalid watch targets or properties; the harness should reject the entire request rather than apply a partial watch set that changes the debugging question.
+- A request defines a sampling interval or watch window that yields zero eligible samples; the harness should reject the request as invalid instead of writing an empty success artifact.
+- A watched node is instanced after the playtest starts; the trace should begin when the node first becomes available and still respect the configured end boundary.
+- A watched property is unavailable on a selected node for the entire run; the outcome should identify that unsupported property explicitly.
+- The configured watch window ends before the behavior of interest happens; the run should still produce a bounded trace that makes the missing evidence clear.
+- A prior run already wrote `trace.jsonl`; the new run must not reuse that older file as the current run's evidence.
+
+## References *(mandatory)*
+
+### Internal References
+
+- README.md
+- AGENTS.md
+- docs/AGENT_RUNTIME_HARNESS.md
+- docs/AGENT_TOOLING_FOUNDATION.md
+- docs/GODOT_PLUGIN_REFERENCES.md
+- docs/BEHAVIOR_CAPTURE_SLICES.md
+- specs/003-editor-evidence-loop/spec.md
+- specs/004-report-build-errors/spec.md
+- addons/agent_runtime_harness/editor/scenegraph_debugger_bridge.gd
+- addons/agent_runtime_harness/shared/inspection_constants.gd
+- tools/evidence/artifact-registry.ps1
+
+### External References
+
+- Godot editor plugins overview: https://docs.godotengine.org/en/stable/tutorials/plugins/editor/index.html
+- Godot EditorPlugin class reference: https://docs.godotengine.org/en/stable/classes/class_editorplugin.html
+- Godot EditorDebuggerPlugin class reference: https://docs.godotengine.org/en/stable/classes/class_editordebuggerplugin.html
+- Godot EditorDebuggerSession class reference: https://docs.godotengine.org/en/stable/classes/class_editordebuggersession.html
+- Godot EngineDebugger class reference: https://docs.godotengine.org/en/stable/classes/class_enginedebugger.html
+- Godot autoload singletons guide: https://docs.godotengine.org/en/stable/tutorials/scripting/singletons_autoload.html
+- Godot scene tree basics: https://docs.godotengine.org/en/stable/tutorials/scripting/scene_tree.html
+
+### Source References
+
+- No `../godot` source files were inspected for this specification; the current scope is grounded in repository documentation plus the existing plugin-first runtime transport and evidence bundle contracts already present in this repository.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: System MUST allow an agent to submit a machine-readable behavior watch request as session configuration or per-run override data for an editor-launched playtest.
+- **FR-002**: System MUST allow a behavior watch request to identify one or more runtime watch targets by absolute runtime node path and the explicit property list to sample for each target.
+- **FR-003**: System MUST allow a behavior watch request to define a bounded sampling cadence using either every-frame sampling or every-N-frames sampling.
+- **FR-004**: System MUST allow a behavior watch request to define a bounded watch window using an explicit start-frame offset plus a bounded frame count for the run.
+- **FR-005**: System MUST normalize every valid behavior watch request before capture begins so default cadence, start-frame offset, bounded frame count, and persistence values are explicit in run metadata.
+- **FR-006**: System MUST persist or expose an applied-watch summary that tells the agent which normalized request the harness actually used for the run.
+- **FR-007**: System MUST reject unsupported selectors, including any selector form other than an absolute runtime node path, properties, cadences, zero-sample windows, or other invalid request fields with explicit machine-readable errors before the playtest begins.
+- **FR-008**: System MUST reject request fields that belong to later behavior-capture slices, including trigger-driven persistence, invariant evaluation, script probes, or open-ended full-scene capture, with a machine-readable unsupported reason instead of partially executing them.
+- **FR-009**: System MUST sample only the requested targets and requested properties during the active watch window and MUST NOT silently expand capture to unrelated nodes or unrelated fields.
+- **FR-010**: System MUST support watched movement-oriented fields needed for Pong-style bounce diagnosis, including position, velocity, collision state, and related movement data when those fields are available on the selected target.
+- **FR-011**: System MUST record each captured sample with stable machine-readable fields that include at minimum the current run identity, frame number, timestamp, watched target identity, and the requested property values for that row.
+- **FR-012**: System MUST persist the sampled output as a fixed `trace.jsonl` artifact for the run using an agent-readable row format suitable for post-run inspection.
+- **FR-013**: System MUST keep watch sampling low-overhead and bounded by honoring the configured cadence and end boundary instead of recording continuous full-scene per-frame data.
+- **FR-014**: System MUST report when a requested target or property produced no samples so the agent can distinguish missing evidence from a clean behavior run.
+- **FR-015**: System MUST fit the targeted watch trace into the existing manifest-centered evidence bundle and MUST reference the current run's `trace.jsonl` artifact from the persisted manifest.
+- **FR-016**: System MUST prevent stale trace output from an earlier run from being reported as the evidence for the current run.
+- **FR-017**: System MUST keep the first release explicitly scoped to slice 1 and slice 2 of `docs/BEHAVIOR_CAPTURE_SLICES.md`.
+- **FR-018**: System MUST keep the first release scoped to editor-launched playtests with the harness already installed and MUST NOT require packaged builds or engine-fork changes.
+- **FR-019**: System MUST describe and justify the supported plugin-first extension points used for this feature, with the first release staying inside the editor plugin or addon, runtime addon plus autoload, and debugger messaging layers unless those surfaces cannot satisfy the bounded watch outcomes.
+- **FR-020**: System MUST emit or identify the machine-readable artifacts agents inspect to validate the feature, including the normalized watch scope, the persisted `trace.jsonl` artifact, and the manifest entry that points to that trace for the current run.
+
+### Key Entities *(include if feature involves data)*
+
+- **Behavior Watch Request**: The run-scoped machine-readable request that declares watch targets, watched properties, cadence, explicit start-frame offset, bounded frame count, and other in-scope options for slices 1 and 2.
+- **Watch Target**: One selected runtime node identified by an absolute runtime node path plus the explicit list of properties to sample for that target.
+- **Applied Watch Summary**: The normalized representation of the watch request that the harness associates with the run and exposes to the agent before or with the resulting evidence.
+- **Trace Sample Row**: One machine-readable time-series entry containing run identity, frame number, timestamp, target identity, and the watched property values collected at that point.
+- **Behavior Trace Artifact**: The persisted bounded `trace.jsonl` file for the current run plus its manifest reference within the evidence bundle.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: In 100% of seeded valid watch-request fixtures, the harness produces an explicit applied-watch summary before the playtest begins, and in 100% of invalid fixtures it returns a machine-readable rejection without starting capture.
+- **SC-002**: In 100% of seeded Pong wall-bounce validation runs for this feature, the current run produces a bounded trace artifact linked from the current evidence bundle within 60 seconds of the playtest ending.
+- **SC-003**: In 100% of targeted watch validation runs, every persisted trace row includes frame number, timestamp, target identity, and only the explicitly requested watched fields.
+- **SC-004**: In 100% of every-N-frames validation runs, the trace never exceeds the configured bounded frame count or configured end boundary for the current request.
+- **SC-005**: In at least 90% of seeded sticky, sliding, or failed-reversal diagnostic exercises for Pong, an agent can identify the relevant behavior window from the manifest plus the targeted trace artifact within 5 minutes without opening a continuous whole-scene log.
+
+## Assumptions
+
+- This specification intentionally covers only slice 1 and slice 2 from `docs/BEHAVIOR_CAPTURE_SLICES.md`; triggered persistence windows, invariants, and script probes remain future work.
+- The first release targets a harness-enabled project that is already open in the Godot editor and can accept editor-launched playtest requests.
+- The watch request is run-scoped and can be supplied through existing session configuration or per-run override mechanisms rather than requiring a new manual editing step.
+- The first release supports absolute runtime node paths as the only watch-target selector form; relative-name and group-based selectors remain out of scope.
+- The first release always persists targeted sampling output as `trace.jsonl` and does not negotiate alternative trace file formats per request.
+- The first release defines the watch window relative to playtest frame 0 by using an explicit start-frame offset plus a bounded frame count; target appearance does not redefine the window.
+- If any requested target, property, or slice-later field is unsupported, the harness rejects the full request instead of silently downgrading to a partial watch set.
+- The first release only needs to capture node-state and related movement data that the harness can observe through existing plugin-first runtime surfaces; custom script-local decision variables remain out of scope until a later slice adds probe support.
+- The manifest-centered evidence bundle remains the primary post-run handoff, and the new trace artifact is additive to that existing contract rather than a replacement for it.

--- a/specs/005-behavior-watch-sampling/tasks.md
+++ b/specs/005-behavior-watch-sampling/tasks.md
@@ -1,0 +1,221 @@
+# Tasks: Behavior Watch Sampling
+
+**Input**: Design documents from `/specs/005-behavior-watch-sampling/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, quickstart.md, contracts/
+
+**Tests**: Every user story includes executable validation tasks using deterministic request fixtures, seeded Pong automation runs, manifest validation, and existing PowerShell regression surfaces that produce machine-readable results.
+
+**Organization**: Tasks are grouped by user story so the request-contract path, bounded trace-sampling path, and manifest-integration path can each be implemented and validated independently once the shared behavior-watch plumbing is ready.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel when file ownership does not overlap
+- **[Story]**: Which user story the task belongs to (`US1`, `US2`, `US3`)
+- All tasks include exact repository paths in the description
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Create the deterministic fixture and regression scaffolding needed for behavior-watch implementation work.
+
+- [ ] T001 Create behavior-watch request fixture scaffolding in `examples/pong-testbed/harness/automation/requests/behavior-watch-valid.json` and `examples/pong-testbed/harness/automation/requests/behavior-watch-invalid-selector.json`
+- [ ] T002 [P] Add behavior-watch regression grouping scaffolds in `tools/tests/ScenegraphAutomationLoop.Tests.ps1` and `tools/tests/AutomationTools.Tests.ps1`
+- [ ] T003 [P] Create behavior-watch expected-output scaffolding in `examples/pong-testbed/evidence/automation/` and `examples/pong-testbed/harness/automation/results/`
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Establish shared request, runtime, and artifact plumbing that all user stories depend on.
+
+**CRITICAL**: No user story work should begin until this phase is complete.
+
+- [ ] T004 Extend `specs/003-editor-evidence-loop/contracts/automation-run-request.schema.json` and `tools/automation/request-editor-evidence-run.ps1` to accept `overrides.behaviorWatchRequest`
+- [ ] T005 [P] Add shared behavior-watch constants and artifact metadata in `addons/agent_runtime_harness/shared/inspection_constants.gd` and `tools/evidence/artifact-registry.ps1`
+- [ ] T006 [P] Create the shared request-validation helper in `addons/agent_runtime_harness/shared/behavior_watch_request_validator.gd`
+- [ ] T007 [P] Add run-scoped watch-session plumbing in `addons/agent_runtime_harness/editor/scenegraph_run_coordinator.gd`, `addons/agent_runtime_harness/editor/scenegraph_debugger_bridge.gd`, and `addons/agent_runtime_harness/runtime/scenegraph_runtime.gd`
+
+**Checkpoint**: Shared behavior-watch plumbing is ready; story work can now proceed.
+
+---
+
+## Phase 3: User Story 1 - Declare A Bounded Watch Request (Priority: P1) MVP
+
+**Goal**: Let an agent submit a bounded behavior watch request that is normalized or rejected before a playtest begins.
+
+**Independent Test**: Validate one seeded Pong watch request and one invalid request without launching a playtest, and confirm the valid request produces explicit defaults while the invalid request returns a machine-readable rejection.
+
+### Validation for User Story 1
+
+- [ ] T008 [P] [US1] Add valid and invalid request fixtures in `examples/pong-testbed/harness/automation/requests/behavior-watch-valid.json`, `examples/pong-testbed/harness/automation/requests/behavior-watch-invalid-selector.json`, and `examples/pong-testbed/harness/automation/requests/behavior-watch-invalid-window.json`
+- [ ] T009 [P] [US1] Add normalization and rejection coverage in `tools/tests/ScenegraphAutomationLoop.Tests.ps1` and `tools/tests/AutomationTools.Tests.ps1` for unsupported selectors, later-slice fields, and zero-sample windows
+
+### Implementation for User Story 1
+
+- [ ] T010 [US1] Implement watch-request normalization defaults and rejection rules in `addons/agent_runtime_harness/shared/behavior_watch_request_validator.gd`
+- [ ] T011 [P] [US1] Publish invalid watch-request failures before playtest launch in `addons/agent_runtime_harness/editor/scenegraph_automation_broker.gd` and `addons/agent_runtime_harness/editor/scenegraph_automation_artifact_store.gd`
+- [ ] T012 [P] [US1] Expose the normalized applied-watch summary in `addons/agent_runtime_harness/editor/scenegraph_run_coordinator.gd` and `addons/agent_runtime_harness/runtime/scenegraph_runtime.gd`
+- [ ] T013 [US1] Align request-contract documentation and examples in `specs/005-behavior-watch-sampling/contracts/behavior-watch-contract.md` and `specs/005-behavior-watch-sampling/quickstart.md`
+
+**Checkpoint**: User Story 1 is complete when behavior-watch requests are deterministically normalized or rejected before runtime sampling starts.
+
+---
+
+## Phase 4: User Story 2 - Persist A Targeted Time-Series Trace (Priority: P2)
+
+**Goal**: Sample only the requested node paths and fields within the configured watch window and persist a bounded `trace.jsonl` artifact.
+
+**Independent Test**: Run deterministic Pong wall-bounce fixtures for every-frame and every-N-frame sampling and confirm the resulting trace contains only the requested Ball fields within the configured start-frame offset and bounded frame count.
+
+### Validation for User Story 2
+
+- [ ] T014 [P] [US2] Add deterministic Pong watch-run fixtures in `examples/pong-testbed/harness/automation/requests/behavior-watch-wall-bounce.every-frame.json` and `examples/pong-testbed/harness/automation/requests/behavior-watch-wall-bounce.every-n.json`
+- [ ] T015 [P] [US2] Add bounded-trace sampling coverage in `tools/tests/ScenegraphAutomationLoop.Tests.ps1` and `tools/tests/AutomationTools.Tests.ps1` for cadence, frame-window enforcement, requested-fields-only rows, and no-sample outcomes
+
+### Implementation for User Story 2
+
+- [ ] T016 [P] [US2] Implement bounded watch-sampling state in `addons/agent_runtime_harness/runtime/behavior_watch_sampler.gd`
+- [ ] T017 [US2] Wire start-frame offset and cadence enforcement into `addons/agent_runtime_harness/runtime/scenegraph_runtime.gd`
+- [ ] T018 [P] [US2] Implement flat `trace.jsonl` row serialization in `addons/agent_runtime_harness/runtime/behavior_trace_writer.gd`
+- [ ] T019 [US2] Persist the current run's `trace.jsonl` artifact through `addons/agent_runtime_harness/runtime/scenegraph_artifact_writer.gd` and `addons/agent_runtime_harness/runtime/behavior_trace_writer.gd`
+- [ ] T020 [US2] Report missing-target, missing-property, and no-sample outcomes in `addons/agent_runtime_harness/runtime/behavior_watch_sampler.gd` and `addons/agent_runtime_harness/editor/scenegraph_automation_artifact_store.gd`
+
+**Checkpoint**: User Story 2 is complete when a deterministic Pong run produces a bounded `trace.jsonl` artifact for the requested watch scope only.
+
+---
+
+## Phase 5: User Story 3 - Keep Evidence Manifest-Centered (Priority: P3)
+
+**Goal**: Keep behavior-watch output on the existing manifest-first evidence path and prevent stale traces from being misattributed to the current run.
+
+**Independent Test**: Persist a completed behavior-watch run and confirm the current manifest references the current run's `trace.jsonl`, exposes the applied-watch summary, and never points to stale trace output from a previous run.
+
+### Validation for User Story 3
+
+- [ ] T021 [P] [US3] Add expected manifest and result fixtures for behavior-watch runs in `examples/pong-testbed/evidence/automation/` and `examples/pong-testbed/harness/automation/results/`
+- [ ] T022 [P] [US3] Add manifest-reference and stale-trace regression coverage in `tools/tests/ScenegraphAutomationLoop.Tests.ps1` and `tools/tests/AutomationTools.Tests.ps1`
+
+### Implementation for User Story 3
+
+- [ ] T023 [US3] Register behavior-watch trace artifact metadata in `tools/evidence/artifact-registry.ps1` and `addons/agent_runtime_harness/shared/inspection_constants.gd`
+- [ ] T024 [US3] Add `trace.jsonl` artifact references and applied-watch summary output in `addons/agent_runtime_harness/runtime/scenegraph_artifact_writer.gd`
+- [ ] T025 [P] [US3] Align run-result-to-manifest handoff behavior in `addons/agent_runtime_harness/editor/scenegraph_automation_artifact_store.gd` and `addons/agent_runtime_harness/editor/scenegraph_run_coordinator.gd`
+- [ ] T026 [US3] Document manifest-first trace consumption in `docs/AGENT_TOOLING_FOUNDATION.md` and `specs/005-behavior-watch-sampling/contracts/behavior-watch-contract.md`
+
+**Checkpoint**: User Story 3 is complete when behavior-watch traces are consumed through the same manifest-centered evidence flow as the rest of the harness.
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+**Purpose**: Finish shared documentation, run full validation, and capture follow-up notes from the quickstart flow.
+
+- [ ] T027 [P] Update slice-1 and slice-2 guidance in `docs/BEHAVIOR_CAPTURE_SLICES.md` and `docs/AGENT_RUNTIME_HARNESS.md`
+- [ ] T028 Run `pwsh ./tools/tests/run-tool-tests.ps1` and fix regressions in `tools/tests/ScenegraphAutomationLoop.Tests.ps1`, `tools/tests/AutomationTools.Tests.ps1`, and any touched contracts
+- [ ] T029 [P] Run `pwsh ./tools/evidence/validate-evidence-manifest.ps1 -ManifestPath <generated-manifest>` against the behavior-watch fixture output and record notes in `specs/005-behavior-watch-sampling/research.md`
+- [ ] T030 [P] Execute the validation flow in `specs/005-behavior-watch-sampling/quickstart.md` against `examples/pong-testbed/` and record follow-up notes in `specs/005-behavior-watch-sampling/research.md`
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Phase 1: Setup**: No dependencies
+- **Phase 2: Foundational**: Depends on Phase 1 and blocks all user-story work
+- **Phase 3: User Story 1**: Depends on Phase 2 and delivers the MVP request-contract path
+- **Phase 4: User Story 2**: Depends on Phase 2 and can proceed independently once shared request and session plumbing exist
+- **Phase 5: User Story 3**: Depends on User Story 2 because manifest integration needs the trace artifact path to exist
+- **Phase 6: Polish**: Depends on all desired user stories being complete
+
+### User Story Dependencies
+
+- **US1**: No dependency on other user stories after Phase 2
+- **US2**: No dependency on US1 once the shared request schema, validator helper, and session plumbing from Phase 2 are in place
+- **US3**: Depends on US2 because manifest integration and stale-trace protection require the trace artifact produced there
+
+### Within Each User Story
+
+- Validation fixtures and regression checks should land before implementation tasks
+- Runtime artifact production must land with the story, not as a later cleanup step
+- A story is not complete until its machine-readable outputs and validation surfaces are updated together
+
+### Parallel Opportunities
+
+- T002 and T003 can run in parallel after T001 starts the fixture structure
+- T005, T006, and T007 can run in parallel after T004 defines the shared request extension
+- In US1, T008 and T009 can run in parallel; T011 and T012 can run in parallel after T010 begins the validator logic
+- In US2, T014 and T015 can run in parallel; T016 and T018 can run in parallel before T017 and T019 integrate them
+- In US3, T021 and T022 can run in parallel; T025 and T026 can run in parallel after T023 and T024 stabilize the artifact path
+- In Phase 6, T027, T029, and T030 can run in parallel after implementation stabilizes
+
+---
+
+## Parallel Example: User Story 1
+
+```text
+T008 Add valid and invalid request fixtures in examples/pong-testbed/harness/automation/requests/behavior-watch-valid.json, examples/pong-testbed/harness/automation/requests/behavior-watch-invalid-selector.json, and examples/pong-testbed/harness/automation/requests/behavior-watch-invalid-window.json
+T009 Add normalization and rejection coverage in tools/tests/ScenegraphAutomationLoop.Tests.ps1 and tools/tests/AutomationTools.Tests.ps1 for unsupported selectors, later-slice fields, and zero-sample windows
+```
+
+```text
+T011 Publish invalid watch-request failures before playtest launch in addons/agent_runtime_harness/editor/scenegraph_automation_broker.gd and addons/agent_runtime_harness/editor/scenegraph_automation_artifact_store.gd
+T012 Expose the normalized applied-watch summary in addons/agent_runtime_harness/editor/scenegraph_run_coordinator.gd and addons/agent_runtime_harness/runtime/scenegraph_runtime.gd
+```
+
+## Parallel Example: User Story 2
+
+```text
+T014 Add deterministic Pong watch-run fixtures in examples/pong-testbed/harness/automation/requests/behavior-watch-wall-bounce.every-frame.json and examples/pong-testbed/harness/automation/requests/behavior-watch-wall-bounce.every-n.json
+T015 Add bounded-trace sampling coverage in tools/tests/ScenegraphAutomationLoop.Tests.ps1 and tools/tests/AutomationTools.Tests.ps1 for cadence, frame-window enforcement, requested-fields-only rows, and no-sample outcomes
+```
+
+```text
+T016 Implement bounded watch-sampling state in addons/agent_runtime_harness/runtime/behavior_watch_sampler.gd
+T018 Implement flat trace.jsonl row serialization in addons/agent_runtime_harness/runtime/behavior_trace_writer.gd
+```
+
+## Parallel Example: User Story 3
+
+```text
+T021 Add expected manifest and result fixtures for behavior-watch runs in examples/pong-testbed/evidence/automation/ and examples/pong-testbed/harness/automation/results/
+T022 Add manifest-reference and stale-trace regression coverage in tools/tests/ScenegraphAutomationLoop.Tests.ps1 and tools/tests/AutomationTools.Tests.ps1
+```
+
+```text
+T025 Align run-result-to-manifest handoff behavior in addons/agent_runtime_harness/editor/scenegraph_automation_artifact_store.gd and addons/agent_runtime_harness/editor/scenegraph_run_coordinator.gd
+T026 Document manifest-first trace consumption in docs/AGENT_TOOLING_FOUNDATION.md and specs/005-behavior-watch-sampling/contracts/behavior-watch-contract.md
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Complete Phase 1: Setup
+2. Complete Phase 2: Foundational
+3. Complete Phase 3: User Story 1
+4. Validate request normalization and rejection independently without launching a playtest
+5. Stop and confirm the agent can author a deterministic bounded watch contract before building runtime sampling
+
+### Incremental Delivery
+
+1. Deliver the shared request and session plumbing
+2. Deliver User Story 1 and validate request normalization and rejection
+3. Deliver User Story 2 and validate bounded trace sampling
+4. Deliver User Story 3 and validate manifest-centered handoff and stale-trace protection
+5. Run polish validations and sync any remaining documentation
+
+### Parallel Team Strategy
+
+1. One contributor handles the shared request extension and validator scaffolding in Phase 2
+2. After Phase 2, one contributor can focus on request-validation UX while another prepares trace sampling fixtures
+3. Once trace persistence stabilizes, another contributor can complete manifest integration and guidance updates in parallel
+
+---
+
+## Notes
+
+- `[P]` means a task is safe to parallelize only when file ownership does not overlap
+- The clarified spec fixes the first release to absolute runtime node paths, explicit start-frame offset plus bounded frame count, and a fixed `trace.jsonl` artifact
+- Do not introduce later-slice trigger windows, invariants, probes, or full-scene continuous logging while implementing these tasks

--- a/specs/005-behavior-watch-sampling/tasks.md
+++ b/specs/005-behavior-watch-sampling/tasks.md
@@ -17,9 +17,9 @@
 
 **Purpose**: Create the deterministic fixture and regression scaffolding needed for behavior-watch implementation work.
 
-- [ ] T001 Create behavior-watch request fixture scaffolding in `examples/pong-testbed/harness/automation/requests/behavior-watch-valid.json` and `examples/pong-testbed/harness/automation/requests/behavior-watch-invalid-selector.json`
-- [ ] T002 [P] Add behavior-watch regression grouping scaffolds in `tools/tests/ScenegraphAutomationLoop.Tests.ps1` and `tools/tests/AutomationTools.Tests.ps1`
-- [ ] T003 [P] Create behavior-watch expected-output scaffolding in `examples/pong-testbed/evidence/automation/` and `examples/pong-testbed/harness/automation/results/`
+- [X] T001 Create behavior-watch request fixture scaffolding in `examples/pong-testbed/harness/automation/requests/behavior-watch-valid.json` and `examples/pong-testbed/harness/automation/requests/behavior-watch-invalid-selector.json`
+- [X] T002 [P] Add behavior-watch regression grouping scaffolds in `tools/tests/ScenegraphAutomationLoop.Tests.ps1` and `tools/tests/AutomationTools.Tests.ps1`
+- [X] T003 [P] Create behavior-watch expected-output scaffolding in `examples/pong-testbed/evidence/automation/` and `examples/pong-testbed/harness/automation/results/`
 
 ---
 
@@ -29,10 +29,10 @@
 
 **CRITICAL**: No user story work should begin until this phase is complete.
 
-- [ ] T004 Extend `specs/003-editor-evidence-loop/contracts/automation-run-request.schema.json` and `tools/automation/request-editor-evidence-run.ps1` to accept `overrides.behaviorWatchRequest`
-- [ ] T005 [P] Add shared behavior-watch constants and artifact metadata in `addons/agent_runtime_harness/shared/inspection_constants.gd` and `tools/evidence/artifact-registry.ps1`
-- [ ] T006 [P] Create the shared request-validation helper in `addons/agent_runtime_harness/shared/behavior_watch_request_validator.gd`
-- [ ] T007 [P] Add run-scoped watch-session plumbing in `addons/agent_runtime_harness/editor/scenegraph_run_coordinator.gd`, `addons/agent_runtime_harness/editor/scenegraph_debugger_bridge.gd`, and `addons/agent_runtime_harness/runtime/scenegraph_runtime.gd`
+- [X] T004 Extend `specs/003-editor-evidence-loop/contracts/automation-run-request.schema.json` and `tools/automation/request-editor-evidence-run.ps1` to accept `overrides.behaviorWatchRequest`
+- [X] T005 [P] Add shared behavior-watch constants and artifact metadata in `addons/agent_runtime_harness/shared/inspection_constants.gd` and `tools/evidence/artifact-registry.ps1`
+- [X] T006 [P] Create the shared request-validation helper in `addons/agent_runtime_harness/shared/behavior_watch_request_validator.gd`
+- [X] T007 [P] Add run-scoped watch-session plumbing in `addons/agent_runtime_harness/editor/scenegraph_run_coordinator.gd`, `addons/agent_runtime_harness/editor/scenegraph_debugger_bridge.gd`, and `addons/agent_runtime_harness/runtime/scenegraph_runtime.gd`
 
 **Checkpoint**: Shared behavior-watch plumbing is ready; story work can now proceed.
 
@@ -46,15 +46,15 @@
 
 ### Validation for User Story 1
 
-- [ ] T008 [P] [US1] Add valid and invalid request fixtures in `examples/pong-testbed/harness/automation/requests/behavior-watch-valid.json`, `examples/pong-testbed/harness/automation/requests/behavior-watch-invalid-selector.json`, and `examples/pong-testbed/harness/automation/requests/behavior-watch-invalid-window.json`
-- [ ] T009 [P] [US1] Add normalization and rejection coverage in `tools/tests/ScenegraphAutomationLoop.Tests.ps1` and `tools/tests/AutomationTools.Tests.ps1` for unsupported selectors, later-slice fields, and zero-sample windows
+- [X] T008 [P] [US1] Add valid and invalid request fixtures in `examples/pong-testbed/harness/automation/requests/behavior-watch-valid.json`, `examples/pong-testbed/harness/automation/requests/behavior-watch-invalid-selector.json`, and `examples/pong-testbed/harness/automation/requests/behavior-watch-invalid-window.json`
+- [X] T009 [P] [US1] Add normalization and rejection coverage in `tools/tests/ScenegraphAutomationLoop.Tests.ps1` and `tools/tests/AutomationTools.Tests.ps1` for unsupported selectors, later-slice fields, and zero-sample windows
 
 ### Implementation for User Story 1
 
-- [ ] T010 [US1] Implement watch-request normalization defaults and rejection rules in `addons/agent_runtime_harness/shared/behavior_watch_request_validator.gd`
-- [ ] T011 [P] [US1] Publish invalid watch-request failures before playtest launch in `addons/agent_runtime_harness/editor/scenegraph_automation_broker.gd` and `addons/agent_runtime_harness/editor/scenegraph_automation_artifact_store.gd`
-- [ ] T012 [P] [US1] Expose the normalized applied-watch summary in `addons/agent_runtime_harness/editor/scenegraph_run_coordinator.gd` and `addons/agent_runtime_harness/runtime/scenegraph_runtime.gd`
-- [ ] T013 [US1] Align request-contract documentation and examples in `specs/005-behavior-watch-sampling/contracts/behavior-watch-contract.md` and `specs/005-behavior-watch-sampling/quickstart.md`
+- [X] T010 [US1] Implement watch-request normalization defaults and rejection rules in `addons/agent_runtime_harness/shared/behavior_watch_request_validator.gd`
+- [X] T011 [P] [US1] Publish invalid watch-request failures before playtest launch in `addons/agent_runtime_harness/editor/scenegraph_automation_broker.gd` and `addons/agent_runtime_harness/editor/scenegraph_automation_artifact_store.gd`
+- [X] T012 [P] [US1] Expose the normalized applied-watch summary in `addons/agent_runtime_harness/editor/scenegraph_run_coordinator.gd` and `addons/agent_runtime_harness/runtime/scenegraph_runtime.gd`
+- [X] T013 [US1] Align request-contract documentation and examples in `specs/005-behavior-watch-sampling/contracts/behavior-watch-contract.md` and `specs/005-behavior-watch-sampling/quickstart.md`
 
 **Checkpoint**: User Story 1 is complete when behavior-watch requests are deterministically normalized or rejected before runtime sampling starts.
 
@@ -68,16 +68,16 @@
 
 ### Validation for User Story 2
 
-- [ ] T014 [P] [US2] Add deterministic Pong watch-run fixtures in `examples/pong-testbed/harness/automation/requests/behavior-watch-wall-bounce.every-frame.json` and `examples/pong-testbed/harness/automation/requests/behavior-watch-wall-bounce.every-n.json`
-- [ ] T015 [P] [US2] Add bounded-trace sampling coverage in `tools/tests/ScenegraphAutomationLoop.Tests.ps1` and `tools/tests/AutomationTools.Tests.ps1` for cadence, frame-window enforcement, requested-fields-only rows, and no-sample outcomes
+- [X] T014 [P] [US2] Add deterministic Pong watch-run fixtures in `examples/pong-testbed/harness/automation/requests/behavior-watch-wall-bounce.every-frame.json` and `examples/pong-testbed/harness/automation/requests/behavior-watch-wall-bounce.every-n.json`
+- [X] T015 [P] [US2] Add bounded-trace sampling coverage in `tools/tests/ScenegraphAutomationLoop.Tests.ps1` and `tools/tests/AutomationTools.Tests.ps1` for cadence, frame-window enforcement, requested-fields-only rows, and no-sample outcomes
 
 ### Implementation for User Story 2
 
-- [ ] T016 [P] [US2] Implement bounded watch-sampling state in `addons/agent_runtime_harness/runtime/behavior_watch_sampler.gd`
-- [ ] T017 [US2] Wire start-frame offset and cadence enforcement into `addons/agent_runtime_harness/runtime/scenegraph_runtime.gd`
-- [ ] T018 [P] [US2] Implement flat `trace.jsonl` row serialization in `addons/agent_runtime_harness/runtime/behavior_trace_writer.gd`
-- [ ] T019 [US2] Persist the current run's `trace.jsonl` artifact through `addons/agent_runtime_harness/runtime/scenegraph_artifact_writer.gd` and `addons/agent_runtime_harness/runtime/behavior_trace_writer.gd`
-- [ ] T020 [US2] Report missing-target, missing-property, and no-sample outcomes in `addons/agent_runtime_harness/runtime/behavior_watch_sampler.gd` and `addons/agent_runtime_harness/editor/scenegraph_automation_artifact_store.gd`
+- [X] T016 [P] [US2] Implement bounded watch-sampling state in `addons/agent_runtime_harness/runtime/behavior_watch_sampler.gd`
+- [X] T017 [US2] Wire start-frame offset and cadence enforcement into `addons/agent_runtime_harness/runtime/scenegraph_runtime.gd`
+- [X] T018 [P] [US2] Implement flat `trace.jsonl` row serialization in `addons/agent_runtime_harness/runtime/behavior_trace_writer.gd`
+- [X] T019 [US2] Persist the current run's `trace.jsonl` artifact through `addons/agent_runtime_harness/runtime/scenegraph_artifact_writer.gd` and `addons/agent_runtime_harness/runtime/behavior_trace_writer.gd`
+- [X] T020 [US2] Report missing-target, missing-property, and no-sample outcomes in `addons/agent_runtime_harness/runtime/behavior_watch_sampler.gd` and `addons/agent_runtime_harness/editor/scenegraph_automation_artifact_store.gd`
 
 **Checkpoint**: User Story 2 is complete when a deterministic Pong run produces a bounded `trace.jsonl` artifact for the requested watch scope only.
 
@@ -91,15 +91,15 @@
 
 ### Validation for User Story 3
 
-- [ ] T021 [P] [US3] Add expected manifest and result fixtures for behavior-watch runs in `examples/pong-testbed/evidence/automation/` and `examples/pong-testbed/harness/automation/results/`
-- [ ] T022 [P] [US3] Add manifest-reference and stale-trace regression coverage in `tools/tests/ScenegraphAutomationLoop.Tests.ps1` and `tools/tests/AutomationTools.Tests.ps1`
+- [X] T021 [P] [US3] Add expected manifest and result fixtures for behavior-watch runs in `examples/pong-testbed/evidence/automation/` and `examples/pong-testbed/harness/automation/results/`
+- [X] T022 [P] [US3] Add manifest-reference and stale-trace regression coverage in `tools/tests/ScenegraphAutomationLoop.Tests.ps1` and `tools/tests/AutomationTools.Tests.ps1`
 
 ### Implementation for User Story 3
 
-- [ ] T023 [US3] Register behavior-watch trace artifact metadata in `tools/evidence/artifact-registry.ps1` and `addons/agent_runtime_harness/shared/inspection_constants.gd`
-- [ ] T024 [US3] Add `trace.jsonl` artifact references and applied-watch summary output in `addons/agent_runtime_harness/runtime/scenegraph_artifact_writer.gd`
-- [ ] T025 [P] [US3] Align run-result-to-manifest handoff behavior in `addons/agent_runtime_harness/editor/scenegraph_automation_artifact_store.gd` and `addons/agent_runtime_harness/editor/scenegraph_run_coordinator.gd`
-- [ ] T026 [US3] Document manifest-first trace consumption in `docs/AGENT_TOOLING_FOUNDATION.md` and `specs/005-behavior-watch-sampling/contracts/behavior-watch-contract.md`
+- [X] T023 [US3] Register behavior-watch trace artifact metadata in `tools/evidence/artifact-registry.ps1` and `addons/agent_runtime_harness/shared/inspection_constants.gd`
+- [X] T024 [US3] Add `trace.jsonl` artifact references and applied-watch summary output in `addons/agent_runtime_harness/runtime/scenegraph_artifact_writer.gd`
+- [X] T025 [P] [US3] Align run-result-to-manifest handoff behavior in `addons/agent_runtime_harness/editor/scenegraph_automation_artifact_store.gd` and `addons/agent_runtime_harness/editor/scenegraph_run_coordinator.gd`
+- [X] T026 [US3] Document manifest-first trace consumption in `docs/AGENT_TOOLING_FOUNDATION.md` and `specs/005-behavior-watch-sampling/contracts/behavior-watch-contract.md`
 
 **Checkpoint**: User Story 3 is complete when behavior-watch traces are consumed through the same manifest-centered evidence flow as the rest of the harness.
 
@@ -109,10 +109,10 @@
 
 **Purpose**: Finish shared documentation, run full validation, and capture follow-up notes from the quickstart flow.
 
-- [ ] T027 [P] Update slice-1 and slice-2 guidance in `docs/BEHAVIOR_CAPTURE_SLICES.md` and `docs/AGENT_RUNTIME_HARNESS.md`
-- [ ] T028 Run `pwsh ./tools/tests/run-tool-tests.ps1` and fix regressions in `tools/tests/ScenegraphAutomationLoop.Tests.ps1`, `tools/tests/AutomationTools.Tests.ps1`, and any touched contracts
-- [ ] T029 [P] Run `pwsh ./tools/evidence/validate-evidence-manifest.ps1 -ManifestPath <generated-manifest>` against the behavior-watch fixture output and record notes in `specs/005-behavior-watch-sampling/research.md`
-- [ ] T030 [P] Execute the validation flow in `specs/005-behavior-watch-sampling/quickstart.md` against `examples/pong-testbed/` and record follow-up notes in `specs/005-behavior-watch-sampling/research.md`
+- [X] T027 [P] Update slice-1 and slice-2 guidance in `docs/BEHAVIOR_CAPTURE_SLICES.md` and `docs/AGENT_RUNTIME_HARNESS.md`
+- [X] T028 Run `pwsh ./tools/tests/run-tool-tests.ps1` and fix regressions in `tools/tests/ScenegraphAutomationLoop.Tests.ps1`, `tools/tests/AutomationTools.Tests.ps1`, and any touched contracts
+- [X] T029 [P] Run `pwsh ./tools/evidence/validate-evidence-manifest.ps1 -ManifestPath <generated-manifest>` against the behavior-watch fixture output and record notes in `specs/005-behavior-watch-sampling/research.md`
+- [X] T030 [P] Execute the validation flow in `specs/005-behavior-watch-sampling/quickstart.md` against `examples/pong-testbed/` and record follow-up notes in `specs/005-behavior-watch-sampling/research.md`
 
 ---
 

--- a/tools/automation/request-editor-evidence-run.ps1
+++ b/tools/automation/request-editor-evidence-run.ps1
@@ -4,6 +4,7 @@ param(
     [string]$ConfigPath,
     [string]$RequestPath,
     [string]$RequestFixturePath,
+    [string]$BehaviorWatchRequestFixturePath,
     [string]$RequestId,
     [string]$ScenarioId,
     [string]$RunId,
@@ -140,6 +141,13 @@ $defaultRequest = if ($PSBoundParameters.ContainsKey('RequestFixturePath')) {
 else {
     [pscustomobject]@{}
 }
+$behaviorWatchRequest = if ($PSBoundParameters.ContainsKey('BehaviorWatchRequestFixturePath')) {
+    $fixturePath = Resolve-RepoPath -Path $BehaviorWatchRequestFixturePath
+    Get-Content -LiteralPath $fixturePath -Raw | ConvertFrom-Json -Depth 100
+}
+else {
+    $null
+}
 
 $requestDocument = [ordered]@{
     requestId = if ($PSBoundParameters.ContainsKey('RequestId')) { $RequestId } elseif ($defaultRequest.requestId) { $defaultRequest.requestId } else { [guid]::NewGuid().Guid }
@@ -156,7 +164,14 @@ $requestDocument = [ordered]@{
 }
 
 if ($defaultRequest.PSObject.Properties.Name -contains 'overrides') {
-    $requestDocument.overrides = $defaultRequest.overrides
+    $requestDocument.overrides = $defaultRequest.overrides | ConvertTo-Json -Depth 100 | ConvertFrom-Json -Depth 100 -AsHashtable
+}
+
+if ($null -ne $behaviorWatchRequest) {
+    if (-not $requestDocument.Contains('overrides')) {
+        $requestDocument.overrides = [ordered]@{}
+    }
+    $requestDocument.overrides.behaviorWatchRequest = $behaviorWatchRequest
 }
 
 $resolvedRequestPath = if ($PSBoundParameters.ContainsKey('RequestPath')) {

--- a/tools/tests/AutomationTools.Tests.ps1
+++ b/tools/tests/AutomationTools.Tests.ps1
@@ -289,6 +289,34 @@ Describe 'tools/automation/request-editor-evidence-run.ps1' {
         }
     }
 
+    It 'writes a schema-valid request artifact with a behavior-watch override fixture' {
+        $sandboxPath = New-RepoSandboxDirectory
+
+        try {
+            $harnessPath = Join-Path $sandboxPath 'harness'
+            New-Item -ItemType Directory -Path $harnessPath -Force | Out-Null
+            Copy-Item -LiteralPath (Get-RepoPath -Path 'examples/pong-testbed/harness/inspection-run-config.json') -Destination (Join-Path $harnessPath 'inspection-run-config.json')
+
+            $result = Invoke-RepoScriptPassThru -ScriptPath 'tools/automation/request-editor-evidence-run.ps1' -Parameters @{
+                ProjectRoot = $sandboxPath
+                RequestFixturePath = 'examples/pong-testbed/harness/automation/requests/run-request.healthy.json'
+                BehaviorWatchRequestFixturePath = 'examples/pong-testbed/harness/automation/requests/behavior-watch-valid.json'
+                RequestedBy = 'automation-tools-behavior-watch-test'
+                PassThru = $true
+            }
+
+            $result.schemaValid | Should -BeTrue
+            $request = Get-Content -LiteralPath $result.requestPath -Raw | ConvertFrom-Json -Depth 100
+            $request.requestedBy | Should -Be 'automation-tools-behavior-watch-test'
+            $request.overrides.behaviorWatchRequest.targets[0].nodePath | Should -Be '/root/Main/Ball'
+            $request.overrides.behaviorWatchRequest.frameCount | Should -Be 4
+            $request.overrides.behaviorWatchRequest.PSObject.Properties.Name | Should -Not -Contain 'cadence'
+        }
+        finally {
+            Remove-Item -LiteralPath $sandboxPath -Recurse -Force -ErrorAction SilentlyContinue
+        }
+    }
+
     It 'writes a schema-valid build-failure request artifact for a sandbox project' {
         $sandboxPath = New-RepoSandboxDirectory
 

--- a/tools/tests/ScenegraphAutomationLoop.Tests.ps1
+++ b/tools/tests/ScenegraphAutomationLoop.Tests.ps1
@@ -64,6 +64,91 @@ Describe 'specs/003-editor-evidence-loop automation schemas' {
         $result.ParsedOutput.valid | Should -BeTrue
     }
 
+    It 'accepts a run request payload with behavior-watch overrides' {
+        $payloadPath = Join-Path $TestDrive 'automation-run-request.behavior-watch.json'
+        @{
+            requestId = 'pong-request-watch-001'
+            scenarioId = 'pong-behavior-watch'
+            runId = 'pong-watch-run-001'
+            targetScene = 'res://scenes/main.tscn'
+            outputDirectory = 'res://evidence/automation/pong-watch-run-001'
+            artifactRoot = 'examples/pong-testbed/evidence/automation/pong-watch-run-001'
+            expectationFiles = @('res://harness/expectations/common.json')
+            capturePolicy = @{
+                startup = $true
+                manual = $true
+                failure = $true
+            }
+            stopPolicy = @{
+                stopAfterValidation = $true
+            }
+            requestedBy = 'scenegraph-automation-test'
+            createdAt = '2026-04-14T00:01:00Z'
+            overrides = @{
+                behaviorWatchRequest = @{
+                    targets = @(
+                        @{
+                            nodePath = '/root/Main/Ball'
+                            properties = @('position', 'velocity', 'collisionState', 'lastCollider')
+                        }
+                    )
+                    frameCount = 4
+                }
+            }
+        } | ConvertTo-Json -Depth 20 | Set-Content -LiteralPath $payloadPath
+
+        $result = Invoke-RepoJsonScript -ScriptPath 'tools/validate-json.ps1' -Arguments @(
+            '-InputPath', $payloadPath,
+            '-SchemaPath', 'specs/003-editor-evidence-loop/contracts/automation-run-request.schema.json'
+        )
+
+        $result.ExitCode | Should -Be 0
+        $result.ParsedOutput.valid | Should -BeTrue
+    }
+
+    It 'rejects a run request payload with later-slice behavior-watch fields' {
+        $payloadPath = Join-Path $TestDrive 'automation-run-request.behavior-watch.invalid.json'
+        @{
+            requestId = 'pong-request-watch-002'
+            scenarioId = 'pong-behavior-watch'
+            runId = 'pong-watch-run-002'
+            targetScene = 'res://scenes/main.tscn'
+            outputDirectory = 'res://evidence/automation/pong-watch-run-002'
+            artifactRoot = 'examples/pong-testbed/evidence/automation/pong-watch-run-002'
+            expectationFiles = @('res://harness/expectations/common.json')
+            capturePolicy = @{
+                startup = $true
+                manual = $true
+                failure = $true
+            }
+            stopPolicy = @{
+                stopAfterValidation = $true
+            }
+            requestedBy = 'scenegraph-automation-test'
+            createdAt = '2026-04-14T00:02:00Z'
+            overrides = @{
+                behaviorWatchRequest = @{
+                    targets = @(
+                        @{
+                            nodePath = '/root/Main/Ball'
+                            properties = @('position')
+                        }
+                    )
+                    frameCount = 4
+                    triggers = @('wall_contact')
+                }
+            }
+        } | ConvertTo-Json -Depth 20 | Set-Content -LiteralPath $payloadPath
+
+        $result = Invoke-RepoJsonScript -ScriptPath 'tools/validate-json.ps1' -Arguments @(
+            '-InputPath', $payloadPath,
+            '-SchemaPath', 'specs/003-editor-evidence-loop/contracts/automation-run-request.schema.json'
+        )
+
+        $result.ExitCode | Should -Be 1
+        $result.ParsedOutput.valid | Should -BeFalse
+    }
+
     It 'accepts a lifecycle status payload' {
         $payloadPath = Join-Path $TestDrive 'automation-lifecycle-status.json'
         @{
@@ -241,6 +326,56 @@ Describe 'examples/pong-testbed automation fixtures' {
         $result.ParsedOutput.valid | Should -BeTrue
     }
 
+    It 'accepts the behavior-watch request fragment fixture with normalization defaults' {
+        $result = Invoke-RepoJsonScript -ScriptPath 'tools/validate-json.ps1' -Arguments @(
+            '-InputPath', 'examples/pong-testbed/harness/automation/requests/behavior-watch-valid.json',
+            '-SchemaPath', 'specs/005-behavior-watch-sampling/contracts/behavior-watch-request.schema.json'
+        )
+
+        $result.ExitCode | Should -Be 0
+        $result.ParsedOutput.valid | Should -BeTrue
+    }
+
+    It 'rejects the invalid-selector behavior-watch request fragment fixture' {
+        $result = Invoke-RepoJsonScript -ScriptPath 'tools/validate-json.ps1' -Arguments @(
+            '-InputPath', 'examples/pong-testbed/harness/automation/requests/behavior-watch-invalid-selector.json',
+            '-SchemaPath', 'specs/005-behavior-watch-sampling/contracts/behavior-watch-request.schema.json'
+        )
+
+        $result.ExitCode | Should -Be 1
+        $result.ParsedOutput.valid | Should -BeFalse
+    }
+
+    It 'rejects the invalid-window behavior-watch request fragment fixture' {
+        $result = Invoke-RepoJsonScript -ScriptPath 'tools/validate-json.ps1' -Arguments @(
+            '-InputPath', 'examples/pong-testbed/harness/automation/requests/behavior-watch-invalid-window.json',
+            '-SchemaPath', 'specs/005-behavior-watch-sampling/contracts/behavior-watch-request.schema.json'
+        )
+
+        $result.ExitCode | Should -Be 1
+        $result.ParsedOutput.valid | Should -BeFalse
+    }
+
+    It 'accepts the every-frame behavior-watch automation request fixture' {
+        $result = Invoke-RepoJsonScript -ScriptPath 'tools/validate-json.ps1' -Arguments @(
+            '-InputPath', 'examples/pong-testbed/harness/automation/requests/behavior-watch-wall-bounce.every-frame.json',
+            '-SchemaPath', 'specs/003-editor-evidence-loop/contracts/automation-run-request.schema.json'
+        )
+
+        $result.ExitCode | Should -Be 0
+        $result.ParsedOutput.valid | Should -BeTrue
+    }
+
+    It 'accepts the every-n behavior-watch automation request fixture' {
+        $result = Invoke-RepoJsonScript -ScriptPath 'tools/validate-json.ps1' -Arguments @(
+            '-InputPath', 'examples/pong-testbed/harness/automation/requests/behavior-watch-wall-bounce.every-n.json',
+            '-SchemaPath', 'specs/003-editor-evidence-loop/contracts/automation-run-request.schema.json'
+        )
+
+        $result.ExitCode | Should -Be 0
+        $result.ParsedOutput.valid | Should -BeTrue
+    }
+
     It 'accepts the capability options fixture' {
         $result = Invoke-RepoJsonScript -ScriptPath 'tools/validate-json.ps1' -Arguments @(
             '-InputPath', 'examples/pong-testbed/harness/automation/results/capability-options.expected.json',
@@ -264,6 +399,45 @@ Describe 'examples/pong-testbed automation fixtures' {
         $result.ParsedOutput.valid | Should -BeTrue
         $manifestValidation.ExitCode | Should -Be 0
         $manifestValidation.ParsedOutput.bundleValid | Should -BeTrue
+    }
+
+    It 'accepts the every-frame behavior-watch run-result fixture, manifest, and trace rows' {
+        $result = Invoke-RepoJsonScript -ScriptPath 'tools/validate-json.ps1' -Arguments @(
+            '-InputPath', 'examples/pong-testbed/harness/automation/results/run-result.behavior-watch.every-frame.expected.json',
+            '-SchemaPath', 'specs/003-editor-evidence-loop/contracts/automation-run-result.schema.json'
+        )
+        $manifestValidation = Invoke-RepoJsonScript -ScriptPath 'tools/evidence/validate-evidence-manifest.ps1' -Arguments @(
+            '-ManifestPath', 'examples/pong-testbed/evidence/automation/pong-behavior-watch-wall-bounce-every-frame/evidence-manifest.json'
+        )
+        $manifest = Read-RepoJson -Path 'examples/pong-testbed/evidence/automation/pong-behavior-watch-wall-bounce-every-frame/evidence-manifest.json'
+        $traceRows = @(Read-RepoJsonLines -Path 'examples/pong-testbed/evidence/automation/pong-behavior-watch-wall-bounce-every-frame/trace.jsonl')
+
+        $result.ExitCode | Should -Be 0
+        $result.ParsedOutput.valid | Should -BeTrue
+        $manifestValidation.ExitCode | Should -Be 0
+        $manifestValidation.ParsedOutput.bundleValid | Should -BeTrue
+        Assert-BehaviorWatchAppliedWatch -AppliedWatch $manifest.appliedWatch -ExpectedRunId 'pong-behavior-watch-wall-bounce-every-frame-run-01' -ExpectedNodePath '/root/Main/Ball' -ExpectedProperties @('position', 'velocity', 'collisionState', 'lastCollider') -ExpectedMode 'every_frame' -ExpectedStartFrameOffset 12 -ExpectedFrameCount 4 -ExpectedSampleCount 4
+        Assert-BehaviorWatchTraceRows -Rows $traceRows -ExpectedNodePath '/root/Main/Ball' -ExpectedProperties @('position', 'velocity', 'collisionState', 'lastCollider') -ExpectedFrames @(12, 13, 14, 15)
+    }
+
+    It 'accepts the every-n behavior-watch run-result fixture, manifest, and trace rows' {
+        $result = Invoke-RepoJsonScript -ScriptPath 'tools/validate-json.ps1' -Arguments @(
+            '-InputPath', 'examples/pong-testbed/harness/automation/results/run-result.behavior-watch.every-n.expected.json',
+            '-SchemaPath', 'specs/003-editor-evidence-loop/contracts/automation-run-result.schema.json'
+        )
+        $manifestValidation = Invoke-RepoJsonScript -ScriptPath 'tools/evidence/validate-evidence-manifest.ps1' -Arguments @(
+            '-ManifestPath', 'examples/pong-testbed/evidence/automation/pong-behavior-watch-wall-bounce-every-n/evidence-manifest.json'
+        )
+        $manifest = Read-RepoJson -Path 'examples/pong-testbed/evidence/automation/pong-behavior-watch-wall-bounce-every-n/evidence-manifest.json'
+        $traceRows = @(Read-RepoJsonLines -Path 'examples/pong-testbed/evidence/automation/pong-behavior-watch-wall-bounce-every-n/trace.jsonl')
+
+        $result.ExitCode | Should -Be 0
+        $result.ParsedOutput.valid | Should -BeTrue
+        $manifestValidation.ExitCode | Should -Be 0
+        $manifestValidation.ParsedOutput.bundleValid | Should -BeTrue
+        Assert-BehaviorWatchAppliedWatch -AppliedWatch $manifest.appliedWatch -ExpectedRunId 'pong-behavior-watch-wall-bounce-every-n-run-01' -ExpectedNodePath '/root/Main/Ball' -ExpectedProperties @('position', 'velocity', 'speed') -ExpectedMode 'every_n_frames' -ExpectedStartFrameOffset 20 -ExpectedFrameCount 6 -ExpectedSampleCount 3
+        $manifest.appliedWatch.cadence.everyNFrames | Should -Be 2
+        Assert-BehaviorWatchTraceRows -Rows $traceRows -ExpectedNodePath '/root/Main/Ball' -ExpectedProperties @('position', 'velocity', 'speed') -ExpectedFrames @(20, 22, 24)
     }
 
     It 'accepts the build-failure lifecycle and run-result fixtures' {

--- a/tools/tests/TestHelpers.ps1
+++ b/tools/tests/TestHelpers.ps1
@@ -152,6 +152,94 @@ function Assert-BuildFailureRunResult {
     @($Result.buildDiagnostics).Count | Should -Be $ExpectedDiagnosticCount
 }
 
+function Read-RepoJsonLines {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Path
+    )
+
+    return Get-Content -LiteralPath (Get-RepoPath -Path $Path) | Where-Object { -not [string]::IsNullOrWhiteSpace($_) } | ForEach-Object {
+        $_ | ConvertFrom-Json -Depth 100
+    }
+}
+
+function Assert-BehaviorWatchAppliedWatch {
+    param(
+        [Parameter(Mandatory = $true)]
+        $AppliedWatch,
+
+        [Parameter(Mandatory = $true)]
+        [string]$ExpectedRunId,
+
+        [Parameter(Mandatory = $true)]
+        [string]$ExpectedNodePath,
+
+        [Parameter(Mandatory = $true)]
+        [string[]]$ExpectedProperties,
+
+        [Parameter(Mandatory = $true)]
+        [string]$ExpectedMode,
+
+        [Parameter(Mandatory = $true)]
+        [int]$ExpectedStartFrameOffset,
+
+        [Parameter(Mandatory = $true)]
+        [int]$ExpectedFrameCount,
+
+        [int]$ExpectedSampleCount = -1
+    )
+
+    $AppliedWatch.runId | Should -Be $ExpectedRunId
+    $AppliedWatch.traceArtifact | Should -Be 'trace.jsonl'
+    @($AppliedWatch.targets).Count | Should -Be 1
+    $AppliedWatch.targets[0].nodePath | Should -Be $ExpectedNodePath
+    @($AppliedWatch.targets[0].properties) | Should -Be $ExpectedProperties
+    $AppliedWatch.cadence.mode | Should -Be $ExpectedMode
+    $AppliedWatch.startFrameOffset | Should -Be $ExpectedStartFrameOffset
+    $AppliedWatch.frameCount | Should -Be $ExpectedFrameCount
+
+    if ($ExpectedMode -eq 'every_frame') {
+        $AppliedWatch.cadence.everyNFrames | Should -BeNullOrEmpty
+    }
+
+    if ($ExpectedSampleCount -ge 0) {
+        $AppliedWatch.outcomes.sampleCount | Should -Be $ExpectedSampleCount
+        $AppliedWatch.outcomes.noSamples | Should -BeFalse
+    }
+}
+
+function Assert-BehaviorWatchTraceRows {
+    param(
+        [Parameter(Mandatory = $true)]
+        [object[]]$Rows,
+
+        [Parameter(Mandatory = $true)]
+        [string]$ExpectedNodePath,
+
+        [Parameter(Mandatory = $true)]
+        [string[]]$ExpectedProperties,
+
+        [int[]]$ExpectedFrames = @()
+    )
+
+    @($Rows).Count | Should -BeGreaterThan 0
+    $allowedKeys = @('frame', 'timestampMs', 'nodePath') + $ExpectedProperties
+
+    foreach ($row in @($Rows)) {
+        $row.nodePath | Should -Be $ExpectedNodePath
+        foreach ($propertyName in $ExpectedProperties) {
+            $row.PSObject.Properties.Name | Should -Contain $propertyName
+        }
+        foreach ($propertyName in $row.PSObject.Properties.Name) {
+            $propertyName | Should -BeIn $allowedKeys
+        }
+    }
+
+    if ($ExpectedFrames.Count -gt 0) {
+        @($Rows | ForEach-Object { [int]$_.frame }) | Should -Be $ExpectedFrames
+    }
+}
+
 function Invoke-RepoScriptPassThru {
     param(
         [Parameter(Mandatory = $true)]


### PR DESCRIPTION
## Summary
- add behavior-watch request validation, runtime sampling, and trace manifest integration
- add seeded Pong request/result/evidence fixtures plus updated PowerShell regression coverage
- document the appliedWatch summary, quickstart flow, and feature validation notes

## Validation
- pwsh ./tools/tests/run-tool-tests.ps1
- pwsh ./tools/evidence/validate-evidence-manifest.ps1 -ManifestPath examples/pong-testbed/evidence/automation/pong-behavior-watch-wall-bounce-every-frame/evidence-manifest.json
- pwsh ./tools/automation/request-editor-evidence-run.ps1 -ProjectRoot examples/pong-testbed -RequestFixturePath examples/pong-testbed/harness/automation/requests/behavior-watch-wall-bounce.every-frame.json -PassThru

## Runtime verification note
- live quickstart runtime verification is still blocked from this checkout until the editor publishes harness/automation/results/capability.json