### PR TITLE
Fix automation result reporting and support URL

### DIFF
--- a/addons/agent_runtime_harness/editor/scenegraph_automation_broker.gd
+++ b/addons/agent_runtime_harness/editor/scenegraph_automation_broker.gd
@@ -23,7 +23,7 @@ var _config_path := "res://harness/inspection-run-config.json"
 var _poll_timer: Timer
 var _last_capability_signature := ""
 var _script_error_summary_regexes: Array[RegEx] = []
-var _script_error_line_regex = null
+var _script_error_line_regex: RegEx = null
 
 
 func configure(plugin: EditorPlugin, bridge: Object, config_path: String = "res://harness/inspection-run-config.json") -> void:
@@ -531,7 +531,7 @@ func _parse_script_editor_diagnostics(default_resource_path: String, text: Strin
 
 func _match_script_error_summary(line_text: String) -> Dictionary:
 	for regex in _get_script_error_summary_regexes():
-		var match := regex.search(line_text)
+		var match: RegExMatch = regex.search(line_text)
 		if match == null:
 			continue
 		return {
@@ -546,7 +546,7 @@ func _match_script_error_line(line_text: String) -> Dictionary:
 	var regex = _get_script_error_line_regex()
 	if regex == null:
 		return {}
-	var match := regex.search(line_text)
+	var match: RegExMatch = regex.search(line_text)
 	if match == null:
 		return {}
 	return {

--- a/addons/agent_runtime_harness/editor/scenegraph_dock.gd
+++ b/addons/agent_runtime_harness/editor/scenegraph_dock.gd
@@ -2,6 +2,8 @@
 extends VBoxContainer
 class_name ScenegraphDock
 
+const InspectionConstants = preload("res://addons/agent_runtime_harness/shared/inspection_constants.gd")
+
 var _bridge = null
 var _agent_asset_deployer = null
 var _status_label: Label
@@ -10,6 +12,7 @@ var _diagnostics_label: RichTextLabel
 var _capture_button: Button
 var _persist_button: Button
 var _deploy_assets_button: Button
+var _support_label: Label
 
 
 func _ready() -> void:
@@ -62,6 +65,11 @@ func _build_ui() -> void:
 	_deploy_assets_button.text = "Deploy Agent Assets"
 	_deploy_assets_button.pressed.connect(_on_deploy_assets_button_pressed)
 	add_child(_deploy_assets_button)
+
+	_support_label = Label.new()
+	_support_label.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
+	_support_label.text = "Report harness issues: %s" % InspectionConstants.CANONICAL_ISSUE_TRACKER_URL
+	add_child(_support_label)
 
 	var summary_heading := Label.new()
 	summary_heading.text = "Latest Snapshot"

--- a/addons/agent_runtime_harness/editor/scenegraph_run_coordinator.gd
+++ b/addons/agent_runtime_harness/editor/scenegraph_run_coordinator.gd
@@ -240,11 +240,15 @@ func _request_stop() -> void:
 	var editor_interface = _get_editor_interface()
 	if editor_interface != null:
 		editor_interface.stop_playing_scene()
+	if not _active or not _awaiting_stop:
+		return
 	if not _is_playing_scene():
 		_finalize_after_stop(InspectionConstants.AUTOMATION_TERMINATION_STOPPED_CLEANLY)
 
 
 func _finalize_after_stop(termination_status: String) -> void:
+	if not _active:
+		return
 	_awaiting_stop = false
 	if _pending_failure_kind != null:
 		_finalize_run("failed", String(_pending_failure_kind), termination_status, _pending_failure_message)
@@ -353,6 +357,23 @@ func _finalize_run(final_status: String, failure_kind, termination_status: Strin
 		result["buildFailurePhase"] = normalized_build_failure.get("buildFailurePhase", InspectionConstants.AUTOMATION_BUILD_FAILURE_PHASE_LAUNCHING)
 		result["buildDiagnostics"] = normalized_build_failure.get("buildDiagnostics", []).duplicate(true)
 		result["rawBuildOutput"] = normalized_build_failure.get("rawBuildOutput", []).duplicate(true)
+	var terminal_extras := {}
+	if manifest_path != null:
+		terminal_extras["evidenceRefs"] = [String(manifest_path)]
+	if failure_kind != null:
+		terminal_extras["failureKind"] = failure_kind
+	if failure_kind == InspectionConstants.AUTOMATION_FAILURE_KIND_BUILD:
+		terminal_extras["buildFailurePhase"] = result.get("buildFailurePhase", InspectionConstants.AUTOMATION_BUILD_FAILURE_PHASE_LAUNCHING)
+		terminal_extras["buildDiagnosticCount"] = result.get("buildDiagnostics", []).size()
+		terminal_extras["rawBuildOutputAvailable"] = not result.get("rawBuildOutput", []).is_empty()
+	var terminal_status := InspectionConstants.AUTOMATION_STATUS_COMPLETED
+	var terminal_details := "Autonomous run completed."
+	if final_status != "completed":
+		terminal_status = InspectionConstants.AUTOMATION_STATUS_FAILED
+		terminal_details = "Autonomous run failed."
+	if not note.is_empty():
+		terminal_details = note
+	_emit_status(terminal_status, terminal_details, terminal_extras)
 	_artifact_store.write_run_result(_active_config, result)
 	emit_signal("run_completed", result)
 	_reset_state()

--- a/addons/agent_runtime_harness/plugin.cfg
+++ b/addons/agent_runtime_harness/plugin.cfg
@@ -1,6 +1,6 @@
 [plugin]
 name="Agent Runtime Harness"
-description="Dock-first scenegraph inspection tooling for editor playtests."
+description="Dock-first scenegraph inspection tooling for editor playtests. Report issues: https://github.com/RJAudas/godot-agent-harness/issues"
 author="GitHub Copilot"
 version="0.1.0"
 script="plugin.gd"

--- a/addons/agent_runtime_harness/shared/behavior_watch_request_validator.gd
+++ b/addons/agent_runtime_harness/shared/behavior_watch_request_validator.gd
@@ -3,10 +3,10 @@ class_name BehaviorWatchRequestValidator
 
 const InspectionConstants = preload("res://addons/agent_runtime_harness/shared/inspection_constants.gd")
 
-const SUPPORTED_TARGET_KEYS := PackedStringArray(["nodePath", "properties"])
-const SUPPORTED_CADENCE_KEYS := PackedStringArray(["mode", "everyNFrames"])
-const SUPPORTED_REQUEST_KEYS := PackedStringArray(["targets", "cadence", "startFrameOffset", "frameCount"])
-const SUPPORTED_PROPERTIES := PackedStringArray([
+const SUPPORTED_TARGET_KEYS := ["nodePath", "properties"]
+const SUPPORTED_CADENCE_KEYS := ["mode", "everyNFrames"]
+const SUPPORTED_REQUEST_KEYS := ["targets", "cadence", "startFrameOffset", "frameCount"]
+const SUPPORTED_PROPERTIES := [
 	"position",
 	"velocity",
 	"intendedVelocity",
@@ -15,15 +15,15 @@ const SUPPORTED_PROPERTIES := PackedStringArray([
 	"movementVector",
 	"speed",
 	"overlapFrames",
-])
-const LATER_SLICE_KEYS := PackedStringArray([
+]
+const LATER_SLICE_KEYS := [
 	"triggers",
 	"invariants",
 	"scriptProbes",
 	"probeScripts",
 	"fullSceneCapture",
 	"fullSceneLogging",
-])
+]
 
 
 func normalize_request(request_value: Variant, run_id: String) -> Dictionary:
@@ -249,7 +249,7 @@ func _is_integral_numeric(value: Variant) -> bool:
 	return is_equal_approx(float(value), round(float(value)))
 
 
-func _collect_unknown_keys(errors: Array, keys: Array, supported_keys: PackedStringArray, field_prefix: String) -> void:
+func _collect_unknown_keys(errors: Array, keys: Array, supported_keys: Array, field_prefix: String) -> void:
 	for key_value in keys:
 		var key := String(key_value)
 		if key in supported_keys:

--- a/addons/agent_runtime_harness/shared/inspection_constants.gd
+++ b/addons/agent_runtime_harness/shared/inspection_constants.gd
@@ -87,6 +87,7 @@ const DEFAULT_AUTOMATION_CAPABILITY_RESULT_PATH := "res://harness/automation/res
 const DEFAULT_AUTOMATION_LIFECYCLE_STATUS_PATH := "res://harness/automation/results/lifecycle-status.json"
 const DEFAULT_AUTOMATION_RUN_RESULT_PATH := "res://harness/automation/results/run-result.json"
 const DEFAULT_BEHAVIOR_WATCH_TRACE_FILE := "trace.jsonl"
+const CANONICAL_ISSUE_TRACKER_URL := "https://github.com/RJAudas/godot-agent-harness/issues"
 
 
 static func supported_artifact_kinds() -> PackedStringArray:

--- a/addons/agent_runtime_harness/templates/project_root/.github/copilot-instructions.runtime-harness.md
+++ b/addons/agent_runtime_harness/templates/project_root/.github/copilot-instructions.runtime-harness.md
@@ -14,3 +14,4 @@
 - For runtime verification requests, prefer proving behavior from the persisted scenegraph artifacts instead of relying on a human description of what happened in the editor.
 - For end-to-end runtime verification, read `harness/automation/results/capability.json` first, request or inspect a brokered run under `harness/automation/requests/` and `harness/automation/results/`, then inspect the persisted bundle manifest.
 - When asked whether a runtime node exists, report the manifest status first, then the node path if found, and then any diagnostic or capture limitation that affects confidence.
+- Report harness bugs or automation-contract defects at `https://github.com/RJAudas/godot-agent-harness/issues`.

--- a/addons/agent_runtime_harness/templates/project_root/AGENTS.runtime-harness.md
+++ b/addons/agent_runtime_harness/templates/project_root/AGENTS.runtime-harness.md
@@ -18,3 +18,4 @@
 - Read `harness/automation/results/capability.json` or the latest final run result before opening raw evidence files.
 - If `run-result.json` reports `failureKind = build`, use the build diagnostics and raw build output there, report `details`, `resourcePath`, and `line`/`column` when available, and do not expect a manifest for that run.
 - Treat blocked capability or run results as explicit unsupported-state signals; do not guess around them with hidden editor interaction.
+- Report harness bugs or automation-contract defects at `https://github.com/RJAudas/godot-agent-harness/issues`.

--- a/examples/pong-testbed/harness/automation/results/lifecycle-status.completed.expected.json
+++ b/examples/pong-testbed/harness/automation/results/lifecycle-status.completed.expected.json
@@ -1,0 +1,11 @@
+{
+  "requestId": "pong-request-healthy-001",
+  "runId": "pong-autonomous-run-001",
+  "status": "completed",
+  "details": "Autonomous run completed.",
+  "timestamp": "2026-04-17T17:55:00Z",
+  "controlPath": "file_broker",
+  "evidenceRefs": [
+    "examples/pong-testbed/harness/expected-evidence-manifest.json"
+  ]
+}

--- a/tools/automation/request-editor-evidence-run.ps1
+++ b/tools/automation/request-editor-evidence-run.ps1
@@ -125,6 +125,34 @@ function Get-ValidationMessage {
     return $FailureMessage
 }
 
+function Get-OptionalPropertyValue {
+    param(
+        [Parameter(Mandatory = $true)]
+        [object]$InputObject,
+
+        [Parameter(Mandatory = $true)]
+        [string]$PropertyName
+    )
+
+    if ($null -eq $InputObject) {
+        return $null
+    }
+
+    if ($InputObject -is [System.Collections.IDictionary]) {
+        if ($InputObject.Contains($PropertyName)) {
+            return $InputObject[$PropertyName]
+        }
+        return $null
+    }
+
+    $property = $InputObject.PSObject.Properties[$PropertyName]
+    if ($null -eq $property) {
+        return $null
+    }
+
+    return $property.Value
+}
+
 $resolvedProjectRoot = Resolve-RepoPath -Path $ProjectRoot
 $resolvedConfigPath = if ($PSBoundParameters.ContainsKey('ConfigPath')) {
     Resolve-ProjectResourcePath -ProjectRootPath $resolvedProjectRoot -Path $ConfigPath
@@ -148,23 +176,32 @@ $behaviorWatchRequest = if ($PSBoundParameters.ContainsKey('BehaviorWatchRequest
 else {
     $null
 }
+$defaultRequestId = Get-OptionalPropertyValue -InputObject $defaultRequest -PropertyName 'requestId'
+$defaultScenarioId = Get-OptionalPropertyValue -InputObject $defaultRequest -PropertyName 'scenarioId'
+$defaultRunId = Get-OptionalPropertyValue -InputObject $defaultRequest -PropertyName 'runId'
+$defaultTargetScene = Get-OptionalPropertyValue -InputObject $defaultRequest -PropertyName 'targetScene'
+$defaultOutputDirectory = Get-OptionalPropertyValue -InputObject $defaultRequest -PropertyName 'outputDirectory'
+$defaultArtifactRoot = Get-OptionalPropertyValue -InputObject $defaultRequest -PropertyName 'artifactRoot'
+$defaultExpectationFiles = Get-OptionalPropertyValue -InputObject $defaultRequest -PropertyName 'expectationFiles'
+$defaultCapturePolicy = Get-OptionalPropertyValue -InputObject $defaultRequest -PropertyName 'capturePolicy'
+$defaultOverrides = Get-OptionalPropertyValue -InputObject $defaultRequest -PropertyName 'overrides'
 
 $requestDocument = [ordered]@{
-    requestId = if ($PSBoundParameters.ContainsKey('RequestId')) { $RequestId } elseif ($defaultRequest.requestId) { $defaultRequest.requestId } else { [guid]::NewGuid().Guid }
-    scenarioId = if ($PSBoundParameters.ContainsKey('ScenarioId')) { $ScenarioId } elseif ($defaultRequest.scenarioId) { $defaultRequest.scenarioId } else { $config.scenarioId }
-    runId = if ($PSBoundParameters.ContainsKey('RunId')) { $RunId } elseif ($defaultRequest.runId) { $defaultRequest.runId } else { ('run-' + [guid]::NewGuid().Guid) }
-    targetScene = if ($PSBoundParameters.ContainsKey('TargetScene')) { $TargetScene } elseif ($defaultRequest.targetScene) { $defaultRequest.targetScene } else { $config.targetScene }
-    outputDirectory = if ($PSBoundParameters.ContainsKey('OutputDirectory')) { $OutputDirectory } elseif ($defaultRequest.outputDirectory) { $defaultRequest.outputDirectory } else { $config.outputDirectory }
-    artifactRoot = if ($PSBoundParameters.ContainsKey('ArtifactRoot')) { $ArtifactRoot } elseif ($defaultRequest.artifactRoot) { $defaultRequest.artifactRoot } else { $config.artifactRoot }
-    expectationFiles = if ($ExpectationFiles.Count -gt 0) { Convert-ToStringArray $ExpectationFiles } elseif ($defaultRequest.expectationFiles) { Convert-ToStringArray $defaultRequest.expectationFiles } else { Convert-ToStringArray $config.expectationFiles }
-    capturePolicy = if ($defaultRequest.capturePolicy) { $defaultRequest.capturePolicy } else { $config.capturePolicy }
+    requestId = if ($PSBoundParameters.ContainsKey('RequestId')) { $RequestId } elseif ($defaultRequestId) { $defaultRequestId } else { [guid]::NewGuid().Guid }
+    scenarioId = if ($PSBoundParameters.ContainsKey('ScenarioId')) { $ScenarioId } elseif ($defaultScenarioId) { $defaultScenarioId } else { $config.scenarioId }
+    runId = if ($PSBoundParameters.ContainsKey('RunId')) { $RunId } elseif ($defaultRunId) { $defaultRunId } else { ('run-' + [guid]::NewGuid().Guid) }
+    targetScene = if ($PSBoundParameters.ContainsKey('TargetScene')) { $TargetScene } elseif ($defaultTargetScene) { $defaultTargetScene } else { $config.targetScene }
+    outputDirectory = if ($PSBoundParameters.ContainsKey('OutputDirectory')) { $OutputDirectory } elseif ($defaultOutputDirectory) { $defaultOutputDirectory } else { $config.outputDirectory }
+    artifactRoot = if ($PSBoundParameters.ContainsKey('ArtifactRoot')) { $ArtifactRoot } elseif ($defaultArtifactRoot) { $defaultArtifactRoot } else { $config.artifactRoot }
+    expectationFiles = if ($ExpectationFiles.Count -gt 0) { Convert-ToStringArray $ExpectationFiles } elseif ($defaultExpectationFiles) { Convert-ToStringArray $defaultExpectationFiles } else { Convert-ToStringArray $config.expectationFiles }
+    capturePolicy = if ($defaultCapturePolicy) { $defaultCapturePolicy } else { $config.capturePolicy }
     stopPolicy = [ordered]@{ stopAfterValidation = $StopAfterValidation }
     requestedBy = $RequestedBy
     createdAt = [DateTime]::UtcNow.ToString('o')
 }
 
-if ($defaultRequest.PSObject.Properties.Name -contains 'overrides') {
-    $requestDocument.overrides = $defaultRequest.overrides | ConvertTo-Json -Depth 100 | ConvertFrom-Json -Depth 100 -AsHashtable
+if ($null -ne $defaultOverrides) {
+    $requestDocument.overrides = $defaultOverrides | ConvertTo-Json -Depth 100 | ConvertFrom-Json -Depth 100 -AsHashtable
 }
 
 if ($null -ne $behaviorWatchRequest) {

--- a/tools/deploy-game-harness.ps1
+++ b/tools/deploy-game-harness.ps1
@@ -101,7 +101,7 @@ function Set-OrAppendManagedBlock {
         $pattern = [regex]::Escape($beginMarker) + '.*?' + [regex]::Escape($endMarker)
         if ([regex]::IsMatch($existing, $pattern, [System.Text.RegularExpressions.RegexOptions]::Singleline)) {
             $updated = [regex]::Replace($existing, $pattern, $managedBlock.TrimEnd(), [System.Text.RegularExpressions.RegexOptions]::Singleline)
-            Write-Utf8NoBomFile -Path $Path -Content $updated.TrimEnd() + [Environment]::NewLine
+            Write-Utf8NoBomFile -Path $Path -Content ($updated.TrimEnd() + [Environment]::NewLine)
             return 'updated'
         }
 

--- a/tools/tests/AutomationTools.Tests.ps1
+++ b/tools/tests/AutomationTools.Tests.ps1
@@ -289,6 +289,32 @@ Describe 'tools/automation/request-editor-evidence-run.ps1' {
         }
     }
 
+    It 'writes a schema-valid request artifact without a fixture' {
+        $sandboxPath = New-RepoSandboxDirectory
+
+        try {
+            $harnessPath = Join-Path $sandboxPath 'harness'
+            New-Item -ItemType Directory -Path $harnessPath -Force | Out-Null
+            Copy-Item -LiteralPath (Get-RepoPath -Path 'examples/pong-testbed/harness/inspection-run-config.json') -Destination (Join-Path $harnessPath 'inspection-run-config.json')
+
+            $result = Invoke-RepoScriptPassThru -ScriptPath 'tools/automation/request-editor-evidence-run.ps1' -Parameters @{
+                ProjectRoot = $sandboxPath
+                RequestedBy = 'automation-tools-default-request-test'
+                PassThru = $true
+            }
+
+            $result.schemaValid | Should -BeTrue
+            $config = Get-Content -LiteralPath (Join-Path $harnessPath 'inspection-run-config.json') -Raw | ConvertFrom-Json -Depth 100
+            $request = Get-Content -LiteralPath $result.requestPath -Raw | ConvertFrom-Json -Depth 100
+            $request.requestedBy | Should -Be 'automation-tools-default-request-test'
+            $request.scenarioId | Should -Be $config.scenarioId
+            $request.targetScene | Should -Be $config.targetScene
+        }
+        finally {
+            Remove-Item -LiteralPath $sandboxPath -Recurse -Force -ErrorAction SilentlyContinue
+        }
+    }
+
     It 'writes a schema-valid request artifact with a behavior-watch override fixture' {
         $sandboxPath = New-RepoSandboxDirectory
 

--- a/tools/tests/DeployGameHarness.Tests.ps1
+++ b/tools/tests/DeployGameHarness.Tests.ps1
@@ -41,6 +41,10 @@ config/name="Sandbox Game"
         $copilotInstructions = Get-Content -LiteralPath (Join-Path $gameRoot '.github/copilot-instructions.md') -Raw
         $copilotInstructions | Should -Match 'BEGIN AGENT_RUNTIME_HARNESS'
         $copilotInstructions | Should -Match 'evidence/scenegraph/latest/evidence-manifest.json'
+        $copilotInstructions | Should -Match 'https://github.com/RJAudas/godot-agent-harness/issues'
+
+        $agentsContent = Get-Content -LiteralPath (Join-Path $gameRoot 'AGENTS.md') -Raw
+        $agentsContent | Should -Match 'https://github.com/RJAudas/godot-agent-harness/issues'
     }
 
     It 'preserves an existing harness config file' {
@@ -56,6 +60,42 @@ config/name="Sandbox Game"
         } | Out-Null
 
         (Get-Content -LiteralPath $configPath -Raw) | Should -Be '{"scenarioId":"custom"}'
+    }
+
+    It 'updates existing managed Copilot and AGENTS blocks in place' {
+        $gameRoot = New-RepoSandboxDirectory
+        $projectPath = Join-Path $gameRoot 'project.godot'
+        Set-Content -LiteralPath $projectPath -Value 'config_version=5' -NoNewline
+        New-Item -ItemType Directory -Path (Join-Path $gameRoot '.github') -Force | Out-Null
+
+        Set-Content -LiteralPath (Join-Path $gameRoot '.github/copilot-instructions.md') -Value @'
+# Copilot Instructions
+
+<!-- BEGIN AGENT_RUNTIME_HARNESS -->
+old copilot block
+<!-- END AGENT_RUNTIME_HARNESS -->
+'@ -NoNewline
+
+        Set-Content -LiteralPath (Join-Path $gameRoot 'AGENTS.md') -Value @'
+# AGENTS.md
+
+<!-- BEGIN AGENT_RUNTIME_HARNESS -->
+old agents block
+<!-- END AGENT_RUNTIME_HARNESS -->
+'@ -NoNewline
+
+        Invoke-RepoScriptPassThru -ScriptPath 'tools/deploy-game-harness.ps1' -Parameters @{
+            GameRoot = $gameRoot
+            PassThru = $true
+        } | Out-Null
+
+        $copilotInstructions = Get-Content -LiteralPath (Join-Path $gameRoot '.github/copilot-instructions.md') -Raw
+        $copilotInstructions | Should -Not -Match 'old copilot block'
+        $copilotInstructions | Should -Match 'https://github.com/RJAudas/godot-agent-harness/issues'
+
+        $agentsContent = Get-Content -LiteralPath (Join-Path $gameRoot 'AGENTS.md') -Raw
+        $agentsContent | Should -Not -Match 'old agents block'
+        $agentsContent | Should -Match 'https://github.com/RJAudas/godot-agent-harness/issues'
     }
 
     It 'reports skipped operations when run with WhatIf' {

--- a/tools/tests/ScenegraphAutomationLoop.Tests.ps1
+++ b/tools/tests/ScenegraphAutomationLoop.Tests.ps1
@@ -194,6 +194,27 @@ Describe 'specs/003-editor-evidence-loop automation schemas' {
         $result.ParsedOutput.valid | Should -BeTrue
     }
 
+    It 'accepts a completed lifecycle status payload' {
+        $payloadPath = Join-Path $TestDrive 'automation-lifecycle-status.completed.json'
+        @{
+            requestId = 'pong-request-001'
+            runId = 'pong-run-001'
+            status = 'completed'
+            details = 'Autonomous run completed.'
+            timestamp = '2026-04-17T17:55:00Z'
+            controlPath = 'file_broker'
+            evidenceRefs = @('examples/pong-testbed/harness/expected-evidence-manifest.json')
+        } | ConvertTo-Json -Depth 20 | Set-Content -LiteralPath $payloadPath
+
+        $result = Invoke-RepoJsonScript -ScriptPath 'tools/validate-json.ps1' -Arguments @(
+            '-InputPath', $payloadPath,
+            '-SchemaPath', 'specs/003-editor-evidence-loop/contracts/automation-lifecycle-status.schema.json'
+        )
+
+        $result.ExitCode | Should -Be 0
+        $result.ParsedOutput.valid | Should -BeTrue
+    }
+
     It 'accepts a completed run result payload' {
         $payloadPath = Join-Path $TestDrive 'automation-run-result.json'
         @{
@@ -458,6 +479,16 @@ Describe 'examples/pong-testbed automation fixtures' {
         Assert-BuildFailureRunResult -Result $runResult -ExpectedPhase 'launching' -ExpectedDiagnosticCount 2
         Assert-BuildDiagnostic -Diagnostic $runResult.buildDiagnostics[0] -ExpectedResourcePath 'res://scripts/build_failures/syntax_error_root.gd' -ExpectedSourceKind 'script'
         Assert-BuildDiagnostic -Diagnostic $runResult.buildDiagnostics[1] -ExpectedResourcePath 'res://scripts/build_failures/syntax_error_child.gd' -ExpectedSourceKind 'script'
+    }
+
+    It 'accepts the completed lifecycle fixture' {
+        $result = Invoke-RepoJsonScript -ScriptPath 'tools/validate-json.ps1' -Arguments @(
+            '-InputPath', 'examples/pong-testbed/harness/automation/results/lifecycle-status.completed.expected.json',
+            '-SchemaPath', 'specs/003-editor-evidence-loop/contracts/automation-lifecycle-status.schema.json'
+        )
+
+        $result.ExitCode | Should -Be 0
+        $result.ParsedOutput.valid | Should -BeTrue
     }
 
     It 'accepts each failure and blocked run result fixture' {


### PR DESCRIPTION
## Summary
- preserve broker run metadata through stop finalization so un-result.json keeps equestId, unId, manifestPath, and outputDirectory
- emit terminal lifecycle artifacts for completed and failed runs instead of leaving lifecycle-status.json at stopping
- expose the canonical issue tracker URL in the plugin surface and deployed runtime-harness guidance
- harden the deploy/request helper scripts and cover the refreshed lifecycle/deploy paths with regression tests

Closes #7.

## Validation
- pwsh ./tools/tests/run-tool-tests.ps1
- host-project broker verification against D:\gameDev\pong, confirming terminal ailed/completed lifecycle artifacts and populated final run-result metadata