### PR TITLE
Update Speckit and fix gitleaks pre-commit hook

### DIFF
--- a/.github/agents/speckit.plan.agent.md
+++ b/.github/agents/speckit.plan.agent.md
@@ -139,15 +139,11 @@ You **MUST** consider the user input before proceeding (if not empty).
    - Skip if project is purely internal (build scripts, one-off tools, etc.)
 
 3. **Agent context update**:
-   - Run `.specify/scripts/powershell/update-agent-context.ps1 -AgentType copilot`
-   - These scripts detect which AI agent is in use
-   - Update the appropriate agent-specific context file
-   - Add only new technology from current plan
-   - Preserve manual additions between markers
+   - Update the plan reference between the `<!-- SPECKIT START -->` and `<!-- SPECKIT END -->` markers in `.github/copilot-instructions.md` to point to the plan file created in step 1 (the IMPL_PLAN path)
 
-**Output**: data-model.md, /contracts/*, quickstart.md, agent-specific file
+**Output**: data-model.md, /contracts/*, quickstart.md, updated agent context file
 
 ## Key rules
 
-- Use absolute paths
+- Use absolute paths for filesystem operations; use project-relative paths for references in documentation and agent context files
 - ERROR on gate failures or unresolved clarifications

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -36,3 +36,8 @@ This repository builds a plugin-first Godot harness that gives coding agents mac
 - Place reusable fixture inputs under `tools/evals/fixtures/001-agent-tooling-foundation/`.
 - Place evidence helper scripts under `tools/evidence/`.
 - Place autonomous boundary contracts and run logs under `tools/automation/`.
+
+<!-- SPECKIT START -->
+For additional context about technologies to be used, project structure,
+shell commands, and other important information, read the current plan
+<!-- SPECKIT END -->

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,4 +2,5 @@ repos:
   - repo: https://github.com/gitleaks/gitleaks
     rev: v8.30.1
     hooks:
-      - id: gitleaks
+      - id: gitleaks-system
+        pass_filenames: false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,5 +2,7 @@ repos:
   - repo: https://github.com/gitleaks/gitleaks
     rev: v8.30.1
     hooks:
+      # Requires a local `gitleaks` binary on PATH because `gitleaks-system`
+      # uses the system-installed executable instead of a pre-commit-managed one.
       - id: gitleaks-system
         pass_filenames: false

--- a/.specify/init-options.json
+++ b/.specify/init-options.json
@@ -1,9 +1,10 @@
 {
   "ai": "copilot",
   "branch_numbering": "sequential",
+  "context_file": ".github/copilot-instructions.md",
   "here": true,
   "integration": "copilot",
   "preset": null,
   "script": "ps",
-  "speckit_version": "0.6.2.dev0"
+  "speckit_version": "0.7.4.dev0"
 }

--- a/.specify/integration.json
+++ b/.specify/integration.json
@@ -1,7 +1,4 @@
 {
   "integration": "copilot",
-  "version": "0.6.2.dev0",
-  "scripts": {
-    "update-context": ".specify/integrations/copilot/scripts/update-context.ps1"
-  }
+  "version": "0.7.4.dev0"
 }

--- a/.specify/integrations/copilot.manifest.json
+++ b/.specify/integrations/copilot.manifest.json
@@ -1,14 +1,14 @@
 {
   "integration": "copilot",
-  "version": "0.6.2.dev0",
-  "installed_at": "2026-04-11T19:49:13.106041+00:00",
+  "version": "0.7.4.dev0",
+  "installed_at": "2026-04-19T13:55:40.743881+00:00",
   "files": {
     ".github/agents/speckit.analyze.agent.md": "56285817b93f55ae926eade0528673d25ffcf441e8109492323bfbe8941be8f7",
     ".github/agents/speckit.checklist.agent.md": "53ce35462c1df402780e730ea54150a30872e6e0d6d44a8bd38dd8b5d42900a9",
     ".github/agents/speckit.clarify.agent.md": "97b14836d6174f0ef51d8bbda0b731c87ef0b011aa36ccd4171a2fc3d7e3280a",
     ".github/agents/speckit.constitution.agent.md": "58d35eb026f56bb7364d91b8b0382d5dd1249ded6c1449a2b69546693afb85f7",
     ".github/agents/speckit.implement.agent.md": "9dda40376414146a8992d09e6853976c75708ba4cad7d9df9fcd6e7faa8f0a4c",
-    ".github/agents/speckit.plan.agent.md": "82961180ad08d9c5f33003d673996dad0bf73d06d7e7b6f07e967cff0a103a0c",
+    ".github/agents/speckit.plan.agent.md": "a4900083ea38ad98fd243594bf45f2846bd7f815731b64f5dc94f7dcbfe318cc",
     ".github/agents/speckit.specify.agent.md": "5bbb5270836cc9a3286ce3ed96a500f3d383a54abb06aa11b01a2d2f76dbf39b",
     ".github/agents/speckit.tasks.agent.md": "d505523168e1f1c758350da9d45c08ff990ed8686d6bc8451db8b89a145768a4",
     ".github/agents/speckit.taskstoissues.agent.md": "12532e50c8f9aeb453a565aec6aa6f53abe53cf92926ca553b3d2c61b6b7b6e3",
@@ -20,9 +20,6 @@
     ".github/prompts/speckit.plan.prompt.md": "2098dae6bd9277335f31cb150b78bfb1de539c0491798e5cfe382c89ab0bcd0e",
     ".github/prompts/speckit.specify.prompt.md": "7b2cc4dc6462da1c96df46bac4f60e53baba3097f4b24ac3f9b684194458aa98",
     ".github/prompts/speckit.tasks.prompt.md": "88fc57c289f99d5e9d35c255f3e2683f73ecb0a5155dcb4d886f82f52b11841f",
-    ".github/prompts/speckit.taskstoissues.prompt.md": "2f9636d4f312a1470f000747cb62677fec0655d8b4e2357fa4fbf238965fa66d",
-    ".vscode/settings.json": "c6782d67fc76b9128803b03247ddd015d542a574ee80a4fe0aca2429aa7bfe08",
-    ".specify/integrations/copilot/scripts/update-context.ps1": "31b3cb0e13a4cbb93932ee0ac5de79436b30f58b1da63f73f8e82ca8050b9ea3",
-    ".specify/integrations/copilot/scripts/update-context.sh": "89abb5cf143d07d9bd4cb4e4fe2623ec850933674a5c3d2ce2236c65c99d4100"
+    ".github/prompts/speckit.taskstoissues.prompt.md": "2f9636d4f312a1470f000747cb62677fec0655d8b4e2357fa4fbf238965fa66d"
   }
 }

--- a/.specify/integrations/speckit.manifest.json
+++ b/.specify/integrations/speckit.manifest.json
@@ -1,18 +1,6 @@
 {
   "integration": "speckit",
-  "version": "0.6.2.dev0",
-  "installed_at": "2026-04-11T19:49:13.119696+00:00",
-  "files": {
-    ".specify/scripts/powershell/check-prerequisites.ps1": "bcb37804b0757c37799b65a9321c1d3fb7b7ddcab6703c55c5b9a142c9166bf1",
-    ".specify/scripts/powershell/common.ps1": "a221d648081292e5d122c40cfd411fcb6d9b7ffe293d43c148f46228658702e6",
-    ".specify/scripts/powershell/create-new-feature.ps1": "84227d4cde2af8ae7c854a2cbfb9145325cfce1be67f8018a63febcff8b1a272",
-    ".specify/scripts/powershell/setup-plan.ps1": "c13ec3f33330e74aa088979c69bf35fe641301aaa50b2c1203c10ce94bcad338",
-    ".specify/scripts/powershell/update-agent-context.ps1": "eac4ea87703a29835a3f416354bf29232cb60e81f16776669aa4aa28c23d7fc2",
-    ".specify/templates/agent-file-template.md": "55ed438c2e861444ef22f45fe5238f3ebf0dc1cb6e53067d7232fbbf4ce82892",
-    ".specify/templates/checklist-template.md": "312eee8291dfa984b21f95ddd0ca778e7a1f0b3a64bfc470d79762a3e3f5d7b8",
-    ".specify/templates/constitution-template.md": "ce7549540fa45543cca797a150201d868e64495fdff39dc38246fb17bd4024b3",
-    ".specify/templates/plan-template.md": "873e84b226fe3d24afe28046931b20db9bbb9210366428dc958a515349ed6e68",
-    ".specify/templates/spec-template.md": "785dc50d856dd92d6515eca0761e16dce0c9ba0a3cd07154fd33eae77932422a",
-    ".specify/templates/tasks-template.md": "5da92ac1fbf5be2f9018a5064497995bf3592761ccb6b3951503c63d851297e8"
-  }
+  "version": "0.7.4.dev0",
+  "installed_at": "2026-04-19T13:55:40.748713+00:00",
+  "files": {}
 }

--- a/.specify/workflows/speckit/workflow.yml
+++ b/.specify/workflows/speckit/workflow.yml
@@ -1,0 +1,63 @@
+schema_version: "1.0"
+workflow:
+  id: "speckit"
+  name: "Full SDD Cycle"
+  version: "1.0.0"
+  author: "GitHub"
+  description: "Runs specify → plan → tasks → implement with review gates"
+
+requires:
+  speckit_version: ">=0.7.2"
+  integrations:
+    any: ["copilot", "claude", "gemini"]
+
+inputs:
+  spec:
+    type: string
+    required: true
+    prompt: "Describe what you want to build"
+  integration:
+    type: string
+    default: "copilot"
+    prompt: "Integration to use (e.g. claude, copilot, gemini)"
+  scope:
+    type: string
+    default: "full"
+    enum: ["full", "backend-only", "frontend-only"]
+
+steps:
+  - id: specify
+    command: speckit.specify
+    integration: "{{ inputs.integration }}"
+    input:
+      args: "{{ inputs.spec }}"
+
+  - id: review-spec
+    type: gate
+    message: "Review the generated spec before planning."
+    options: [approve, reject]
+    on_reject: abort
+
+  - id: plan
+    command: speckit.plan
+    integration: "{{ inputs.integration }}"
+    input:
+      args: "{{ inputs.spec }}"
+
+  - id: review-plan
+    type: gate
+    message: "Review the plan before generating tasks."
+    options: [approve, reject]
+    on_reject: abort
+
+  - id: tasks
+    command: speckit.tasks
+    integration: "{{ inputs.integration }}"
+    input:
+      args: "{{ inputs.spec }}"
+
+  - id: implement
+    command: speckit.implement
+    integration: "{{ inputs.integration }}"
+    input:
+      args: "{{ inputs.spec }}"

--- a/.specify/workflows/workflow-registry.json
+++ b/.specify/workflows/workflow-registry.json
@@ -1,0 +1,13 @@
+{
+  "schema_version": "1.0",
+  "workflows": {
+    "speckit": {
+      "name": "Full SDD Cycle",
+      "version": "1.0.0",
+      "description": "Runs specify \u2192 plan \u2192 tasks \u2192 implement with review gates",
+      "source": "bundled",
+      "installed_at": "2026-04-19T13:55:40.862184+00:00",
+      "updated_at": "2026-04-19T13:55:40.862192+00:00"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

This updates the repository's GitHub Speckit integration to the newer 0.7.4.dev0 asset set and fixes the local Gitleaks pre-commit setup for environments that use a system-installed Gitleaks binary.

## What changed

- update Speckit integration metadata from 0.6.2.dev0 to 0.7.4.dev0
- add the bundled Speckit workflow definitions under `.specify/workflows/`
- update the Copilot instruction context to include the Speckit plan reference block
- refresh the Speckit plan agent guidance to update `.github/copilot-instructions.md` directly
- switch the pre-commit hook from `gitleaks` to `gitleaks-system`
- add `pass_filenames: false` so pre-commit does not pass file arguments that break `gitleaks git --pre-commit`

## Why

The Speckit upgrade brings the repository onto the newer generated integration layout.

The Gitleaks change avoids the pre-commit cached Go-built binary path and fixes the known argument-passing issue with `gitleaks-system`, which otherwise fails when pre-commit forwards filenames.

## Validation

- `pre-commit run gitleaks-system --all-files -v`
- `git commit` on the branch passed the Gitleaks hook
