### PR TITLE
Fix: honor brokered runId overrides in persisted evidence manifests

### DIFF
--- a/addons/agent_runtime_harness/runtime/scenegraph_runtime.gd
+++ b/addons/agent_runtime_harness/runtime/scenegraph_runtime.gd
@@ -70,7 +70,7 @@ func configure_session(session_context: Dictionary) -> void:
 	set_physics_process(_behavior_watch_sampler.is_enabled())
 
 	if session_context.has("config_path"):
-		_load_session_config(String(session_context.get("config_path")))
+		_load_session_config(String(session_context.get("config_path")), session_context)
 
 	_send_debugger_message("session_configured", [_build_session_configuration_event()])
 
@@ -155,7 +155,7 @@ func _resolve_root_node() -> Node:
 	return get_tree().root
 
 
-func _load_session_config(config_path: String) -> void:
+func _load_session_config(config_path: String, caller_supplied: Dictionary = {}) -> void:
 	if not FileAccess.file_exists(config_path):
 		return
 
@@ -166,12 +166,18 @@ func _load_session_config(config_path: String) -> void:
 	if typeof(parsed) != TYPE_DICTIONARY:
 		return
 
-	_session_context["run_id"] = parsed.get("runId", _session_context.get("run_id", _build_identifier("run")))
-	_session_context["scenario_id"] = parsed.get("scenarioId", _session_context.get("scenario_id", InspectionConstants.DEFAULT_SCENARIO_ID))
-	_session_context["artifact_root"] = parsed.get("artifactRoot", _session_context.get("artifact_root", InspectionConstants.DEFAULT_MANIFEST_ARTIFACT_ROOT))
-	_session_context["output_directory"] = parsed.get("outputDirectory", _session_context.get("output_directory", InspectionConstants.DEFAULT_OUTPUT_DIRECTORY))
-	_session_context["capture_policy"] = parsed.get("capturePolicy", _session_context.get("capture_policy", {}))
-	_session_context["stop_policy"] = parsed.get("defaultRequestOverrides", {}).get("stopPolicy", _session_context.get("stop_policy", {}))
+	if not caller_supplied.has("run_id"):
+		_session_context["run_id"] = parsed.get("runId", _session_context.get("run_id", _build_identifier("run")))
+	if not caller_supplied.has("scenario_id"):
+		_session_context["scenario_id"] = parsed.get("scenarioId", _session_context.get("scenario_id", InspectionConstants.DEFAULT_SCENARIO_ID))
+	if not caller_supplied.has("artifact_root"):
+		_session_context["artifact_root"] = parsed.get("artifactRoot", _session_context.get("artifact_root", InspectionConstants.DEFAULT_MANIFEST_ARTIFACT_ROOT))
+	if not caller_supplied.has("output_directory"):
+		_session_context["output_directory"] = parsed.get("outputDirectory", _session_context.get("output_directory", InspectionConstants.DEFAULT_OUTPUT_DIRECTORY))
+	if not caller_supplied.has("capture_policy"):
+		_session_context["capture_policy"] = parsed.get("capturePolicy", _session_context.get("capture_policy", {}))
+	if not caller_supplied.has("stop_policy"):
+		_session_context["stop_policy"] = parsed.get("defaultRequestOverrides", {}).get("stopPolicy", _session_context.get("stop_policy", {}))
 
 	_expectations.clear()
 	for expectation_path_value in parsed.get("expectationFiles", []):


### PR DESCRIPTION
Fixes #9

## Problem

Brokered automation requests with a custom `runId` propagated it into `run-result.json` and `lifecycle-status.json`, but the persisted `evidence-manifest.json` kept the `runId` from `harness/inspection-run-config.json`. Final validation then failed with *Manifest runId did not match the active automation request.*

## Root cause

`ScenegraphRuntime.configure_session()` wrote broker-supplied values (including `run_id`) into `_session_context`, then called `_load_session_config()` which unconditionally overwrote `run_id`, `scenario_id`, `artifact_root`, `output_directory`, `capture_policy` and `stop_policy` with the values from the config file. `scenegraph_artifact_writer.gd` then wrote the stale config `runId` into the manifest (and derived `manifestId`).

## Fix

Treat the inspection-run-config as *defaults*. `configure_session` now passes the caller-supplied dictionary to `_load_session_config`, which skips any key the caller explicitly provided. Brokered overrides flow through to the manifest, while the direct-play path from `plugin.gd` (which only passes `config_path` + `requested_by`) continues to honor every field from the config file.

## Verification

- `pwsh ./tools/tests/run-tool-tests.ps1` → 84/84 passing.
- Pending: manual brokered re-run to confirm `evidence-manifest.json.runId` + `manifestId` match the override and final validation reports success.