### PR TITLE
fix: flush input-dispatch outcomes before persist (#25 sub-item 1)

### DIFF
--- a/addons/agent_runtime_harness/runtime/scenegraph_runtime.gd
+++ b/addons/agent_runtime_harness/runtime/scenegraph_runtime.gd
@@ -150,10 +150,13 @@ func persist_latest_bundle() -> Dictionary:
 		return {}
 
 	# Flush any undelivered input-dispatch events as skipped before the manifest
-	# is assembled. The _exit_tree flush only fires when the game process ends,
-	# but stopAfterValidation persists mid-run, so without this the outcomes
-	# file does not exist yet when the writer validates it. (issue #25 §1)
-	_flush_pending_input_dispatch_outcomes()
+	# is assembled, but only when the coordinator has signalled the run is
+	# ending (via set_termination). A mid-run persist — dock-button checkpoint,
+	# or stopAfterValidation=false continuing play — must not flush, because
+	# dispatch_remaining_as_skipped also disables further input dispatch for
+	# the rest of the session. (issue #25 §1; Copilot review on PR #27)
+	if _session_context.has("termination"):
+		_flush_pending_input_dispatch_outcomes()
 
 	var session_context := _session_context.duplicate(true)
 

--- a/addons/agent_runtime_harness/runtime/scenegraph_runtime.gd
+++ b/addons/agent_runtime_harness/runtime/scenegraph_runtime.gd
@@ -149,6 +149,12 @@ func persist_latest_bundle() -> Dictionary:
 	if _latest_snapshot.is_empty():
 		return {}
 
+	# Flush any undelivered input-dispatch events as skipped before the manifest
+	# is assembled. The _exit_tree flush only fires when the game process ends,
+	# but stopAfterValidation persists mid-run, so without this the outcomes
+	# file does not exist yet when the writer validates it. (issue #25 §1)
+	_flush_pending_input_dispatch_outcomes()
+
 	var session_context := _session_context.duplicate(true)
 
 	# Attach runtime error records for T016 (artifact writer flush).


### PR DESCRIPTION
## Summary

`persist_latest_bundle` runs the manifest validator, which checks that `input-dispatch-outcomes.jsonl` exists on disk. Under the default `stopAfterValidation=true` policy, the scene stops at the startup capture long before the declared dispatch frames (e.g. 30, 32) execute, so no events dispatch and no rows are appended. The existing flush in `_exit_tree` fires only when the game process exits — well after the manifest is already written.

**Symptom:** every successful input-dispatch run reported `failureKind: validation` with notes *"Manifest did not include an input-dispatch outcome artifact reference for the active run."* and *"Input dispatch was requested but input-dispatch-outcomes.jsonl was not written."*, even though the run itself completed cleanly.

**Fix:** flush any undelivered input-dispatch events as skipped at the top of `persist_latest_bundle`, before the writer assembles the manifest. `dispatch_remaining_as_skipped` is idempotent after the first full sweep, so the existing `_exit_tree` flush is a no-op on the second call and normal-exit behavior is unchanged.

Addresses issue #25 sub-item 1 — the umbrella issue (#25) stays open until all three substrate fixes land.

## Acceptance criteria (from issue #25 §1)

- [x] Every input-dispatch run that reaches frame-dispatch writes `input-dispatch-outcomes.jsonl` with one row per declared event.
- [x] The evidence manifest's `artifactRefs` includes an entry with `kind: input-dispatch-outcomes` pointing at the file.
- [x] Pong smoke test completes with `status: success`, not `failureKind: validation`.

## Runtime verification

Deployed to `D:\gameDev\pong` via `tools/deploy-game-harness.ps1 -AddonOnly`, then:

```powershell
pwsh ./tools/automation/invoke-input-dispatch.ps1 \
  -ProjectRoot 'D:/gameDev/pong' \
  -RequestJson '{"requestId":"pr1-fix","scenarioId":"pr1-fix","runId":"pr1-fix-run","targetScene":"res://main_menu.tscn",...,"inputDispatchScript":{"events":[{"kind":"key","identifier":"ENTER","phase":"press","frame":30},{"kind":"key","identifier":"ENTER","phase":"release","frame":32}]}}'
```

### Before fix (reproduces the bug)

```json
{
  "failureKind": "validation",
  "validationResult": {
    "bundleValid": false,
    "notes": [
      "Manifest did not include an input-dispatch outcome artifact reference for the active run.",
      "Input dispatch was requested but input-dispatch-outcomes.jsonl was not written."
    ]
  }
}
```

### After fix

```json
{
  "failureKind": null,
  "finalStatus": "completed",
  "validationResult": {
    "artifactRefsChecked": 4,
    "bundleValid": true,
    "notes": [
      "Manifest and referenced scenegraph artifacts exist for the active run.",
      "Input dispatch outcomes were validated for the active run."
    ]
  }
}
```

### Outcomes file on disk

```
evidence/automation/pr1-fix/input-dispatch-outcomes.jsonl
```

```jsonl
{"declaredFrame":30,"dispatchedFrame":-1,"eventIndex":0,"identifier":"ENTER","kind":"key","phase":"press","reasonMessage":"Run ended before the requested frame was reached.","runId":"pr1-fix-run","status":"skipped_frame_unreached"}
{"declaredFrame":32,"dispatchedFrame":-1,"eventIndex":1,"identifier":"ENTER","kind":"key","phase":"release","reasonMessage":"Run ended before the requested frame was reached.","runId":"pr1-fix-run","status":"skipped_frame_unreached"}
```

Both events recorded with the correct `runId`, both marked `skipped_frame_unreached` because stopAfterValidation fires at startup (well before frame 30). This is the *expected* status for a capture-only run; a run without stopAfterValidation would produce `dispatched` status instead.

### Manifest artifact ref

```json
{
  "kind": "input-dispatch-outcomes",
  "path": "evidence/automation/pr1-fix/input-dispatch-outcomes.jsonl",
  "mediaType": "application/jsonl",
  "description": "Per-event runtime input-dispatch outcomes captured during the run."
}
```

## Test plan

- [x] Pong smoke — before-fix reproduces `failureKind: validation` with both notes
- [x] Pong smoke — after-fix produces `bundleValid: true` with 2 outcome rows and the artifact ref
- [x] Normal-exit path unaffected — `dispatch_remaining_as_skipped` is idempotent, `_exit_tree` flush is a no-op on second call
- [ ] Dispatched-status case (run without stopAfterValidation, scene survives past frame 30) — not exercised in this PR; logic path is unchanged from master for events that dispatch normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)