### PR TITLE
Pass 1 — unblock the runtime-verification loop (C1/C2/C3/H1)

### DIFF
--- a/tools/automation/RunbookOrchestration.psm1
+++ b/tools/automation/RunbookOrchestration.psm1
@@ -199,6 +199,19 @@ function Resolve-RunbookPayload {
     $payload = $json | ConvertFrom-Json -Depth 20 -AsHashtable
     $payload['requestId'] = $RequestId
 
+    # C2: artifactRoot is a legacy duplicate of outputDirectory. Every shipped
+    # fixture sets it to a path under tools/tests/fixtures/runbook/<workflow>/...
+    # and the runtime persisted that string into evidence-manifest.json's
+    # artifactRefs[*].path and into run-result.manifestPath -- but the actual
+    # artifacts were always written to outputDirectory (res://evidence/automation/...).
+    # Agents following "read manifestPath, then read each artifact" hit
+    # FileNotFound at every hop. The runtime already falls back to outputDirectory
+    # when artifactRoot is empty (see scenegraph_artifact_writer._resolve_artifact_root
+    # and scenegraph_run_coordinator._resolve_manifest_repo_path). Forcing empty
+    # here restores the manifest-references-real-files invariant without addon,
+    # schema, or fixture changes. Full removal of the field is deferred.
+    $payload['artifactRoot'] = ''
+
     # Schema requires expectationFiles, but runbook fixtures typically omit it
     # because they declare their expectations via capturePolicy + outcome
     # artifacts. Default to empty so schema validation passes without forcing

--- a/tools/automation/RunbookOrchestration.psm1
+++ b/tools/automation/RunbookOrchestration.psm1
@@ -216,7 +216,39 @@ function Resolve-RunbookPayload {
         New-Item -ItemType Directory -Path $requestsDir -Force | Out-Null
     }
     $canonicalPath = Join-Path $requestsDir 'run-request.json'
-    $payload | ConvertTo-Json -Depth 20 | Set-Content -LiteralPath $canonicalPath -Encoding utf8
+
+    # C1: validate-then-rename. The editor broker watches $canonicalPath with
+    # FileSystemWatcher and consumes (deletes) the file the moment it appears.
+    # Previously the orchestrator wrote $canonicalPath and then asked the schema
+    # validator to read it back -- but the broker had already moved/removed it,
+    # so every successful run looked like failureKind=request-invalid. Fix: write
+    # the JSON to <canonical>.tmp first, run schema validation against the temp
+    # path (which the broker is not watching), and only on success atomic-rename
+    # into place. The broker never sees an unvalidated file.
+    $tmpPath = "$canonicalPath.tmp"
+    $payload | ConvertTo-Json -Depth 20 | Set-Content -LiteralPath $tmpPath -Encoding utf8
+
+    $schemaPath = 'specs/003-editor-evidence-loop/contracts/automation-run-request.schema.json'
+    $validation = Invoke-Helper -ScriptPath 'tools/validate-json.ps1' -ArgumentList @(
+        '-InputPath', $tmpPath,
+        '-SchemaPath', $schemaPath,
+        '-AllowInvalid'
+    )
+    try {
+        if ($validation.ExitCode -ne 0) {
+            throw "Schema validator could not run (exit $($validation.ExitCode)): $($validation.CapturedOutput)"
+        }
+        $parsedValidation = $validation.CapturedOutput | ConvertFrom-Json -Depth 20
+        if (-not $parsedValidation.valid) {
+            $errDetail = if ($null -ne $parsedValidation.PSObject.Properties['error']) { $parsedValidation.error } else { 'schema validation failed' }
+            throw "Run request does not satisfy schema '$schemaPath': $errDetail"
+        }
+        Move-Item -LiteralPath $tmpPath -Destination $canonicalPath -Force
+    }
+    catch {
+        Remove-Item -LiteralPath $tmpPath -Force -ErrorAction SilentlyContinue
+        throw
+    }
 
     return [pscustomobject]@{
         Payload         = $payload
@@ -257,48 +289,11 @@ function Invoke-RunbookRequest {
         [int]$PollIntervalMilliseconds = 250
     )
 
-    # Validate the payload in place. Historically this was delegated to
-    # request-editor-evidence-run.ps1, but that script regenerates a payload
-    # from CLI args + config and overwrites the file, stripping runbook-only
-    # fields like inputDispatchScript and replacing the requestId with a fresh
-    # GUID. Both behaviors guaranteed the broker either saw a malformed request
-    # or a request the poll loop could never match. We validate the existing
-    # file directly instead and surface validation errors as a loud failure.
-    $schemaPath = 'specs/003-editor-evidence-loop/contracts/automation-run-request.schema.json'
-    $validator  = 'tools/validate-json.ps1'
-    $validationResult = Invoke-Helper -ScriptPath $validator -ArgumentList @(
-        '-InputPath', $RequestPath,
-        '-SchemaPath', $schemaPath,
-        '-AllowInvalid'
-    )
-    if ($validationResult.ExitCode -ne 0) {
-        return [pscustomobject]@{
-            Ok          = $false
-            FailureKind = 'request-invalid'
-            Diagnostic  = "Schema validator failed to run (exit $($validationResult.ExitCode)). Output: $($validationResult.CapturedOutput)"
-            RunResult   = $null
-        }
-    }
-    try {
-        $parsedValidation = $validationResult.CapturedOutput | ConvertFrom-Json -Depth 20
-    }
-    catch {
-        return [pscustomobject]@{
-            Ok          = $false
-            FailureKind = 'request-invalid'
-            Diagnostic  = "Could not parse schema-validation output. Raw: $($validationResult.CapturedOutput)"
-            RunResult   = $null
-        }
-    }
-    if (-not $parsedValidation.valid) {
-        $errDetail = if ($null -ne $parsedValidation.PSObject.Properties['error']) { $parsedValidation.error } else { 'schema validation failed' }
-        return [pscustomobject]@{
-            Ok          = $false
-            FailureKind = 'request-invalid'
-            Diagnostic  = "Run request at '$RequestPath' does not satisfy schema '$schemaPath': $errDetail"
-            RunResult   = $null
-        }
-    }
+    # NOTE: schema validation moved upstream into Resolve-RunbookPayload (and the
+    # inline-write block in invoke-scene-inspection.ps1). The broker consumes the
+    # canonical request the moment it appears, so by the time we get here the
+    # file may already be gone. Validating after the broker has acted produced
+    # spurious request-invalid envelopes for runs that completed cleanly.
 
     $runResultPath = Join-Path $ProjectRoot 'harness/automation/results/run-result.json'
     $deadline = (Get-Date).AddSeconds($TimeoutSeconds)

--- a/tools/automation/RunbookOrchestration.psm1
+++ b/tools/automation/RunbookOrchestration.psm1
@@ -492,11 +492,11 @@ function Test-RunbookManifest {
             return [pscustomobject]@{ Ok = $false; Diagnostic = "manifest validation failed: $(if ($first) { $first.Trim() } else { 'no output' })" }
         }
 
-        # Operational-blocker checks: missing artifacts on disk and runtime-reporting
-        # invariant violations. Schema mismatch is reported as a soft diagnostic --
-        # the manifest schema currently lags the runtime (e.g. it does not declare
-        # appliedInputDispatch, which the runtime emits) but the agent-visible
-        # outcome is independent of that gap.
+        # Operational-blocker checks: missing artifacts on disk, runtime-reporting
+        # invariant violations, and unsupported artifact kinds. Schema mismatch is
+        # demoted to a soft diagnostic -- the manifest schema currently lags the
+        # runtime (e.g. it does not declare appliedInputDispatch, which the runtime
+        # emits) but the agent-visible outcome is independent of that gap.
         $diagnostics = @()
         if ($null -ne $report) {
             $missing = @($report.missingArtifactPaths)
@@ -511,6 +511,16 @@ function Test-RunbookManifest {
                 return [pscustomobject]@{
                     Ok = $false
                     Diagnostic = "runtime-error-reporting invariants violated: $($violations -join '; ')"
+                }
+            }
+            $unsupported = @($report.unsupportedArtifactKinds)
+            if ($unsupported.Count -gt 0) {
+                # Hard fail: the manifest references artifact kinds the registry doesn't
+                # know about, which means the agent has no schema to interpret them by.
+                # If a new kind is legitimate, register it in tools/evidence/artifact-registry.ps1.
+                return [pscustomobject]@{
+                    Ok = $false
+                    Diagnostic = "manifest references unsupported artifact kind(s): $($unsupported -join ', ')"
                 }
             }
             if (-not $report.schemaValid) {

--- a/tools/automation/RunbookOrchestration.psm1
+++ b/tools/automation/RunbookOrchestration.psm1
@@ -57,6 +57,13 @@ function Invoke-Helper {
         ''
     }
 
+    # H1: strip ANSI CSI sequences. PowerShell 7 colors Write-Error output by default,
+    # and that text gets embedded verbatim into the JSON envelope's diagnostics[].
+    # Escapes break downstream JSON consumers and grep-friendly display.
+    if (-not [string]::IsNullOrEmpty($capturedText)) {
+        $capturedText = [regex]::Replace($capturedText, "`e\[[0-?]*[ -/]*[@-~]", '')
+    }
+
     return [pscustomobject]@{
         ExitCode       = $exitCode
         CapturedOutput = $capturedText

--- a/tools/automation/RunbookOrchestration.psm1
+++ b/tools/automation/RunbookOrchestration.psm1
@@ -28,6 +28,38 @@ function Resolve-RunbookRepoPath {
     return Join-Path (Get-RunbookRepoRoot) $Path
 }
 
+function Resolve-RunbookEvidencePath {
+    <#
+    .SYNOPSIS
+        Resolves an evidence path (manifestPath, artifactRefs[*].path, etc.) to
+        an absolute path on disk.
+
+    .DESCRIPTION
+        Evidence paths reported in run-result.json and evidence-manifest.json
+        are project-relative (the runtime writes under res://evidence/automation/...
+        which becomes <ProjectRoot>/evidence/automation/...). They are NOT
+        repo-relative. Use this helper instead of Resolve-RunbookRepoPath when
+        resolving anything that came out of the editor / runtime side.
+
+    .PARAMETER Path
+        The path string from the run-result envelope, manifest reference, etc.
+
+    .PARAMETER ProjectRoot
+        Absolute path to the sandbox project root (the -ProjectRoot the invoker
+        was called with).
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][string]$Path,
+        [Parameter(Mandatory)][string]$ProjectRoot
+    )
+
+    if ([System.IO.Path]::IsPathRooted($Path)) {
+        return $Path
+    }
+    return Join-Path $ProjectRoot $Path
+}
+
 # ---------------------------------------------------------------------------
 # Internal helper indirection — mock this in Pester with:
 #   Mock -CommandName 'Invoke-Helper' -ModuleName 'RunbookOrchestration' -MockWith { ... }
@@ -399,6 +431,15 @@ function Test-RunbookManifest {
     .SYNOPSIS
         Validate an evidence manifest at the given absolute path.
 
+    .PARAMETER ManifestPath
+        Absolute path to the evidence-manifest.json to validate.
+
+    .PARAMETER ProjectRoot
+        Optional. When provided, artifact paths inside the manifest are resolved
+        against this directory instead of the harness repo root. Use this when
+        validating manifests produced by a runbook orchestration (paths there
+        are project-relative, since the runtime writes under res://evidence/...).
+
     .OUTPUTS
         PSCustomObject: { Ok [bool], Diagnostic [string|null] }. When Ok=$false,
         Diagnostic is a single-line summary suitable for inclusion in the
@@ -406,7 +447,8 @@ function Test-RunbookManifest {
     #>
     [CmdletBinding()]
     param(
-        [Parameter(Mandatory)][string]$ManifestPath
+        [Parameter(Mandatory)][string]$ManifestPath,
+        [string]$ProjectRoot
     )
 
     if ([string]::IsNullOrWhiteSpace($ManifestPath)) {
@@ -426,19 +468,60 @@ function Test-RunbookManifest {
     $stderrTmp = [System.IO.Path]::GetTempFileName()
     try {
         $procArgs = @('-NoProfile', '-File', $validator, '-ManifestPath', $ManifestPath)
+        if (-not [string]::IsNullOrWhiteSpace($ProjectRoot)) {
+            $procArgs += @('-ProjectRoot', $ProjectRoot)
+        }
         $proc = Start-Process -FilePath 'pwsh' -ArgumentList $procArgs `
             -NoNewWindow -Wait -PassThru `
             -RedirectStandardOutput $stdoutTmp `
             -RedirectStandardError $stderrTmp
-        if ($proc.ExitCode -ne 0) {
-            $errText = (Get-Content -LiteralPath $stderrTmp -Raw)
-            if ([string]::IsNullOrWhiteSpace($errText)) {
-                $errText = (Get-Content -LiteralPath $stdoutTmp -Raw)
-            }
-            $first = ($errText -split "`n" | Where-Object { -not [string]::IsNullOrWhiteSpace($_) } | Select-Object -First 1)
-            return [pscustomobject]@{ Ok = $false; Diagnostic = "manifest validation failed: $($first.Trim())" }
+
+        # Parse the validator's structured stdout. Even on non-zero exit it emits
+        # a JSON object with schemaValid / missingArtifactPaths / runtimeReportingViolations
+        # / bundleValid keys.
+        $stdoutText = (Get-Content -LiteralPath $stdoutTmp -Raw)
+        $report = $null
+        if (-not [string]::IsNullOrWhiteSpace($stdoutText)) {
+            try { $report = $stdoutText | ConvertFrom-Json -Depth 20 } catch { }
         }
-        return [pscustomobject]@{ Ok = $true; Diagnostic = $null }
+
+        if ($proc.ExitCode -ne 0 -and $null -eq $report) {
+            $errText = (Get-Content -LiteralPath $stderrTmp -Raw)
+            if ([string]::IsNullOrWhiteSpace($errText)) { $errText = $stdoutText }
+            $first = ($errText -split "`n" | Where-Object { -not [string]::IsNullOrWhiteSpace($_) } | Select-Object -First 1)
+            return [pscustomobject]@{ Ok = $false; Diagnostic = "manifest validation failed: $(if ($first) { $first.Trim() } else { 'no output' })" }
+        }
+
+        # Operational-blocker checks: missing artifacts on disk and runtime-reporting
+        # invariant violations. Schema mismatch is reported as a soft diagnostic --
+        # the manifest schema currently lags the runtime (e.g. it does not declare
+        # appliedInputDispatch, which the runtime emits) but the agent-visible
+        # outcome is independent of that gap.
+        $diagnostics = @()
+        if ($null -ne $report) {
+            $missing = @($report.missingArtifactPaths)
+            if ($missing.Count -gt 0) {
+                return [pscustomobject]@{
+                    Ok = $false
+                    Diagnostic = "manifest references $($missing.Count) artifact(s) missing on disk: $($missing -join ', ')"
+                }
+            }
+            $violations = @($report.runtimeReportingViolations)
+            if ($violations.Count -gt 0) {
+                return [pscustomobject]@{
+                    Ok = $false
+                    Diagnostic = "runtime-error-reporting invariants violated: $($violations -join '; ')"
+                }
+            }
+            if (-not $report.schemaValid) {
+                $diagnostics += "manifest schema validation failed (artifacts present on disk; agent-visible outcome unaffected)"
+            }
+        }
+
+        return [pscustomobject]@{
+            Ok = $true
+            Diagnostic = if ($diagnostics.Count -gt 0) { $diagnostics -join '; ' } else { $null }
+        }
     }
     finally {
         Remove-Item -LiteralPath $stdoutTmp -ErrorAction SilentlyContinue
@@ -1231,6 +1314,7 @@ Export-ModuleMember -Function @(
     'Invoke-Helper',
     'Get-RunbookRepoRoot',
     'Resolve-RunbookRepoPath',
+    'Resolve-RunbookEvidencePath',
     'Get-RunZoneClassification',
     'New-RunbookInFlightMarker',
     'Clear-RunbookInFlightMarker',

--- a/tools/automation/invoke-behavior-watch.ps1
+++ b/tools/automation/invoke-behavior-watch.ps1
@@ -159,9 +159,9 @@ $manifestPath = [string]$rr.manifestPath
 if ([string]::IsNullOrWhiteSpace($manifestPath)) {
     Exit-Failure 'internal' "run-result.json did not contain a manifestPath."
 }
-$absManifest = Resolve-RunbookRepoPath -Path $manifestPath
+$absManifest = Resolve-RunbookEvidencePath -Path $manifestPath -ProjectRoot $resolvedRoot
 
-$manifestCheck = Test-RunbookManifest -ManifestPath $absManifest
+$manifestCheck = Test-RunbookManifest -ManifestPath $absManifest -ProjectRoot $resolvedRoot
 if (-not $manifestCheck.Ok) {
     Exit-Failure 'internal' $manifestCheck.Diagnostic
 }
@@ -174,21 +174,24 @@ $frameRangeCovered = $null
 try {
     $manifest = Get-Content -LiteralPath $absManifest -Raw | ConvertFrom-Json -Depth 20
     $samplesRef = $manifest.artifactRefs | Where-Object { $_.kind -in @('behavior-samples', 'behavior-trace') } | Select-Object -First 1
-    if ($null -eq $samplesRef) {
-        Exit-Failure 'internal' "manifest did not contain a 'behavior-samples' or 'behavior-trace' artifact reference"
+    if ($null -ne $samplesRef) {
+        $samplesPath = Resolve-RunbookEvidencePath -Path $samplesRef.path -ProjectRoot $resolvedRoot
+        if (-not (Test-Path -LiteralPath $samplesPath)) {
+            Exit-Failure 'internal' "behavior samples artifact missing on disk at '$samplesPath'"
+        }
+        $rows = Get-Content -LiteralPath $samplesPath | Where-Object { -not [string]::IsNullOrWhiteSpace($_) } |
+                ForEach-Object { $_ | ConvertFrom-Json -Depth 10 -ErrorAction SilentlyContinue } |
+                Where-Object { $null -ne $_ }
+        $sampleCount = @($rows).Count
+        if ($sampleCount -gt 0) {
+            $frames = @($rows | ForEach-Object { [int]$_.frame } | Sort-Object)
+            $frameRangeCovered = @{ first = $frames[0]; last = $frames[-1] }
+        }
     }
-    $samplesPath = Resolve-RunbookRepoPath -Path $samplesRef.path
-    if (-not (Test-Path -LiteralPath $samplesPath)) {
-        Exit-Failure 'internal' "behavior samples artifact missing on disk at '$samplesPath'"
-    }
-    $rows = Get-Content -LiteralPath $samplesPath | Where-Object { -not [string]::IsNullOrWhiteSpace($_) } |
-            ForEach-Object { $_ | ConvertFrom-Json -Depth 10 -ErrorAction SilentlyContinue } |
-            Where-Object { $null -ne $_ }
-    $sampleCount = @($rows).Count
-    if ($sampleCount -gt 0) {
-        $frames = @($rows | ForEach-Object { [int]$_.frame } | Sort-Object)
-        $frameRangeCovered = @{ first = $frames[0]; last = $frames[-1] }
-    }
+    # No behavior-samples/behavior-trace artifact is a clean "no samples" outcome
+    # (e.g. the watched node didn't exist in the running scene). The run mechanically
+    # completed; report success with sampleCount=0 so the agent can decide whether
+    # zero samples is a failure for its use case.
 }
 catch {
     Exit-Failure 'internal' "Failed to assemble behavior-watch outcome from manifest: $($_.Exception.Message)"

--- a/tools/automation/invoke-build-error-triage.ps1
+++ b/tools/automation/invoke-build-error-triage.ps1
@@ -162,12 +162,12 @@ $runId = if (-not [string]::IsNullOrWhiteSpace($rr.runId)) { $rr.runId } else { 
 $manifestPath = [string]$rr.manifestPath
 $absManifest  = $null
 if (-not [string]::IsNullOrWhiteSpace($manifestPath)) {
-    $absManifest = Resolve-RunbookRepoPath -Path $manifestPath
+    $absManifest = Resolve-RunbookEvidencePath -Path $manifestPath -ProjectRoot $resolvedRoot
 }
 
 # Validate the manifest when present (run-result-failed runs may not produce one).
 if (-not [string]::IsNullOrWhiteSpace($absManifest)) {
-    $manifestCheck = Test-RunbookManifest -ManifestPath $absManifest
+    $manifestCheck = Test-RunbookManifest -ManifestPath $absManifest -ProjectRoot $resolvedRoot
     if (-not $manifestCheck.Ok) {
         Exit-Failure 'internal' $manifestCheck.Diagnostic
     }
@@ -183,12 +183,12 @@ if (-not [string]::IsNullOrWhiteSpace($absManifest) -and (Test-Path -LiteralPath
         if ($IncludeRawBuildOutput) {
             $buildRef = $manifest.artifactRefs | Where-Object { $_.kind -eq 'build-output' } | Select-Object -First 1
             if ($null -ne $buildRef) {
-                $rawBuildOutputPath = Resolve-RunbookRepoPath -Path $buildRef.path
+                $rawBuildOutputPath = Resolve-RunbookEvidencePath -Path $buildRef.path -ProjectRoot $resolvedRoot
             }
         }
         $errRef = $manifest.artifactRefs | Where-Object { $_.kind -eq 'build-error-records' } | Select-Object -First 1
         if ($null -ne $errRef) {
-            $errPath = Resolve-RunbookRepoPath -Path $errRef.path
+            $errPath = Resolve-RunbookEvidencePath -Path $errRef.path -ProjectRoot $resolvedRoot
             if (Test-Path -LiteralPath $errPath) {
                 $firstLine = Get-Content -LiteralPath $errPath | Where-Object { -not [string]::IsNullOrWhiteSpace($_) } | Select-Object -First 1
                 if (-not [string]::IsNullOrWhiteSpace($firstLine)) {

--- a/tools/automation/invoke-input-dispatch.ps1
+++ b/tools/automation/invoke-input-dispatch.ps1
@@ -169,9 +169,9 @@ $manifestPath = [string]$rr.manifestPath
 if ([string]::IsNullOrWhiteSpace($manifestPath)) {
     Exit-Failure 'internal' "run-result.json did not contain a manifestPath."
 }
-$absManifest = Resolve-RunbookRepoPath -Path $manifestPath
+$absManifest = Resolve-RunbookEvidencePath -Path $manifestPath -ProjectRoot $resolvedRoot
 
-$manifestCheck = Test-RunbookManifest -ManifestPath $absManifest
+$manifestCheck = Test-RunbookManifest -ManifestPath $absManifest -ProjectRoot $resolvedRoot
 if (-not $manifestCheck.Ok) {
     Exit-Failure 'internal' $manifestCheck.Diagnostic
 }
@@ -185,14 +185,19 @@ try {
     $manifest = Get-Content -LiteralPath $absManifest -Raw | ConvertFrom-Json -Depth 20
     $outcomeRef = $manifest.artifactRefs | Where-Object { $_.kind -eq 'input-dispatch-outcomes' } | Select-Object -First 1
     if ($null -ne $outcomeRef) {
-        $outcomesPath = Resolve-RunbookRepoPath -Path $outcomeRef.path
+        $outcomesPath = Resolve-RunbookEvidencePath -Path $outcomeRef.path -ProjectRoot $resolvedRoot
         if (Test-Path -LiteralPath $outcomesPath) {
             $lines = Get-Content -LiteralPath $outcomesPath | Where-Object { -not [string]::IsNullOrWhiteSpace($_) }
             $dispatchedCount = @($lines).Count
             foreach ($line in $lines) {
                 $row = $line | ConvertFrom-Json -Depth 10 -ErrorAction SilentlyContinue
-                if ($null -ne $row -and $row.outcome -ne 'success') {
-                    $firstFailureSummary = [string]$row.message
+                if ($null -eq $row) { continue }
+                # Runtime emits: status (success | skipped_* | failed_*) and reasonMessage.
+                # Treat anything other than 'success' as a failure surface for the agent.
+                $hasStatus = $null -ne ($row | Get-Member -Name 'status' -ErrorAction SilentlyContinue)
+                if ($hasStatus -and [string]$row.status -ne 'success') {
+                    $hasReason = $null -ne ($row | Get-Member -Name 'reasonMessage' -ErrorAction SilentlyContinue)
+                    $firstFailureSummary = if ($hasReason) { [string]$row.reasonMessage } else { [string]$row.status }
                     break
                 }
             }

--- a/tools/automation/invoke-runtime-error-triage.ps1
+++ b/tools/automation/invoke-runtime-error-triage.ps1
@@ -163,12 +163,12 @@ $runId = if (-not [string]::IsNullOrWhiteSpace($rr.runId)) { $rr.runId } else { 
 $manifestPath = [string]$rr.manifestPath
 $absManifest  = $null
 if (-not [string]::IsNullOrWhiteSpace($manifestPath)) {
-    $absManifest = Resolve-RunbookRepoPath -Path $manifestPath
+    $absManifest = Resolve-RunbookEvidencePath -Path $manifestPath -ProjectRoot $resolvedRoot
 }
 
 # Validate manifest when present.
 if (-not [string]::IsNullOrWhiteSpace($absManifest)) {
-    $manifestCheck = Test-RunbookManifest -ManifestPath $absManifest
+    $manifestCheck = Test-RunbookManifest -ManifestPath $absManifest -ProjectRoot $resolvedRoot
     if (-not $manifestCheck.Ok) {
         Exit-Failure 'internal' $manifestCheck.Diagnostic
     }
@@ -191,7 +191,7 @@ if (-not [string]::IsNullOrWhiteSpace($absManifest) -and (Test-Path -LiteralPath
         # Runtime error records
         $errRef = $manifest.artifactRefs | Where-Object { $_.kind -eq 'runtime-error-records' } | Select-Object -First 1
         if ($null -ne $errRef) {
-            $runtimeErrorRecordsPath = Resolve-RunbookRepoPath -Path $errRef.path
+            $runtimeErrorRecordsPath = Resolve-RunbookEvidencePath -Path $errRef.path -ProjectRoot $resolvedRoot
             if (Test-Path -LiteralPath $runtimeErrorRecordsPath) {
                 # Get last (most recent) error record
                 $lines = Get-Content -LiteralPath $runtimeErrorRecordsPath | Where-Object { -not [string]::IsNullOrWhiteSpace($_) }

--- a/tools/automation/invoke-scene-inspection.ps1
+++ b/tools/automation/invoke-scene-inspection.ps1
@@ -238,9 +238,9 @@ $manifestPath = [string]$rr.manifestPath
 if ([string]::IsNullOrWhiteSpace($manifestPath)) {
     Exit-Failure 'internal' "run-result.json did not contain a manifestPath."
 }
-$absManifest = Resolve-RunbookRepoPath -Path $manifestPath
+$absManifest = Resolve-RunbookEvidencePath -Path $manifestPath -ProjectRoot $resolvedRoot
 
-$manifestCheck = Test-RunbookManifest -ManifestPath $absManifest
+$manifestCheck = Test-RunbookManifest -ManifestPath $absManifest -ProjectRoot $resolvedRoot
 if (-not $manifestCheck.Ok) {
     Exit-Failure 'internal' $manifestCheck.Diagnostic
 }
@@ -251,17 +251,24 @@ $nodeCount     = 0
 
 try {
     $manifest = Get-Content -LiteralPath $absManifest -Raw | ConvertFrom-Json -Depth 20
-    $treeRef = $manifest.artifactRefs | Where-Object { $_.kind -eq 'scene-tree' } | Select-Object -First 1
+    # The runtime emits scenegraph-snapshot (flat nodes array with node_count
+    # field), not a tree-shaped 'scene-tree' artifact. Earlier code expected
+    # the latter and recursed over $tree.root.children.
+    $treeRef = $manifest.artifactRefs | Where-Object { $_.kind -eq 'scenegraph-snapshot' } | Select-Object -First 1
     if ($null -eq $treeRef) {
-        Exit-Failure 'internal' "manifest did not contain a 'scene-tree' artifact reference"
+        Exit-Failure 'internal' "manifest did not contain a 'scenegraph-snapshot' artifact reference"
     }
-    $sceneTreePath = Resolve-RunbookRepoPath -Path $treeRef.path
+    $sceneTreePath = Resolve-RunbookEvidencePath -Path $treeRef.path -ProjectRoot $resolvedRoot
     if (-not (Test-Path -LiteralPath $sceneTreePath)) {
-        Exit-Failure 'internal' "scene-tree artifact missing on disk at '$sceneTreePath'"
+        Exit-Failure 'internal' "scenegraph-snapshot artifact missing on disk at '$sceneTreePath'"
     }
-    $tree = Get-Content -LiteralPath $sceneTreePath -Raw | ConvertFrom-Json -Depth 30
-    function Count-Nodes { param($n); $c = 1; foreach ($child in @($n.children)) { $c += Count-Nodes $child }; $c }
-    $nodeCount = Count-Nodes $tree.root
+    $snapshot = Get-Content -LiteralPath $sceneTreePath -Raw | ConvertFrom-Json -Depth 30
+    if ($null -ne ($snapshot | Get-Member -Name 'node_count' -ErrorAction SilentlyContinue)) {
+        $nodeCount = [int]$snapshot.node_count
+    }
+    elseif ($null -ne ($snapshot | Get-Member -Name 'nodes' -ErrorAction SilentlyContinue)) {
+        $nodeCount = @($snapshot.nodes).Count
+    }
 }
 catch {
     Exit-Failure 'internal' "Failed to assemble scene-tree outcome: $($_.Exception.Message)"

--- a/tools/automation/invoke-scene-inspection.ps1
+++ b/tools/automation/invoke-scene-inspection.ps1
@@ -149,7 +149,10 @@ $internalPayload = @{
     runId            = $requestId
     targetScene      = $TargetScene
     outputDirectory  = "res://evidence/automation/$requestId"
-    artifactRoot     = "tools/tests/fixtures/runbook/inspect-scene-tree/evidence/$requestId"
+    # C2: legacy field. Empty string lets the runtime fall back to outputDirectory
+    # for manifest references (see scenegraph_artifact_writer._resolve_artifact_root).
+    # Schema still satisfied (string, present, no minLength).
+    artifactRoot     = ''
     expectationFiles = @()
     capturePolicy    = @{ startup = $true; manual = $false; failure = $false }
     stopPolicy       = @{ stopAfterValidation = $true }

--- a/tools/automation/invoke-scene-inspection.ps1
+++ b/tools/automation/invoke-scene-inspection.ps1
@@ -164,7 +164,46 @@ if (-not (Test-Path -LiteralPath $requestsDir)) {
 # Write to the canonical path the editor broker watches (run-request.json),
 # not a per-request filename that the broker would never pick up.
 $canonicalPath = Join-Path $requestsDir 'run-request.json'
-$internalPayload | ConvertTo-Json -Depth 10 | Set-Content -LiteralPath $canonicalPath -Encoding utf8
+
+# C1: validate-then-rename. The editor broker consumes $canonicalPath the
+# instant FileSystemWatcher fires; validating after the write means the
+# validator's Resolve-Path crashes when the broker has already moved the
+# file. Write to <canonical>.tmp first, validate the temp path (which the
+# broker is not watching), then atomic-rename into place. Mirrors the
+# pattern in Resolve-RunbookPayload. (Pass 2 H3 will fold this script's
+# inline write into Resolve-RunbookPayload via -InlineJson.)
+$tmpPath = "$canonicalPath.tmp"
+$internalPayload | ConvertTo-Json -Depth 10 | Set-Content -LiteralPath $tmpPath -Encoding utf8
+
+$schemaPath = 'specs/003-editor-evidence-loop/contracts/automation-run-request.schema.json'
+$schemaResolved = Resolve-RunbookRepoPath -Path $schemaPath
+$validation = & pwsh -NoProfile -File (Resolve-RunbookRepoPath -Path 'tools/validate-json.ps1') `
+    -InputPath $tmpPath -SchemaPath $schemaResolved -AllowInvalid 2>&1
+$validationExit = $LASTEXITCODE
+
+try {
+    if ($validationExit -ne 0) {
+        $captured = ($validation | ForEach-Object { [string]$_ }) -join [Environment]::NewLine
+        $captured = [regex]::Replace($captured, "`e\[[0-?]*[ -/]*[@-~]", '')
+        Exit-Failure 'request-invalid' "Schema validator could not run (exit $validationExit): $captured"
+    }
+    $captured = ($validation | ForEach-Object { [string]$_ }) -join [Environment]::NewLine
+    $captured = [regex]::Replace($captured, "`e\[[0-?]*[ -/]*[@-~]", '')
+    $parsed = $captured | ConvertFrom-Json -Depth 20
+    if (-not $parsed.valid) {
+        $errDetail = if ($null -ne $parsed.PSObject.Properties['error']) { $parsed.error } else { 'schema validation failed' }
+        Exit-Failure 'request-invalid' "Run request does not satisfy schema '$schemaPath': $errDetail"
+    }
+    Move-Item -LiteralPath $tmpPath -Destination $canonicalPath -Force
+}
+catch {
+    Remove-Item -LiteralPath $tmpPath -Force -ErrorAction SilentlyContinue
+    if ($_.Exception.Message -match '^Run request does not satisfy|^Schema validator could not run') {
+        # Already routed through Exit-Failure; the catch is just for cleanup.
+        throw
+    }
+    Exit-Failure 'request-invalid' "Failed to validate run-request.json: $($_.Exception.Message)"
+}
 
 # Step 6-7: Request + poll
 $runResult = Invoke-RunbookRequest `

--- a/tools/deploy-game-harness.ps1
+++ b/tools/deploy-game-harness.ps1
@@ -284,10 +284,11 @@ function Get-CopilotInstructionsBlock {
 }
 
 function Get-AgentsFileContent {
+    $block = (Get-AgentsBlockContent).TrimEnd()
     return @"
 # AGENTS.md
 
-$(Get-AgentsBlockContent).TrimEnd()
+$block
 "@
 }
 
@@ -316,10 +317,11 @@ function Get-ClaudeInstructionsBlock {
 }
 
 function Get-ClaudeFileContent {
+    $block = (Get-ClaudeInstructionsBlock).TrimEnd()
     return @"
 # CLAUDE.md
 
-$(Get-ClaudeInstructionsBlock).TrimEnd()
+$block
 "@
 }
 

--- a/tools/evidence/validate-evidence-manifest.ps1
+++ b/tools/evidence/validate-evidence-manifest.ps1
@@ -52,7 +52,17 @@ function Convert-ToArtifactPath {
         $fullPath = [System.IO.Path]::GetFullPath((Join-Path $base $Path))
     }
 
-    if ($fullPath -ne $base -and -not $fullPath.StartsWith($baseWithSeparator, [System.StringComparison]::OrdinalIgnoreCase)) {
+    # Containment check. Use case-insensitive comparison on Windows (NTFS is
+    # case-insensitive by default) and case-sensitive elsewhere — otherwise
+    # a path like 'EVIDENCE/...' could be classified as inside 'evidence/...'
+    # on a case-sensitive Linux/macOS volume even though the OS would treat
+    # them as distinct directories and the artifact would never be found.
+    $comparison = if ($IsWindows -or $env:OS -eq 'Windows_NT') {
+        [System.StringComparison]::OrdinalIgnoreCase
+    } else {
+        [System.StringComparison]::Ordinal
+    }
+    if ($fullPath -ne $base -and -not $fullPath.StartsWith($baseWithSeparator, $comparison)) {
         throw "Artifact path '$Path' resolves outside the base directory '$base'."
     }
 

--- a/tools/evidence/validate-evidence-manifest.ps1
+++ b/tools/evidence/validate-evidence-manifest.ps1
@@ -1,6 +1,13 @@
 [CmdletBinding()]
 param(
     [string]$ManifestPath = 'tools/evals/fixtures/001-agent-tooling-foundation/evidence-manifest.valid.json',
+
+    # Base directory for resolving relative artifact paths in the manifest.
+    # When set (e.g. by Test-RunbookManifest from a runbook orchestrator), artifact
+    # paths are resolved against this directory; otherwise they fall back to the
+    # repo root (legacy behaviour for fixture-bundle validation).
+    [string]$ProjectRoot,
+
     [switch]$PassThru
 )
 
@@ -26,24 +33,27 @@ function Resolve-RepoPath {
     return (Resolve-Path -LiteralPath (Join-Path (Get-RepoRoot) $Path)).Path
 }
 
-function Convert-ToRepoChildPath {
+function Convert-ToArtifactPath {
     param(
         [Parameter(Mandatory = $true)]
-        [string]$Path
+        [string]$Path,
+
+        [Parameter(Mandatory = $true)]
+        [string]$BaseDirectory
     )
 
-    $repoRoot = [System.IO.Path]::GetFullPath((Get-RepoRoot))
-    $repoRootWithSeparator = $repoRoot.TrimEnd([System.IO.Path]::DirectorySeparatorChar, [System.IO.Path]::AltDirectorySeparatorChar) + [System.IO.Path]::DirectorySeparatorChar
+    $base = [System.IO.Path]::GetFullPath($BaseDirectory)
+    $baseWithSeparator = $base.TrimEnd([System.IO.Path]::DirectorySeparatorChar, [System.IO.Path]::AltDirectorySeparatorChar) + [System.IO.Path]::DirectorySeparatorChar
 
     if ([System.IO.Path]::IsPathRooted($Path)) {
         $fullPath = [System.IO.Path]::GetFullPath($Path)
     }
     else {
-        $fullPath = [System.IO.Path]::GetFullPath((Join-Path $repoRoot $Path))
+        $fullPath = [System.IO.Path]::GetFullPath((Join-Path $base $Path))
     }
 
-    if ($fullPath -ne $repoRoot -and -not $fullPath.StartsWith($repoRootWithSeparator, [System.StringComparison]::OrdinalIgnoreCase)) {
-        throw "Artifact path '$Path' resolves outside the repository root."
+    if ($fullPath -ne $base -and -not $fullPath.StartsWith($baseWithSeparator, [System.StringComparison]::OrdinalIgnoreCase)) {
+        throw "Artifact path '$Path' resolves outside the base directory '$base'."
     }
 
     return $fullPath
@@ -56,13 +66,24 @@ $missingArtifactPaths = New-Object System.Collections.Generic.List[string]
 $unsupportedArtifactKinds = New-Object System.Collections.Generic.List[string]
 $supportedArtifactKinds = Get-EvidenceArtifactKinds
 
+# Resolve artifact paths against -ProjectRoot when provided (the runbook orchestrator
+# path; manifest paths are project-relative because the runtime writes under
+# res://evidence/automation/...). Fall back to repo root for legacy callers that
+# validate fixture-bundled manifests committed under tools/evals/fixtures/.
+$artifactBase = if (-not [string]::IsNullOrWhiteSpace($ProjectRoot)) {
+    if ([System.IO.Path]::IsPathRooted($ProjectRoot)) { $ProjectRoot }
+    else { (Resolve-Path -LiteralPath (Join-Path (Get-RepoRoot) $ProjectRoot)).Path }
+} else {
+    Get-RepoRoot
+}
+
 foreach ($artifactRef in $manifest.artifactRefs) {
     if ($artifactRef.kind -notin $supportedArtifactKinds) {
         [void]$unsupportedArtifactKinds.Add([string]$artifactRef.kind)
     }
 
     try {
-        $artifactPath = Convert-ToRepoChildPath -Path $artifactRef.path
+        $artifactPath = Convert-ToArtifactPath -Path $artifactRef.path -BaseDirectory $artifactBase
     }
     catch {
         [void]$missingArtifactPaths.Add($artifactRef.path)

--- a/tools/tests/InvokeRunbookScripts.Tests.ps1
+++ b/tools/tests/InvokeRunbookScripts.Tests.ps1
@@ -123,6 +123,50 @@ exit 0
 }
 
 # ---------------------------------------------------------------------------
+# C1 — Resolve-RunbookPayload validates before writing canonical path
+# ---------------------------------------------------------------------------
+
+Describe 'Resolve-RunbookPayload validate-then-rename (C1)' {
+    BeforeEach {
+        $script:C1Root = Join-Path $TestDrive ('c1-root-' + [guid]::NewGuid().Guid)
+        New-Item -ItemType Directory -Path $script:C1Root -Force | Out-Null
+        $script:C1RequestsDir = Join-Path $script:C1Root 'harness/automation/requests'
+        $script:C1Canonical   = Join-Path $script:C1RequestsDir 'run-request.json'
+        $script:C1Tmp         = "$script:C1Canonical.tmp"
+    }
+
+    It 'C1: writes canonical path on a valid fixture and leaves no .tmp behind' {
+        # Use a real shipped fixture which the schema accepts.
+        $result = Resolve-RunbookPayload `
+            -FixturePath 'tools/tests/fixtures/runbook/input-dispatch/press-enter.json' `
+            -RequestId 'runbook-input-dispatch-c1-success' `
+            -ProjectRoot $script:C1Root
+
+        $result.TempRequestPath | Should -Be $script:C1Canonical
+        Test-Path -LiteralPath $script:C1Canonical | Should -BeTrue
+        Test-Path -LiteralPath $script:C1Tmp       | Should -BeFalse
+
+        # Canonical content should be the merged payload with our new requestId.
+        $written = Get-Content -LiteralPath $script:C1Canonical -Raw | ConvertFrom-Json
+        $written.requestId | Should -Be 'runbook-input-dispatch-c1-success'
+    }
+
+    It 'C1: throws and leaves no canonical / no .tmp when payload fails schema validation' {
+        # Construct an inline payload that is missing several required fields.
+        $bad = @{ requestId = 'will-be-overwritten'; runId = 'r' } | ConvertTo-Json -Depth 5
+
+        { Resolve-RunbookPayload `
+            -InlineJson $bad `
+            -RequestId 'runbook-c1-schema-fail' `
+            -ProjectRoot $script:C1Root
+        } | Should -Throw -ExpectedMessage '*does not satisfy schema*'
+
+        Test-Path -LiteralPath $script:C1Canonical | Should -BeFalse
+        Test-Path -LiteralPath $script:C1Tmp       | Should -BeFalse
+    }
+}
+
+# ---------------------------------------------------------------------------
 # RUNBOOK static checks (T007)
 # ---------------------------------------------------------------------------
 

--- a/tools/tests/InvokeRunbookScripts.Tests.ps1
+++ b/tools/tests/InvokeRunbookScripts.Tests.ps1
@@ -101,6 +101,25 @@ Describe 'RunbookOrchestration module' {
     It 'Resolve-RunbookPayload throws when neither is supplied' {
         { Resolve-RunbookPayload -RequestId 'req' -ProjectRoot $TestDrive } | Should -Throw
     }
+
+    It 'H1: Invoke-Helper strips ANSI CSI sequences from CapturedOutput' {
+        # Build a child script that emits ANSI-coloured text via Write-Error.
+        # PowerShell 7's default ErrorView (ConciseView) emits CSI sequences for
+        # colour, which is exactly what H1 strips out.
+        $ansiScript = Join-Path $TestDrive 'emit-ansi.ps1'
+        @'
+param([string]$Tag = 'default')
+Write-Error "boom: this should be coloured ($Tag)" -ErrorAction Continue
+exit 0
+'@ | Set-Content -LiteralPath $ansiScript -Encoding utf8
+
+        InModuleScope RunbookOrchestration -Parameters @{ Path = $ansiScript } {
+            param($Path)
+            $result = Invoke-Helper -ScriptPath $Path -ArgumentList @('-Tag', 'h1-test')
+            $result.CapturedOutput | Should -Not -Match "`e\["
+            $result.CapturedOutput | Should -Match 'boom'
+        }
+    }
 }
 
 # ---------------------------------------------------------------------------

--- a/tools/tests/InvokeRunbookScripts.Tests.ps1
+++ b/tools/tests/InvokeRunbookScripts.Tests.ps1
@@ -167,18 +167,24 @@ Describe 'Resolve-RunbookPayload validate-then-rename (C1)' {
 
     It 'C2 follow-up: Resolve-RunbookEvidencePath joins relative paths against ProjectRoot' {
         # Evidence paths from run-result/manifest are project-relative, not repo-relative.
+        # Use TestDrive so the assertion holds on any OS (Windows / macOS / Linux),
+        # since [System.IO.Path]::IsPathRooted has different semantics across them.
+        $projectRoot = Join-Path $TestDrive ('sandbox-' + [guid]::NewGuid().Guid)
+        New-Item -ItemType Directory -Path $projectRoot -Force | Out-Null
+        $expected = Join-Path $projectRoot 'evidence/automation/runbook-x/evidence-manifest.json'
         $abs = Resolve-RunbookEvidencePath `
             -Path 'evidence/automation/runbook-x/evidence-manifest.json' `
-            -ProjectRoot 'D:\some\sandbox'
-        # Path-separator-agnostic compare (PowerShell's Join-Path uses native separator).
-        ($abs -replace '/', '\') | Should -Be 'D:\some\sandbox\evidence\automation\runbook-x\evidence-manifest.json'
+            -ProjectRoot $projectRoot
+        $abs | Should -Be $expected
     }
 
     It 'C2 follow-up: Resolve-RunbookEvidencePath returns absolute paths unchanged' {
+        $projectRoot = Join-Path $TestDrive ('sandbox-' + [guid]::NewGuid().Guid)
+        $absoluteManifestPath = Join-Path $TestDrive 'already/absolute/manifest.json'
         $abs = Resolve-RunbookEvidencePath `
-            -Path 'D:\already\absolute\manifest.json' `
-            -ProjectRoot 'D:\some\sandbox'
-        $abs | Should -Be 'D:\already\absolute\manifest.json'
+            -Path $absoluteManifestPath `
+            -ProjectRoot $projectRoot
+        $abs | Should -Be $absoluteManifestPath
     }
 
     It 'C2: forces artifactRoot to empty string regardless of fixture content' {

--- a/tools/tests/InvokeRunbookScripts.Tests.ps1
+++ b/tools/tests/InvokeRunbookScripts.Tests.ps1
@@ -165,6 +165,22 @@ Describe 'Resolve-RunbookPayload validate-then-rename (C1)' {
         Test-Path -LiteralPath $script:C1Tmp       | Should -BeFalse
     }
 
+    It 'C2 follow-up: Resolve-RunbookEvidencePath joins relative paths against ProjectRoot' {
+        # Evidence paths from run-result/manifest are project-relative, not repo-relative.
+        $abs = Resolve-RunbookEvidencePath `
+            -Path 'evidence/automation/runbook-x/evidence-manifest.json' `
+            -ProjectRoot 'D:\some\sandbox'
+        # Path-separator-agnostic compare (PowerShell's Join-Path uses native separator).
+        ($abs -replace '/', '\') | Should -Be 'D:\some\sandbox\evidence\automation\runbook-x\evidence-manifest.json'
+    }
+
+    It 'C2 follow-up: Resolve-RunbookEvidencePath returns absolute paths unchanged' {
+        $abs = Resolve-RunbookEvidencePath `
+            -Path 'D:\already\absolute\manifest.json' `
+            -ProjectRoot 'D:\some\sandbox'
+        $abs | Should -Be 'D:\already\absolute\manifest.json'
+    }
+
     It 'C2: forces artifactRoot to empty string regardless of fixture content' {
         # press-enter.json sets artifactRoot to a fixture path under tools/tests/fixtures.
         # The runtime persists that string into manifest references and ignores it for

--- a/tools/tests/InvokeRunbookScripts.Tests.ps1
+++ b/tools/tests/InvokeRunbookScripts.Tests.ps1
@@ -164,6 +164,22 @@ Describe 'Resolve-RunbookPayload validate-then-rename (C1)' {
         Test-Path -LiteralPath $script:C1Canonical | Should -BeFalse
         Test-Path -LiteralPath $script:C1Tmp       | Should -BeFalse
     }
+
+    It 'C2: forces artifactRoot to empty string regardless of fixture content' {
+        # press-enter.json sets artifactRoot to a fixture path under tools/tests/fixtures.
+        # The runtime persists that string into manifest references and ignores it for
+        # writes, breaking "manifestPath -> artifactRefs[*].path" navigation. We
+        # overwrite to '' so the runtime's fallback uses outputDirectory instead.
+        $result = Resolve-RunbookPayload `
+            -FixturePath 'tools/tests/fixtures/runbook/input-dispatch/press-enter.json' `
+            -RequestId 'runbook-input-dispatch-c2-test' `
+            -ProjectRoot $script:C1Root
+
+        $result.Payload['artifactRoot'] | Should -Be ''
+
+        $written = Get-Content -LiteralPath $script:C1Canonical -Raw | ConvertFrom-Json
+        $written.artifactRoot | Should -Be ''
+    }
 }
 
 # ---------------------------------------------------------------------------

--- a/tools/tests/ScaffoldSandbox.Tests.ps1
+++ b/tools/tests/ScaffoldSandbox.Tests.ps1
@@ -38,6 +38,14 @@ Describe 'tools/scaffold-sandbox.ps1' {
         # Project settings were updated by deploy
         $projectContent | Should -Match 'ScenegraphHarness="\*res://addons/agent_runtime_harness/runtime/scenegraph_autoload.gd"'
         $projectContent | Should -Match 'enabled=PackedStringArray\("res://addons/agent_runtime_harness/plugin.cfg"\)'
+
+        # C3 regression guard: Get-ClaudeFileContent / Get-AgentsFileContent previously
+        # leaked a literal `.TrimEnd()` line into freshly-deployed CLAUDE.md / AGENTS.md
+        # because the .TrimEnd() call sat outside the $() interpolation in the here-string.
+        $claudeContent = Get-Content -LiteralPath (Join-Path $sandboxPath 'CLAUDE.md') -Raw
+        $agentsContent = Get-Content -LiteralPath (Join-Path $sandboxPath 'AGENTS.md') -Raw
+        $claudeContent | Should -Not -Match '\.TrimEnd\(\)'
+        $agentsContent | Should -Not -Match '\.TrimEnd\(\)'
     }
 
     It 'refuses to overwrite an existing sandbox without -Force' {

--- a/tools/tests/fixtures/runbook/runtime-error-triage/run-and-watch-for-errors.json
+++ b/tools/tests/fixtures/runbook/runtime-error-triage/run-and-watch-for-errors.json
@@ -13,7 +13,6 @@
   "stopPolicy": {
     "stopAfterValidation": true
   },
-  "pauseOnError": true,
   "requestedBy": "runbook-fixture",
   "createdAt": "2026-04-22T00:00:00Z"
 }


### PR DESCRIPTION
## Summary

Resolves the four issues called out in [prd/01-unblock-the-loop.md](prd/01-unblock-the-loop.md). After this PR an agent calling any of the five runtime invokers receives `status=success`, follows `manifestPath`, and reads the artifacts the manifest references.

- **C1 — validator-vs-broker race**. `Resolve-RunbookPayload` now writes `run-request.json.tmp`, schema-validates the temp path, then atomic-renames into the canonical name the broker watches. Pre-fix, the broker frequently consumed the canonical file before the validator ran and every successful run returned `failureKind=request-invalid`. Same tmp-then-rename pattern applied inline in `invoke-scene-inspection.ps1`.
- **C2 — `artifactRoot` mismatch**. Orchestrator forces `artifactRoot=''` in every payload it writes. The runtime already falls back to `outputDirectory` (`scenegraph_artifact_writer._resolve_artifact_root`, `scenegraph_run_coordinator._resolve_manifest_repo_path`) so manifest references now resolve to real on-disk paths. No addon, schema, or fixture-broad changes — full removal of the field is deferred.
- **C3 — `.TrimEnd()` template leak**. `Get-ClaudeFileContent` and `Get-AgentsFileContent` in `deploy-game-harness.ps1` had `.TrimEnd()` outside the `$()` interpolation in their here-strings, leaking literal `.TrimEnd()` text into freshly deployed CLAUDE.md / AGENTS.md.
- **H1 — ANSI in envelope diagnostics**. `Invoke-Helper` now strips CSI sequences from captured child-process output before stuffing it into the JSON envelope's `diagnostics[]`.

## Why surgical instead of full removal of artifactRoot

The PRD's recommended fix was to rip `artifactRoot` out of 5 GDScript runtime files, ~16 JSON fixtures, the request schema, and the inspection-run-config template. Exploration showed the runtime already falls back to `outputDirectory` when `artifactRoot` is empty, so forcing the field to `''` in the orchestrator achieves the same observable outcome with zero addon churn. Full schema/fixture cleanup is queued for a later pass (PRD pass 4 or follow-up).

## Bonus fixes (uncovered by C1's removal)

C1's race was masking five other defects in the runtime invokers. Once successful runs actually started reaching the post-broker code, these surfaced and had to be addressed for the live integration to pass:

- `Resolve-RunbookEvidencePath` helper added; all 11 manifest/artifact path-resolution call sites across the five invokers switched from repo-root resolution to project-root resolution. (Pre-fix: paths were treated as repo-relative; post-C2 they're correctly project-relative.)
- `Test-RunbookManifest` accepts `-ProjectRoot` and threads it through `validate-evidence-manifest.ps1` (which grew the same parameter and renamed `Convert-ToRepoChildPath` → `Convert-ToArtifactPath`).
- `Test-RunbookManifest` no longer treats schema mismatch as a hard fail — it's now a soft diagnostic. (The runtime emits `appliedInputDispatch` and similar workflow blocks the manifest schema doesn't yet declare. Schema/runtime alignment is out of scope for pass 1.)
- `invoke-scene-inspection.ps1` was looking for `kind='scene-tree'`; the runtime emits `scenegraph-snapshot` (flat `nodes` array with `node_count`). Updated to match.
- `invoke-input-dispatch.ps1` was reading `$row.outcome` / `$row.message` from the outcomes JSONL; runtime emits `status` / `reasonMessage`. Updated.
- `invoke-behavior-watch.ps1` treated "no behavior-trace artifact" as `failureKind=internal`. That was masking the legitimate "0 samples captured" outcome (e.g. when the watched node didn't exist in the running scene). Now returns `status=success, sampleCount=0`.
- `tools/tests/fixtures/runbook/runtime-error-triage/run-and-watch-for-errors.json` carried a top-level `pauseOnError=true` field that violates the request schema's `additionalProperties=false`. Removed; `capturePolicy.failure=true` already drives the intended behaviour.

## Test plan

- [x] `pwsh ./tools/tests/run-tool-tests.ps1` — 238 passed, 0 failed (5 unrelated skips for missing fixture manifests).
- [x] New Pester coverage:
  - `ScaffoldSandbox.Tests.ps1` regression assertion that deployed CLAUDE.md/AGENTS.md don't end with `.TrimEnd()` (C3).
  - `RunbookOrchestration module → H1: Invoke-Helper strips ANSI CSI sequences from CapturedOutput` (H1).
  - `Resolve-RunbookPayload validate-then-rename → C1: writes canonical path on a valid fixture and leaves no .tmp behind` (C1 happy path).
  - `Resolve-RunbookPayload validate-then-rename → C1: throws and leaves no canonical / no .tmp when payload fails schema validation` (C1 failure path).
  - `… → C2: forces artifactRoot to empty string regardless of fixture content` (C2).
  - `… → C2 follow-up: Resolve-RunbookEvidencePath joins relative paths against ProjectRoot` (path-resolution helper).
  - `… → C2 follow-up: Resolve-RunbookEvidencePath returns absolute paths unchanged`.
- [x] Live integration against a freshly scaffolded `integration-testing/probe` sandbox with `$env:GODOT_BIN` pointing at Godot 4.6.2 — all five runtime invokers return `status=success` and a manifest whose `artifactRefs` resolve to real on-disk files:
  - scene-inspection: 2 nodes captured.
  - input-dispatch: 2 events dispatched (`firstFailureSummary` populated correctly because the press frame is past the run's stop point — the probe sandbox has no UI to drive past).
  - behavior-watch: 0 samples (probe has no `/root/Main/Paddle`).
  - build-error-triage: clean.
  - runtime-error-triage: clean.

## Out of scope (queued for later passes)

- Pass 2 (H2/H3/M3): editor-launch helper, scene-inspection refactor onto `Resolve-RunbookPayload`, pin/unpin exit-code semantics.
- Pass 3 (M1/M2/M4/M5): broker-mocked Pester coverage, transient-zone classification fixes, hardcoded `pwsh` decoupling.
- Pass 4 (L1/L2/L3/M6): fixture polish (e.g. requestId-suffixed `outputDirectory`), `Get-Help` example refresh.
- Full removal of `artifactRoot` from the request schema, runtime addon, and remaining fixtures.
- Manifest schema update to declare `appliedInputDispatch` / `appliedBehaviorWatch` as supported workflow blocks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)