### PR TITLE
Fix GDScript addon parse errors

### DIFF
--- a/.github/instructions/addons.instructions.md
+++ b/.github/instructions/addons.instructions.md
@@ -5,6 +5,7 @@ applyTo: "addons/agent_runtime_harness/**"
 # Addon Instructions
 
 - Keep changes plugin-first and compatible with normal Godot addon patterns.
+- For GDScript addon code, keep `const` initializers to literal constant expressions (`[]`, `{}`, scalars) instead of constructors such as `PackedStringArray(...)`, and prefer explicit `RegEx`/`RegExMatch` typing when APIs like `search()` do not infer cleanly.
 - Prefer structured runtime outputs that an agent can consume directly over editor-only UI state.
 - Preserve deterministic scenario and evidence expectations when introducing runtime-facing behavior.
 - Do not propose engine-fork changes from addon files unless the task includes evidence that addon, debugger, and GDExtension options are insufficient.

--- a/addons/agent_runtime_harness/editor/scenegraph_automation_broker.gd
+++ b/addons/agent_runtime_harness/editor/scenegraph_automation_broker.gd
@@ -23,7 +23,7 @@ var _config_path := "res://harness/inspection-run-config.json"
 var _poll_timer: Timer
 var _last_capability_signature := ""
 var _script_error_summary_regexes: Array[RegEx] = []
-var _script_error_line_regex = null
+var _script_error_line_regex: RegEx = null
 
 
 func configure(plugin: EditorPlugin, bridge: Object, config_path: String = "res://harness/inspection-run-config.json") -> void:
@@ -531,7 +531,7 @@ func _parse_script_editor_diagnostics(default_resource_path: String, text: Strin
 
 func _match_script_error_summary(line_text: String) -> Dictionary:
 	for regex in _get_script_error_summary_regexes():
-		var match := regex.search(line_text)
+		var match: RegExMatch = regex.search(line_text)
 		if match == null:
 			continue
 		return {
@@ -543,10 +543,10 @@ func _match_script_error_summary(line_text: String) -> Dictionary:
 
 
 func _match_script_error_line(line_text: String) -> Dictionary:
-	var regex = _get_script_error_line_regex()
+	var regex: RegEx = _get_script_error_line_regex()
 	if regex == null:
 		return {}
-	var match := regex.search(line_text)
+	var match: RegExMatch = regex.search(line_text)
 	if match == null:
 		return {}
 	return {
@@ -564,7 +564,7 @@ func _get_script_error_summary_regexes() -> Array[RegEx]:
 	return _script_error_summary_regexes
 
 
-func _get_script_error_line_regex():
+func _get_script_error_line_regex() -> RegEx:
 	if _script_error_line_regex == null:
 		var regex := RegEx.new()
 		if regex.compile(SCRIPT_ERROR_LINE_PATTERN) != OK:

--- a/addons/agent_runtime_harness/shared/behavior_watch_request_validator.gd
+++ b/addons/agent_runtime_harness/shared/behavior_watch_request_validator.gd
@@ -3,10 +3,10 @@ class_name BehaviorWatchRequestValidator
 
 const InspectionConstants = preload("res://addons/agent_runtime_harness/shared/inspection_constants.gd")
 
-const SUPPORTED_TARGET_KEYS := PackedStringArray(["nodePath", "properties"])
-const SUPPORTED_CADENCE_KEYS := PackedStringArray(["mode", "everyNFrames"])
-const SUPPORTED_REQUEST_KEYS := PackedStringArray(["targets", "cadence", "startFrameOffset", "frameCount"])
-const SUPPORTED_PROPERTIES := PackedStringArray([
+const SUPPORTED_TARGET_KEYS := ["nodePath", "properties"]
+const SUPPORTED_CADENCE_KEYS := ["mode", "everyNFrames"]
+const SUPPORTED_REQUEST_KEYS := ["targets", "cadence", "startFrameOffset", "frameCount"]
+const SUPPORTED_PROPERTIES := [
 	"position",
 	"velocity",
 	"intendedVelocity",
@@ -15,15 +15,15 @@ const SUPPORTED_PROPERTIES := PackedStringArray([
 	"movementVector",
 	"speed",
 	"overlapFrames",
-])
-const LATER_SLICE_KEYS := PackedStringArray([
+]
+const LATER_SLICE_KEYS := [
 	"triggers",
 	"invariants",
 	"scriptProbes",
 	"probeScripts",
 	"fullSceneCapture",
 	"fullSceneLogging",
-])
+]
 
 
 func normalize_request(request_value: Variant, run_id: String) -> Dictionary:
@@ -249,7 +249,7 @@ func _is_integral_numeric(value: Variant) -> bool:
 	return is_equal_approx(float(value), round(float(value)))
 
 
-func _collect_unknown_keys(errors: Array, keys: Array, supported_keys: PackedStringArray, field_prefix: String) -> void:
+func _collect_unknown_keys(errors: Array, keys: Array, supported_keys: Array, field_prefix: String) -> void:
 	for key_value in keys:
 		var key := String(key_value)
 		if key in supported_keys:


### PR DESCRIPTION
## Summary
- fix GDScript addon parse errors caused by non-literal const initializers in the behavior watch validator
- make regex result typing explicit in the automation broker for Godot 4.6.2 compatibility
- capture the pattern in addon Copilot instructions to avoid regenerating the same issue

## Validation
- pwsh ./tools/tests/run-tool-tests.ps1
- Godot 4.6.2 console editor load against D:\gameDev\pong with --headless --editor --quit-after 1