### PR TITLE
Pass 2 — DRY and ergonomics (H2/H3/M3)

### DIFF
--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -86,9 +86,37 @@ The envelope's `status` field is authoritative in both cases; the exit code is a
 ## Prerequisites
 
 - PowerShell 7+ (`pwsh`) on `PATH`.
-- A Godot editor running against an integration-testing sandbox (see
-  `docs/INTEGRATION_TESTING.md` for setup).
+- A Godot editor running against an integration-testing sandbox. Either launch
+  it manually, or pass `-EnsureEditor` to any runtime-verification script and
+  the harness will idempotently launch one for you. See "Editor lifecycle helpers"
+  below.
 - *(Tests only — no live editor needed)*: `pwsh ./tools/tests/run-tool-tests.ps1`.
+
+## Editor lifecycle helpers
+
+Two sibling helpers manage the editor process so agents don't have to:
+
+| Helper | What it does |
+|---|---|
+| `tools/automation/invoke-launch-editor.ps1` | Idempotently launch (or attach to) a Godot editor for `-ProjectRoot`. Returns success in <1s when an editor is already running and capability.json is fresh; otherwise spawns Godot with `--editor --path ROOT --verbose` and polls capability.json until it appears. `-ForceRestart` stops any existing editor first. Output envelope carries `outcome.editorPid`, `outcome.capabilityPath`, `outcome.capabilityAgeSeconds`, `outcome.reusedExistingEditor`. |
+| `tools/automation/invoke-stop-editor.ps1` | Stop the Godot editor for `-ProjectRoot`. Matches by `--path` command-line so it leaves unrelated editor instances alone. Output envelope carries `outcome.stoppedPids` and `outcome.remainingPids`. |
+
+Every runtime-verification invoker also accepts a `-EnsureEditor` switch that delegates to `invoke-launch-editor.ps1` before running the workflow. Auto-launch failures surface as the workflow's own `editor-not-running` envelope.
+
+```powershell
+# One-step convenience: spawn editor (if needed) + run workflow
+pwsh ./tools/automation/invoke-scene-inspection.ps1 `
+    -ProjectRoot ./integration-testing/probe -EnsureEditor
+
+# Two-step explicit (idempotent reuse, then run)
+pwsh ./tools/automation/invoke-launch-editor.ps1 -ProjectRoot ./integration-testing/probe
+pwsh ./tools/automation/invoke-input-dispatch.ps1 `
+    -ProjectRoot ./integration-testing/probe `
+    -RequestFixturePath ./tools/tests/fixtures/runbook/input-dispatch/press-enter.json
+
+# Cleanup
+pwsh ./tools/automation/invoke-stop-editor.ps1 -ProjectRoot ./integration-testing/probe
+```
 
 ## See also
 

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -72,6 +72,17 @@ On failure: `status = "failure"`, `failureKind` is one of
 | `timeout` | Increase `-TimeoutSeconds` or check if the editor is stuck. |
 | `internal` | Read `diagnostics[0]`; file a bug against the harness. |
 
+## Exit-code convention
+
+Runtime-verification scripts exit non-zero for any `status=failure` envelope.
+
+Lifecycle scripts (pin / unpin) distinguish two non-success outcomes:
+
+- `status="refused"` → **exit 0**. The script ran successfully and correctly declined a precondition (e.g. `pin-name-collision`, `pin-target-not-found`). Read the envelope's `failureKind` and `diagnostics[0]` to learn why.
+- `status="failed"` → **exit 1**. An unexpected error the caller should investigate (e.g. `io-error`).
+
+The envelope's `status` field is authoritative in both cases; the exit code is a fast-path signal for shell pipelines.
+
 ## Prerequisites
 
 - PowerShell 7+ (`pwsh`) on `PATH`.

--- a/addons/agent_runtime_harness/templates/project_root/.claude/skills/godot-debug-build/SKILL.md
+++ b/addons/agent_runtime_harness/templates/project_root/.claude/skills/godot-debug-build/SKILL.md
@@ -20,9 +20,11 @@ Treat `$ARGUMENTS` as an optional fixture path. Default: `{{HARNESS_REPO_ROOT}}/
 
 ## Execution
 
+`-EnsureEditor` idempotently launches a Godot editor for the project (or reuses one if already running and capability.json is fresh). Pass it on every call.
+
 ```powershell
 pwsh {{HARNESS_REPO_ROOT}}/tools/automation/invoke-build-error-triage.ps1 `
-  -ProjectRoot "<project-root>" `
+  -ProjectRoot "<project-root>" -EnsureEditor `
   -RequestFixturePath "<fixture-path-or-default>"
 ```
 
@@ -44,7 +46,7 @@ On `failureKind=build`, report `firstDiagnostic` verbatim — do not paraphrase.
 
 | `failureKind` | What it means | Next step |
 |---|---|---|
-| `editor-not-running` | Capability missing or stale | Tell the user to launch: `godot --editor --path "<project-root>"` |
+| `editor-not-running` | Auto-launch failed (e.g. missing `$env:GODOT_BIN`, project failed to import) | Read `diagnostics[0]` for the underlying reason; common fix is to ensure `$env:GODOT_BIN` points at a Godot 4 binary |
 | `build` | Compile error captured (expected outcome) | Report `outcome.firstDiagnostic` verbatim; no manifest may exist |
 | `runtime` | Build succeeded but runtime failed | Use `/godot-debug-runtime` for runtime-error details |
 | `timeout` | Build did not complete | Editor may be frozen |

--- a/addons/agent_runtime_harness/templates/project_root/.claude/skills/godot-debug-runtime/SKILL.md
+++ b/addons/agent_runtime_harness/templates/project_root/.claude/skills/godot-debug-runtime/SKILL.md
@@ -20,9 +20,11 @@ Treat `$ARGUMENTS` as an optional fixture path. Default: `{{HARNESS_REPO_ROOT}}/
 
 ## Execution
 
+`-EnsureEditor` idempotently launches a Godot editor for the project (or reuses one if already running and capability.json is fresh). Pass it on every call.
+
 ```powershell
 pwsh {{HARNESS_REPO_ROOT}}/tools/automation/invoke-runtime-error-triage.ps1 `
-  -ProjectRoot "<project-root>" `
+  -ProjectRoot "<project-root>" -EnsureEditor `
   -RequestFixturePath "<fixture-path-or-default>"
 ```
 
@@ -43,7 +45,7 @@ Pass `-IncludeFullStack` when the user asks for full stack traces.
 
 | `failureKind` | What it means | Next step |
 |---|---|---|
-| `editor-not-running` | Capability missing or stale | Tell the user to launch: `godot --editor --path "<project-root>"` |
+| `editor-not-running` | Auto-launch failed (e.g. missing `$env:GODOT_BIN`, project failed to import) | Read `diagnostics[0]` for the underlying reason; common fix is to ensure `$env:GODOT_BIN` points at a Godot 4 binary |
 | `build` | GDScript compile error before runtime started | Use `/godot-debug-build` for richer build diagnostics |
 | `runtime` | Runtime error captured (expected outcome for this skill) | Report `outcome.latestErrorSummary`; do not treat as harness failure |
 | `timeout` | Run did not complete in time | Increase `-TimeoutSeconds` or check if the editor is frozen |

--- a/addons/agent_runtime_harness/templates/project_root/.claude/skills/godot-inspect/SKILL.md
+++ b/addons/agent_runtime_harness/templates/project_root/.claude/skills/godot-inspect/SKILL.md
@@ -20,10 +20,10 @@ Treat `$ARGUMENTS` as the absolute path to a Godot project root (the directory c
 
 ## Execution
 
-Run the `invoke-scene-inspection.ps1` script once. It owns the full capability-check → request → poll → manifest-read loop and emits a single JSON envelope to stdout.
+Run the `invoke-scene-inspection.ps1` script once. It owns the full capability-check → request → poll → manifest-read loop and emits a single JSON envelope to stdout. Pass `-EnsureEditor` so the script idempotently launches a Godot editor if one isn't already running for this project (reuses an existing one when capability.json is fresh).
 
 ```powershell
-pwsh {{HARNESS_REPO_ROOT}}/tools/automation/invoke-scene-inspection.ps1 -ProjectRoot "<project-root>"
+pwsh {{HARNESS_REPO_ROOT}}/tools/automation/invoke-scene-inspection.ps1 -ProjectRoot "<project-root>" -EnsureEditor
 ```
 
 Parse the stdout as JSON. Report `outcome.nodeCount` to the user and, if asked, read `outcome.sceneTreePath` to summarize notable nodes.
@@ -43,7 +43,7 @@ Parse the stdout as JSON. Report `outcome.nodeCount` to the user and, if asked, 
 
 | `failureKind` | What it means | Next step |
 |---|---|---|
-| `editor-not-running` | Capability artifact missing or stale | Tell the user to launch: `godot --editor --path "<project-root>"` |
+| `editor-not-running` | Auto-launch failed (e.g. missing `$env:GODOT_BIN`, project failed to import) | Read `diagnostics[0]` for the underlying reason; common fix is to ensure `$env:GODOT_BIN` points at a Godot 4 binary |
 | `build` | GDScript compile error before the scene could load | Report `diagnostics[0]` verbatim; no manifest will exist |
 | `runtime` | Editor-side blocker (no scene staged, wrong target scene, etc.) | **Read `harness/automation/results/capability.json`** next. Check `blockedReasons` and `singleTargetReady`. If `target_scene_missing`: tell the user to open the target scene in the editor dock or set `Project Settings → Application → Run → Main Scene`. **Do not blind-retry** — this gate is editor-side, not something the script can override. |
 | `timeout` | Capture did not complete | The editor may be frozen or not in play mode |

--- a/addons/agent_runtime_harness/templates/project_root/.claude/skills/godot-press/SKILL.md
+++ b/addons/agent_runtime_harness/templates/project_root/.claude/skills/godot-press/SKILL.md
@@ -20,11 +20,13 @@ Treat `$ARGUMENTS` as either a **fixture path** or a **bare key name** (`ENTER`,
 
 ## Execution
 
+`-EnsureEditor` idempotently launches a Godot editor for the project (or reuses one if already running and capability.json is fresh). Pass it on every call.
+
 Fixture form (preferred when a fixture exists):
 
 ```powershell
 pwsh {{HARNESS_REPO_ROOT}}/tools/automation/invoke-input-dispatch.ps1 `
-  -ProjectRoot "<project-root>" `
+  -ProjectRoot "<project-root>" -EnsureEditor `
   -RequestFixturePath "<fixture-path>"
 ```
 
@@ -32,7 +34,7 @@ Inline form (when no fixture fits):
 
 ```powershell
 pwsh {{HARNESS_REPO_ROOT}}/tools/automation/invoke-input-dispatch.ps1 `
-  -ProjectRoot "<project-root>" `
+  -ProjectRoot "<project-root>" -EnsureEditor `
   -RequestJson '{"requestId":"placeholder","scenarioId":"runbook-input-dispatch","runId":"runbook-input-dispatch","targetScene":"<main scene res:// path>","outputDirectory":"res://evidence/automation/agent","artifactRoot":"evidence/automation/agent","expectationFiles":[],"capturePolicy":{"startup":true,"manual":true,"failure":true},"stopPolicy":{"stopAfterValidation":true},"requestedBy":"agent","createdAt":"<UTC ISO-8601>","inputDispatchScript":{"events":[{"kind":"key","identifier":"ENTER","phase":"press","frame":30},{"kind":"key","identifier":"ENTER","phase":"release","frame":32}]}}'
 ```
 
@@ -53,7 +55,7 @@ pwsh {{HARNESS_REPO_ROOT}}/tools/automation/invoke-input-dispatch.ps1 `
 
 | `failureKind` | What it means | Next step |
 |---|---|---|
-| `editor-not-running` | Capability missing or stale | Tell the user to launch: `godot --editor --path "<project-root>"` |
+| `editor-not-running` | Auto-launch failed (e.g. missing `$env:GODOT_BIN`, project failed to import) | Read `diagnostics[0]` for the underlying reason; common fix is to ensure `$env:GODOT_BIN` points at a Godot 4 binary |
 | `request-invalid` | Payload schema violation | Read `diagnostics[0]`; fix the fixture or inline JSON |
 | `build` | GDScript compile error before dispatch | Report `diagnostics[0]` verbatim |
 | `runtime` | Editor-side blocker | Read `harness/automation/results/capability.json` for `blockedReasons` / `singleTargetReady`. If `target_scene_missing`: tell the user to open the target scene in the editor dock. **Do not blind-retry.** |

--- a/addons/agent_runtime_harness/templates/project_root/.claude/skills/godot-watch/SKILL.md
+++ b/addons/agent_runtime_harness/templates/project_root/.claude/skills/godot-watch/SKILL.md
@@ -20,9 +20,11 @@ Treat `$ARGUMENTS` as a fixture path under `{{HARNESS_REPO_ROOT}}/tools/tests/fi
 
 ## Execution
 
+`-EnsureEditor` idempotently launches a Godot editor for the project (or reuses one if already running and capability.json is fresh). Pass it on every call.
+
 ```powershell
 pwsh {{HARNESS_REPO_ROOT}}/tools/automation/invoke-behavior-watch.ps1 `
-  -ProjectRoot "<project-root>" `
+  -ProjectRoot "<project-root>" -EnsureEditor `
   -RequestFixturePath "<fixture-path>"
 ```
 
@@ -30,7 +32,7 @@ Or with inline JSON:
 
 ```powershell
 pwsh {{HARNESS_REPO_ROOT}}/tools/automation/invoke-behavior-watch.ps1 `
-  -ProjectRoot "<project-root>" `
+  -ProjectRoot "<project-root>" -EnsureEditor `
   -RequestJson '{"requestId":"placeholder","scenarioId":"runbook-behavior-watch","runId":"runbook-behavior-watch","targetScene":"<main scene>","outputDirectory":"res://evidence/automation/agent","artifactRoot":"evidence/automation/agent","capturePolicy":{"startup":true},"stopPolicy":{"stopAfterValidation":true},"requestedBy":"agent","createdAt":"<UTC ISO-8601>","behaviorWatchRequest":{"targets":[{"nodePath":"/root/Main/Paddle","properties":["position"]}],"frameCount":10}}'
 ```
 
@@ -48,7 +50,7 @@ pwsh {{HARNESS_REPO_ROOT}}/tools/automation/invoke-behavior-watch.ps1 `
 
 | `failureKind` | What it means | Next step |
 |---|---|---|
-| `editor-not-running` | Capability missing or stale | Tell the user to launch: `godot --editor --path "<project-root>"` |
+| `editor-not-running` | Auto-launch failed (e.g. missing `$env:GODOT_BIN`, project failed to import) | Read `diagnostics[0]` for the underlying reason; common fix is to ensure `$env:GODOT_BIN` points at a Godot 4 binary |
 | `request-invalid` | Payload schema violation | Read `diagnostics[0]`; fix the fixture or inline JSON |
 | `build` | GDScript compile error | Report `diagnostics[0]` verbatim |
 | `runtime` | Editor-side blocker or in-game error | Read `harness/automation/results/capability.json` for `blockedReasons`. If `target_scene_missing`, tell the user to open the scene in the editor dock. |

--- a/addons/agent_runtime_harness/templates/project_root/CLAUDE.runtime-harness.md
+++ b/addons/agent_runtime_harness/templates/project_root/CLAUDE.runtime-harness.md
@@ -4,20 +4,26 @@ This project has the `agent_runtime_harness` addon installed. When the user asks
 
 ## Fast path — one invoke script, one envelope
 
+The runtime invokers all assume a Godot editor is running against the project. Pass `-EnsureEditor` to have them auto-launch one (idempotent: reuses an existing editor when capability.json is fresh).
+
 ```powershell
-# Scene inspection (no input)
+# Scene inspection (no input). -EnsureEditor spawns the editor if needed.
 pwsh {{HARNESS_REPO_ROOT}}/tools/automation/invoke-scene-inspection.ps1 `
-  -ProjectRoot "<absolute path to this project>"
+  -ProjectRoot "<absolute path to this project>" -EnsureEditor
 
 # Input dispatch (keypresses / InputMap actions)
 pwsh {{HARNESS_REPO_ROOT}}/tools/automation/invoke-input-dispatch.ps1 `
-  -ProjectRoot "<absolute path to this project>" `
+  -ProjectRoot "<absolute path to this project>" -EnsureEditor `
   -RequestFixturePath "{{HARNESS_REPO_ROOT}}/tools/tests/fixtures/runbook/input-dispatch/press-enter.json"
 
 # Runtime error triage
 pwsh {{HARNESS_REPO_ROOT}}/tools/automation/invoke-runtime-error-triage.ps1 `
-  -ProjectRoot "<absolute path to this project>" `
+  -ProjectRoot "<absolute path to this project>" -EnsureEditor `
   -RequestFixturePath "{{HARNESS_REPO_ROOT}}/tools/tests/fixtures/runbook/runtime-error-triage/run-and-watch-for-errors.json"
+
+# When you're done with this project, stop the editor:
+pwsh {{HARNESS_REPO_ROOT}}/tools/automation/invoke-stop-editor.ps1 `
+  -ProjectRoot "<absolute path to this project>"
 ```
 
 Parse stdout JSON: `status`, `failureKind`, `manifestPath`, `diagnostics`, `outcome`. On success read `manifestPath`, then the one artifact the manifest references.

--- a/tools/automation/invoke-behavior-watch.ps1
+++ b/tools/automation/invoke-behavior-watch.ps1
@@ -60,7 +60,11 @@ param(
 
     [int]$MaxCapabilityAgeSeconds = 300,
 
-    [int]$PollIntervalMilliseconds = 250
+    [int]$PollIntervalMilliseconds = 250,
+
+    # When set, auto-launch a Godot editor against -ProjectRoot before running.
+    # Idempotent: reuses an existing editor if capability.json is fresh.
+    [switch]$EnsureEditor
 )
 
 Set-StrictMode -Version Latest
@@ -98,6 +102,22 @@ if ($hasFixture -and $hasInline) {
 }
 if (-not $hasFixture -and -not $hasInline) {
     Exit-Failure 'request-invalid' 'Exactly one of -RequestFixturePath or -RequestJson must be supplied.'
+}
+
+# Optional: auto-launch the editor if the caller asked for -EnsureEditor.
+if ($EnsureEditor) {
+    $launcher = Join-Path $PSScriptRoot 'invoke-launch-editor.ps1'
+    $launchOut = & pwsh -NoProfile -File $launcher -ProjectRoot $resolvedRoot 2>&1
+    try {
+        $launchEnv = ($launchOut -join [Environment]::NewLine) | ConvertFrom-Json -Depth 20
+    }
+    catch {
+        Exit-Failure 'editor-not-running' "Auto-launch produced non-JSON output: $($launchOut -join '; ')"
+    }
+    if ($launchEnv.status -ne 'success') {
+        $detail = if ($null -ne $launchEnv.diagnostics -and @($launchEnv.diagnostics).Count -gt 0) { $launchEnv.diagnostics[0] } else { 'no diagnostic' }
+        Exit-Failure 'editor-not-running' "Auto-launch failed (failureKind=$($launchEnv.failureKind)): $detail"
+    }
 }
 
 # Lifecycle preamble (US1): concurrent-run guard, in-flight marker, transient-zone cleanup

--- a/tools/automation/invoke-behavior-watch.ps1
+++ b/tools/automation/invoke-behavior-watch.ps1
@@ -108,8 +108,11 @@ if (-not $hasFixture -and -not $hasInline) {
 if ($EnsureEditor) {
     $launcher = Join-Path $PSScriptRoot 'invoke-launch-editor.ps1'
     # Capture stdout only -- the helper writes a single-line stderr summary that
-    # would corrupt the JSON envelope if 2>&1-merged.
-    $launchOut = & pwsh -NoProfile -File $launcher -ProjectRoot $resolvedRoot
+    # would corrupt the JSON envelope if 2>&1-merged. Thread our own
+    # -MaxCapabilityAgeSeconds through so a stricter caller setting is not
+    # silently relaxed by the launcher's default (300s).
+    $launchOut = & pwsh -NoProfile -File $launcher `
+        -ProjectRoot $resolvedRoot -MaxCapabilityAgeSeconds $MaxCapabilityAgeSeconds
     try {
         $launchEnv = ($launchOut -join [Environment]::NewLine) | ConvertFrom-Json -Depth 20
     }

--- a/tools/automation/invoke-behavior-watch.ps1
+++ b/tools/automation/invoke-behavior-watch.ps1
@@ -107,7 +107,9 @@ if (-not $hasFixture -and -not $hasInline) {
 # Optional: auto-launch the editor if the caller asked for -EnsureEditor.
 if ($EnsureEditor) {
     $launcher = Join-Path $PSScriptRoot 'invoke-launch-editor.ps1'
-    $launchOut = & pwsh -NoProfile -File $launcher -ProjectRoot $resolvedRoot 2>&1
+    # Capture stdout only -- the helper writes a single-line stderr summary that
+    # would corrupt the JSON envelope if 2>&1-merged.
+    $launchOut = & pwsh -NoProfile -File $launcher -ProjectRoot $resolvedRoot
     try {
         $launchEnv = ($launchOut -join [Environment]::NewLine) | ConvertFrom-Json -Depth 20
     }

--- a/tools/automation/invoke-build-error-triage.ps1
+++ b/tools/automation/invoke-build-error-triage.ps1
@@ -116,7 +116,9 @@ if (-not $hasFixture -and -not $hasInline) {
 # Optional: auto-launch the editor if the caller asked for -EnsureEditor.
 if ($EnsureEditor) {
     $launcher = Join-Path $PSScriptRoot 'invoke-launch-editor.ps1'
-    $launchOut = & pwsh -NoProfile -File $launcher -ProjectRoot $resolvedRoot 2>&1
+    # Capture stdout only -- the helper writes a single-line stderr summary that
+    # would corrupt the JSON envelope if 2>&1-merged.
+    $launchOut = & pwsh -NoProfile -File $launcher -ProjectRoot $resolvedRoot
     try {
         $launchEnv = ($launchOut -join [Environment]::NewLine) | ConvertFrom-Json -Depth 20
     }

--- a/tools/automation/invoke-build-error-triage.ps1
+++ b/tools/automation/invoke-build-error-triage.ps1
@@ -117,8 +117,11 @@ if (-not $hasFixture -and -not $hasInline) {
 if ($EnsureEditor) {
     $launcher = Join-Path $PSScriptRoot 'invoke-launch-editor.ps1'
     # Capture stdout only -- the helper writes a single-line stderr summary that
-    # would corrupt the JSON envelope if 2>&1-merged.
-    $launchOut = & pwsh -NoProfile -File $launcher -ProjectRoot $resolvedRoot
+    # would corrupt the JSON envelope if 2>&1-merged. Thread our own
+    # -MaxCapabilityAgeSeconds through so a stricter caller setting is not
+    # silently relaxed by the launcher's default (300s).
+    $launchOut = & pwsh -NoProfile -File $launcher `
+        -ProjectRoot $resolvedRoot -MaxCapabilityAgeSeconds $MaxCapabilityAgeSeconds
     try {
         $launchEnv = ($launchOut -join [Environment]::NewLine) | ConvertFrom-Json -Depth 20
     }

--- a/tools/automation/invoke-build-error-triage.ps1
+++ b/tools/automation/invoke-build-error-triage.ps1
@@ -70,7 +70,11 @@ param(
 
     [int]$MaxCapabilityAgeSeconds = 300,
 
-    [int]$PollIntervalMilliseconds = 250
+    [int]$PollIntervalMilliseconds = 250,
+
+    # When set, auto-launch a Godot editor against -ProjectRoot before running.
+    # Idempotent: reuses an existing editor if capability.json is fresh.
+    [switch]$EnsureEditor
 )
 
 Set-StrictMode -Version Latest
@@ -107,6 +111,22 @@ if ($hasFixture -and $hasInline) {
 }
 if (-not $hasFixture -and -not $hasInline) {
     Exit-Failure 'request-invalid' 'Exactly one of -RequestFixturePath or -RequestJson must be supplied.'
+}
+
+# Optional: auto-launch the editor if the caller asked for -EnsureEditor.
+if ($EnsureEditor) {
+    $launcher = Join-Path $PSScriptRoot 'invoke-launch-editor.ps1'
+    $launchOut = & pwsh -NoProfile -File $launcher -ProjectRoot $resolvedRoot 2>&1
+    try {
+        $launchEnv = ($launchOut -join [Environment]::NewLine) | ConvertFrom-Json -Depth 20
+    }
+    catch {
+        Exit-Failure 'editor-not-running' "Auto-launch produced non-JSON output: $($launchOut -join '; ')"
+    }
+    if ($launchEnv.status -ne 'success') {
+        $detail = if ($null -ne $launchEnv.diagnostics -and @($launchEnv.diagnostics).Count -gt 0) { $launchEnv.diagnostics[0] } else { 'no diagnostic' }
+        Exit-Failure 'editor-not-running' "Auto-launch failed (failureKind=$($launchEnv.failureKind)): $detail"
+    }
 }
 
 # Lifecycle preamble (US1): concurrent-run guard, in-flight marker, transient-zone cleanup

--- a/tools/automation/invoke-input-dispatch.ps1
+++ b/tools/automation/invoke-input-dispatch.ps1
@@ -116,7 +116,9 @@ if (-not $hasFixture -and -not $hasInline) {
 # Optional: auto-launch the editor if the caller asked for -EnsureEditor.
 if ($EnsureEditor) {
     $launcher = Join-Path $PSScriptRoot 'invoke-launch-editor.ps1'
-    $launchOut = & pwsh -NoProfile -File $launcher -ProjectRoot $resolvedRoot 2>&1
+    # Capture stdout only -- the helper writes a single-line stderr summary that
+    # would corrupt the JSON envelope if 2>&1-merged.
+    $launchOut = & pwsh -NoProfile -File $launcher -ProjectRoot $resolvedRoot
     try {
         $launchEnv = ($launchOut -join [Environment]::NewLine) | ConvertFrom-Json -Depth 20
     }

--- a/tools/automation/invoke-input-dispatch.ps1
+++ b/tools/automation/invoke-input-dispatch.ps1
@@ -65,7 +65,11 @@ param(
 
     [int]$MaxCapabilityAgeSeconds = 300,
 
-    [int]$PollIntervalMilliseconds = 250
+    [int]$PollIntervalMilliseconds = 250,
+
+    # When set, auto-launch a Godot editor against -ProjectRoot before running.
+    # Idempotent: reuses an existing editor if capability.json is fresh.
+    [switch]$EnsureEditor
 )
 
 Set-StrictMode -Version Latest
@@ -108,6 +112,22 @@ if (-not $hasFixture -and -not $hasInline) {
 }
 
 # Step 2-3: Resolve project root (already done above)
+
+# Optional: auto-launch the editor if the caller asked for -EnsureEditor.
+if ($EnsureEditor) {
+    $launcher = Join-Path $PSScriptRoot 'invoke-launch-editor.ps1'
+    $launchOut = & pwsh -NoProfile -File $launcher -ProjectRoot $resolvedRoot 2>&1
+    try {
+        $launchEnv = ($launchOut -join [Environment]::NewLine) | ConvertFrom-Json -Depth 20
+    }
+    catch {
+        Exit-Failure 'editor-not-running' "Auto-launch produced non-JSON output: $($launchOut -join '; ')"
+    }
+    if ($launchEnv.status -ne 'success') {
+        $detail = if ($null -ne $launchEnv.diagnostics -and @($launchEnv.diagnostics).Count -gt 0) { $launchEnv.diagnostics[0] } else { 'no diagnostic' }
+        Exit-Failure 'editor-not-running' "Auto-launch failed (failureKind=$($launchEnv.failureKind)): $detail"
+    }
+}
 
 # Lifecycle preamble (US1): concurrent-run guard, in-flight marker, transient-zone cleanup
 $_assertResult   = Assert-NoInFlightRun -ProjectRoot $resolvedRoot

--- a/tools/automation/invoke-input-dispatch.ps1
+++ b/tools/automation/invoke-input-dispatch.ps1
@@ -117,8 +117,11 @@ if (-not $hasFixture -and -not $hasInline) {
 if ($EnsureEditor) {
     $launcher = Join-Path $PSScriptRoot 'invoke-launch-editor.ps1'
     # Capture stdout only -- the helper writes a single-line stderr summary that
-    # would corrupt the JSON envelope if 2>&1-merged.
-    $launchOut = & pwsh -NoProfile -File $launcher -ProjectRoot $resolvedRoot
+    # would corrupt the JSON envelope if 2>&1-merged. Thread our own
+    # -MaxCapabilityAgeSeconds through so a stricter caller setting is not
+    # silently relaxed by the launcher's default (300s).
+    $launchOut = & pwsh -NoProfile -File $launcher `
+        -ProjectRoot $resolvedRoot -MaxCapabilityAgeSeconds $MaxCapabilityAgeSeconds
     try {
         $launchEnv = ($launchOut -join [Environment]::NewLine) | ConvertFrom-Json -Depth 20
     }

--- a/tools/automation/invoke-launch-editor.ps1
+++ b/tools/automation/invoke-launch-editor.ps1
@@ -104,32 +104,69 @@ function Resolve-GodotBinary {
 
 function Get-EditorProcessesForProject {
     param([Parameter(Mandatory)][string]$ProjectRoot)
-    # Match Godot processes whose CommandLine includes --path <ProjectRoot> so
-    # we never touch unrelated editor instances. CIM is Windows-only; on POSIX
-    # we fall back to a name match (good enough for the common case).
+    # Match Godot processes whose command-line carries `--path <ProjectRoot>` as a
+    # discrete argument (quoted or unquoted) so we never confuse "/proj" with
+    # "/proj2" or stop unrelated editor instances. The match enforces a token
+    # boundary after the path (whitespace, closing quote, or end-of-string) and
+    # treats forward / back slashes as interchangeable on Windows.
     $isWin = $IsWindows -or $env:OS -eq 'Windows_NT'
-    $matches = @()
+
+    $found = [System.Collections.Generic.List[object]]::new()
+
     if ($isWin) {
+        # Case-insensitive regex requiring `--path` (or `--path=`) followed by
+        # an exact, slash-normalised root token bounded by whitespace or EOL.
+        $normRoot = $ProjectRoot.TrimEnd('\', '/').Replace('/', '\')
+        $rootEsc = [regex]::Escape($normRoot)
+        $pattern = '(?i)--path(?:\s+|=)("?)' + $rootEsc + '\1(?=\s|$)'
+
         try {
             $procs = Get-CimInstance -ClassName Win32_Process -Filter "Name LIKE 'Godot%'" -ErrorAction SilentlyContinue
             foreach ($p in @($procs)) {
                 $cmd = [string]$p.CommandLine
                 if ([string]::IsNullOrEmpty($cmd)) { continue }
-                # Compare on normalised slashes since Godot may have been launched with either.
                 $normCmd = $cmd.Replace('/', '\')
-                $normRoot = $ProjectRoot.Replace('/', '\')
-                if ($normCmd -like "*--path*$normRoot*") {
-                    $matches += [pscustomobject]@{ Id = [int]$p.ProcessId; CommandLine = $cmd; Name = [string]$p.Name }
+                if ($normCmd -match $pattern) {
+                    [void]$found.Add([pscustomobject]@{ Id = [int]$p.ProcessId; CommandLine = $cmd; Name = [string]$p.Name })
                 }
             }
         }
         catch { }
+        return ,@($found)
     }
-    else {
-        $matches = @(Get-Process -Name 'Godot*' -ErrorAction SilentlyContinue |
-            Select-Object -Property @{N='Id';E={$_.Id}}, @{N='Name';E={$_.ProcessName}}, @{N='CommandLine';E={''}})
+
+    # POSIX: shell out to /usr/bin/env ps for cmdline inspection. We deliberately
+    # avoid the `ps` alias (resolves to Get-Process in PowerShell) and skip the
+    # name-only `Get-Process Godot*` fallback -- that returns every Godot
+    # editor on the box and breaks the "leave unrelated instances alone"
+    # contract that invoke-stop-editor depends on.
+    $normRoot = $ProjectRoot.TrimEnd('/')
+    $rootEsc = [regex]::Escape($normRoot)
+    $pattern = '--path(?:\s+|=)("?)' + $rootEsc + '\1(?=\s|$)'
+
+    $psBinary = (Get-Command ps -CommandType Application -ErrorAction SilentlyContinue | Select-Object -First 1)
+    if ($null -eq $psBinary) { return ,@() }
+
+    $psLines = $null
+    try {
+        $psLines = & $psBinary.Source -eo 'pid=,args=' 2>$null
     }
-    return ,$matches
+    catch { return ,@() }
+
+    foreach ($line in @($psLines)) {
+        $trimmed = $line.Trim()
+        if ([string]::IsNullOrEmpty($trimmed)) { continue }
+        if ($trimmed -notmatch '^\s*\d+\s+') { continue }
+        $procId = [int]([regex]::Match($trimmed, '^\s*(\d+)\s+').Groups[1].Value)
+        $cmd = $trimmed -replace '^\s*\d+\s+', ''
+        # Restrict to Godot binaries to avoid matching unrelated invocations
+        # that happen to carry `--path`.
+        if ($cmd -notmatch '(?i)\bGodot') { continue }
+        if ($cmd -match $pattern) {
+            [void]$found.Add([pscustomobject]@{ Id = $procId; CommandLine = $cmd; Name = 'Godot' })
+        }
+    }
+    return ,@($found)
 }
 
 function Test-CapabilityFresh {
@@ -207,6 +244,13 @@ if (-not (Test-Path -LiteralPath $logDir)) {
 $stdoutLog = Join-Path $logDir 'editor.stdout.log'
 $stderrLog = Join-Path $logDir 'editor.stderr.log'
 
+# Capture spawn time BEFORE Start-Process so the post-spawn poll loop can
+# require capability.json's mtime >= $spawnedAt. Otherwise a stale
+# capability.json from a prior session that's still within
+# MaxCapabilityAgeSeconds would short-circuit the cold launch path and
+# return success before the freshly spawned editor is actually ready.
+$spawnedAt = [DateTime]::UtcNow
+
 try {
     $proc = Start-Process -FilePath $godot `
         -ArgumentList @('--editor', '--path', $resolvedRoot, '--verbose') `
@@ -218,13 +262,14 @@ catch {
     Exit-Failure 'editor-not-running' "Failed to spawn Godot at '$godot': $($_.Exception.Message)"
 }
 
-# Poll capability.json until it appears + parses, OR until ReadyTimeoutSeconds.
+# Poll capability.json until the *newly spawned* editor publishes one, OR until
+# ReadyTimeoutSeconds. "Newly published" = file exists, parses cleanly, and its
+# LastWriteTimeUtc >= $spawnedAt (ignore prior-session leftovers).
 $deadline = (Get-Date).AddSeconds($ReadyTimeoutSeconds)
 $age = $null
 while ((Get-Date) -lt $deadline) {
     Start-Sleep -Milliseconds 500
 
-    # If the editor process already died, surface that immediately.
     if ($proc.HasExited) {
         $tailErr = if (Test-Path -LiteralPath $stderrLog) {
             (Get-Content -LiteralPath $stderrLog -Tail 5 -ErrorAction SilentlyContinue) -join '; '
@@ -232,8 +277,16 @@ while ((Get-Date) -lt $deadline) {
         Exit-Failure 'editor-not-running' "Godot process exited with code $($proc.ExitCode) before capability.json appeared. stderr tail: $tailErr"
     }
 
-    $age = Test-CapabilityFresh -Path $capabilityPath -MaxAgeSeconds $MaxCapabilityAgeSeconds
-    if ($null -ne $age) { break }
+    if (Test-Path -LiteralPath $capabilityPath) {
+        $mtimeUtc = (Get-Item -LiteralPath $capabilityPath).LastWriteTimeUtc
+        if ($mtimeUtc -ge $spawnedAt) {
+            $candidateAge = Test-CapabilityFresh -Path $capabilityPath -MaxAgeSeconds $MaxCapabilityAgeSeconds
+            if ($null -ne $candidateAge) {
+                $age = $candidateAge
+                break
+            }
+        }
+    }
 }
 
 if ($null -eq $age) {
@@ -253,5 +306,17 @@ $outcome = @{
 $envelope = Write-RunbookEnvelope -Status 'success' -RunId $runId -RequestId $requestId `
     -Diagnostics @() -Outcome $outcome
 $envelope
-Write-RunbookStderrSummary "OK: spawned editor PID $($proc.Id); capability ready in $((Get-Date) - (Get-Process -Id $proc.Id).StartTime | Select-Object -ExpandProperty TotalSeconds | ForEach-Object { [int]$_ })s (or ${age}s old)."
+
+# Summary is best-effort. Get-Process can throw under StrictMode if the editor
+# has already exited (or its PID has been recycled), but the success envelope
+# is already on stdout -- never let a cosmetic stderr line turn a successful
+# invocation into a failing one.
+try {
+    $startTime = (Get-Process -Id $proc.Id -ErrorAction Stop).StartTime
+    $readySecs = [int]((Get-Date) - $startTime).TotalSeconds
+    Write-RunbookStderrSummary "OK: spawned editor PID $($proc.Id); capability ready in ${readySecs}s (mtime ${age}s ago)."
+}
+catch {
+    Write-RunbookStderrSummary "OK: spawned editor PID $($proc.Id); capability mtime ${age}s ago."
+}
 exit 0

--- a/tools/automation/invoke-launch-editor.ps1
+++ b/tools/automation/invoke-launch-editor.ps1
@@ -1,0 +1,257 @@
+<#
+.SYNOPSIS
+    Launch (or attach to) a Godot editor for a sandbox project, returning when
+    the harness capability surface is ready.
+
+.DESCRIPTION
+    invoke-launch-editor.ps1 is the missing prerequisite step every runtime-
+    verification workflow needs: a live editor running against the target
+    project. It is idempotent — when an editor for the same -ProjectRoot is
+    already running and capability.json is fresh, it returns success in well
+    under a second. Otherwise it spawns Godot with `--editor --path <ProjectRoot>`,
+    redirects stdout/stderr to <ProjectRoot>/.editor-logs/, and polls
+    capability.json until it appears (or -ReadyTimeoutSeconds elapses).
+
+    The script emits a stable JSON envelope on stdout matching the same shape
+    as the runtime-verification invokers (status / failureKind / manifestPath /
+    runId / requestId / completedAt / diagnostics / outcome). manifestPath is
+    always null because no run was performed. outcome carries the editor PID,
+    the absolute capability.json path, and capability.json's age in seconds.
+
+    Pair with invoke-stop-editor.ps1 to terminate the editor cleanly.
+
+.PARAMETER ProjectRoot
+    Repo-relative or absolute path to the integration-testing sandbox.
+
+.PARAMETER ReadyTimeoutSeconds
+    Wall-clock budget for capability.json to appear after spawn. Default 90.
+    Cold starts (first launch with no shader cache) typically need 30-60s.
+
+.PARAMETER MaxCapabilityAgeSeconds
+    Existing capability.json is treated as "fresh" if its mtime is within this
+    window. When a fresh capability is found alongside a live Godot process,
+    the launcher short-circuits and returns success without spawning. Default 300.
+
+.PARAMETER ForceRestart
+    Stop any existing Godot processes for this project before launching. Use
+    when you suspect a stale editor is misbehaving.
+
+.EXAMPLE
+    pwsh ./tools/automation/invoke-launch-editor.ps1 -ProjectRoot integration-testing/probe
+
+    Launches (or reuses) the editor and returns when capability.json is ready.
+
+.EXAMPLE
+    pwsh ./tools/automation/invoke-launch-editor.ps1 `
+        -ProjectRoot integration-testing/probe -ForceRestart
+
+    Stops any existing editor for this project, then launches a fresh one.
+#>
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)]
+    [string]$ProjectRoot,
+
+    [int]$ReadyTimeoutSeconds = 90,
+
+    [int]$MaxCapabilityAgeSeconds = 300,
+
+    [switch]$ForceRestart
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$modulePath = Join-Path $PSScriptRoot 'RunbookOrchestration.psm1'
+Import-Module $modulePath -Force
+
+$resolvedRoot = Resolve-RunbookRepoPath -Path $ProjectRoot
+$workflowSlug = 'launch-editor'
+$requestId    = New-RunbookRequestId -Workflow $workflowSlug
+$runId        = $requestId
+
+function Exit-Failure {
+    param([string]$Kind, [string]$Message, [hashtable]$Outcome)
+    if ($null -eq $Outcome) {
+        $Outcome = @{ editorPid = $null; capabilityPath = $null; capabilityAgeSeconds = $null }
+    }
+    Write-RunbookEnvelope -Status 'failure' -FailureKind $Kind -RunId $runId -RequestId $requestId `
+        -Diagnostics @($Message) -Outcome $Outcome
+    Write-RunbookStderrSummary "FAIL: $Kind; $Message"
+    exit 1
+}
+
+function Resolve-GodotBinary {
+    if ($env:GODOT_BIN) {
+        if (Test-Path -LiteralPath $env:GODOT_BIN) {
+            return (Resolve-Path -LiteralPath $env:GODOT_BIN).Path
+        }
+        throw "GODOT_BIN is set to '$($env:GODOT_BIN)' but the file does not exist."
+    }
+    foreach ($candidate in @('godot', 'godot4')) {
+        $command = Get-Command $candidate -ErrorAction SilentlyContinue
+        if ($command) { return $command.Source }
+    }
+    $found = Get-Command 'Godot*' -CommandType Application -ErrorAction SilentlyContinue
+    if ($found) {
+        # On Windows, prefer the *_console.exe build for reliable stdout capture.
+        $console = $found | Where-Object { $_.Name -match 'console' } | Select-Object -First 1
+        if ($console) { return $console.Source }
+        return ($found | Select-Object -First 1).Source
+    }
+    throw "Could not locate the Godot binary. Set GODOT_BIN or add godot/godot4 to PATH."
+}
+
+function Get-EditorProcessesForProject {
+    param([Parameter(Mandatory)][string]$ProjectRoot)
+    # Match Godot processes whose CommandLine includes --path <ProjectRoot> so
+    # we never touch unrelated editor instances. CIM is Windows-only; on POSIX
+    # we fall back to a name match (good enough for the common case).
+    $isWin = $IsWindows -or $env:OS -eq 'Windows_NT'
+    $matches = @()
+    if ($isWin) {
+        try {
+            $procs = Get-CimInstance -ClassName Win32_Process -Filter "Name LIKE 'Godot%'" -ErrorAction SilentlyContinue
+            foreach ($p in @($procs)) {
+                $cmd = [string]$p.CommandLine
+                if ([string]::IsNullOrEmpty($cmd)) { continue }
+                # Compare on normalised slashes since Godot may have been launched with either.
+                $normCmd = $cmd.Replace('/', '\')
+                $normRoot = $ProjectRoot.Replace('/', '\')
+                if ($normCmd -like "*--path*$normRoot*") {
+                    $matches += [pscustomobject]@{ Id = [int]$p.ProcessId; CommandLine = $cmd; Name = [string]$p.Name }
+                }
+            }
+        }
+        catch { }
+    }
+    else {
+        $matches = @(Get-Process -Name 'Godot*' -ErrorAction SilentlyContinue |
+            Select-Object -Property @{N='Id';E={$_.Id}}, @{N='Name';E={$_.ProcessName}}, @{N='CommandLine';E={''}})
+    }
+    return ,$matches
+}
+
+function Test-CapabilityFresh {
+    param(
+        [Parameter(Mandatory)][string]$Path,
+        [Parameter(Mandatory)][int]$MaxAgeSeconds
+    )
+    if (-not (Test-Path -LiteralPath $Path)) { return $null }
+    $age = ((Get-Date) - (Get-Item -LiteralPath $Path).LastWriteTime).TotalSeconds
+    if ($age -gt $MaxAgeSeconds) { return $null }
+    try {
+        $null = Get-Content -LiteralPath $Path -Raw | ConvertFrom-Json -Depth 20
+    }
+    catch { return $null }
+    return [int]$age
+}
+
+# --- Resolve project root + capability path ---
+
+if (-not (Test-Path -LiteralPath $resolvedRoot)) {
+    Exit-Failure 'internal' "ProjectRoot '$resolvedRoot' does not exist."
+}
+$projectGodot = Join-Path $resolvedRoot 'project.godot'
+if (-not (Test-Path -LiteralPath $projectGodot)) {
+    Exit-Failure 'internal' "No project.godot at '$resolvedRoot' — not a Godot project root."
+}
+
+$capabilityPath = Join-Path $resolvedRoot 'harness/automation/results/capability.json'
+
+# --- ForceRestart path: stop any existing editors for this project first ---
+
+if ($ForceRestart) {
+    foreach ($p in (Get-EditorProcessesForProject -ProjectRoot $resolvedRoot)) {
+        Stop-Process -Id $p.Id -Force -ErrorAction SilentlyContinue
+    }
+    Start-Sleep -Milliseconds 500
+}
+
+# --- Idempotent fast path: live editor + fresh capability -> return success ---
+
+if (-not $ForceRestart) {
+    $existing = Get-EditorProcessesForProject -ProjectRoot $resolvedRoot
+    $existingCount = @($existing).Count
+    if ($existingCount -gt 0) {
+        $age = Test-CapabilityFresh -Path $capabilityPath -MaxAgeSeconds $MaxCapabilityAgeSeconds
+        if ($null -ne $age) {
+            $outcome = @{
+                editorPid            = [int](@($existing)[0].Id)
+                capabilityPath       = $capabilityPath
+                capabilityAgeSeconds = $age
+                reusedExistingEditor = $true
+            }
+            $envelope = Write-RunbookEnvelope -Status 'success' -RunId $runId -RequestId $requestId `
+                -Diagnostics @() -Outcome $outcome
+            $envelope
+            Write-RunbookStderrSummary "OK: reused existing editor PID $($outcome.editorPid); capability ${age}s old."
+            exit 0
+        }
+    }
+}
+
+# --- Launch a fresh editor ---
+
+try {
+    $godot = Resolve-GodotBinary
+}
+catch {
+    Exit-Failure 'internal' $_.Exception.Message
+}
+
+$logDir = Join-Path $resolvedRoot '.editor-logs'
+if (-not (Test-Path -LiteralPath $logDir)) {
+    New-Item -ItemType Directory -Path $logDir -Force | Out-Null
+}
+$stdoutLog = Join-Path $logDir 'editor.stdout.log'
+$stderrLog = Join-Path $logDir 'editor.stderr.log'
+
+try {
+    $proc = Start-Process -FilePath $godot `
+        -ArgumentList @('--editor', '--path', $resolvedRoot, '--verbose') `
+        -PassThru `
+        -RedirectStandardOutput $stdoutLog `
+        -RedirectStandardError $stderrLog
+}
+catch {
+    Exit-Failure 'editor-not-running' "Failed to spawn Godot at '$godot': $($_.Exception.Message)"
+}
+
+# Poll capability.json until it appears + parses, OR until ReadyTimeoutSeconds.
+$deadline = (Get-Date).AddSeconds($ReadyTimeoutSeconds)
+$age = $null
+while ((Get-Date) -lt $deadline) {
+    Start-Sleep -Milliseconds 500
+
+    # If the editor process already died, surface that immediately.
+    if ($proc.HasExited) {
+        $tailErr = if (Test-Path -LiteralPath $stderrLog) {
+            (Get-Content -LiteralPath $stderrLog -Tail 5 -ErrorAction SilentlyContinue) -join '; '
+        } else { '' }
+        Exit-Failure 'editor-not-running' "Godot process exited with code $($proc.ExitCode) before capability.json appeared. stderr tail: $tailErr"
+    }
+
+    $age = Test-CapabilityFresh -Path $capabilityPath -MaxAgeSeconds $MaxCapabilityAgeSeconds
+    if ($null -ne $age) { break }
+}
+
+if ($null -eq $age) {
+    Exit-Failure 'timeout' "capability.json did not appear within ${ReadyTimeoutSeconds}s. Editor PID $($proc.Id) is still running; inspect '$stdoutLog' / '$stderrLog' for clues." @{
+        editorPid            = $proc.Id
+        capabilityPath       = $capabilityPath
+        capabilityAgeSeconds = $null
+    }
+}
+
+$outcome = @{
+    editorPid            = $proc.Id
+    capabilityPath       = $capabilityPath
+    capabilityAgeSeconds = $age
+    reusedExistingEditor = $false
+}
+$envelope = Write-RunbookEnvelope -Status 'success' -RunId $runId -RequestId $requestId `
+    -Diagnostics @() -Outcome $outcome
+$envelope
+Write-RunbookStderrSummary "OK: spawned editor PID $($proc.Id); capability ready in $((Get-Date) - (Get-Process -Id $proc.Id).StartTime | Select-Object -ExpandProperty TotalSeconds | ForEach-Object { [int]$_ })s (or ${age}s old)."
+exit 0

--- a/tools/automation/invoke-pin-run.ps1
+++ b/tools/automation/invoke-pin-run.ps1
@@ -76,7 +76,11 @@ function Exit-Failure {
         -DryRun $DryRun.IsPresent -Diagnostics @($Message) -PlannedPaths @() -PinName $PinName
     $label = $status.ToUpperInvariant()
     Write-RunbookStderrSummary "${label}: $Kind; $Message"
-    exit 1
+    # Exit 0 for `refused` -- the script ran successfully and correctly declined a
+    # precondition (e.g. pin-name-collision). Exit 1 only for unexpected failures
+    # the caller should investigate. Envelope `status` field is the authoritative
+    # signal in either case.
+    if ($status -eq 'refused') { exit 0 } else { exit 1 }
 }
 
 $copyResult = Copy-RunToPinnedZone -ProjectRoot $resolvedRoot -PinName $PinName `

--- a/tools/automation/invoke-runtime-error-triage.ps1
+++ b/tools/automation/invoke-runtime-error-triage.ps1
@@ -117,7 +117,9 @@ if (-not $hasFixture -and -not $hasInline) {
 # Optional: auto-launch the editor if the caller asked for -EnsureEditor.
 if ($EnsureEditor) {
     $launcher = Join-Path $PSScriptRoot 'invoke-launch-editor.ps1'
-    $launchOut = & pwsh -NoProfile -File $launcher -ProjectRoot $resolvedRoot 2>&1
+    # Capture stdout only -- the helper writes a single-line stderr summary that
+    # would corrupt the JSON envelope if 2>&1-merged.
+    $launchOut = & pwsh -NoProfile -File $launcher -ProjectRoot $resolvedRoot
     try {
         $launchEnv = ($launchOut -join [Environment]::NewLine) | ConvertFrom-Json -Depth 20
     }

--- a/tools/automation/invoke-runtime-error-triage.ps1
+++ b/tools/automation/invoke-runtime-error-triage.ps1
@@ -70,7 +70,11 @@ param(
 
     [int]$MaxCapabilityAgeSeconds = 300,
 
-    [int]$PollIntervalMilliseconds = 250
+    [int]$PollIntervalMilliseconds = 250,
+
+    # When set, auto-launch a Godot editor against -ProjectRoot before running.
+    # Idempotent: reuses an existing editor if capability.json is fresh.
+    [switch]$EnsureEditor
 )
 
 Set-StrictMode -Version Latest
@@ -108,6 +112,22 @@ if ($hasFixture -and $hasInline) {
 }
 if (-not $hasFixture -and -not $hasInline) {
     Exit-Failure 'request-invalid' 'Exactly one of -RequestFixturePath or -RequestJson must be supplied.'
+}
+
+# Optional: auto-launch the editor if the caller asked for -EnsureEditor.
+if ($EnsureEditor) {
+    $launcher = Join-Path $PSScriptRoot 'invoke-launch-editor.ps1'
+    $launchOut = & pwsh -NoProfile -File $launcher -ProjectRoot $resolvedRoot 2>&1
+    try {
+        $launchEnv = ($launchOut -join [Environment]::NewLine) | ConvertFrom-Json -Depth 20
+    }
+    catch {
+        Exit-Failure 'editor-not-running' "Auto-launch produced non-JSON output: $($launchOut -join '; ')"
+    }
+    if ($launchEnv.status -ne 'success') {
+        $detail = if ($null -ne $launchEnv.diagnostics -and @($launchEnv.diagnostics).Count -gt 0) { $launchEnv.diagnostics[0] } else { 'no diagnostic' }
+        Exit-Failure 'editor-not-running' "Auto-launch failed (failureKind=$($launchEnv.failureKind)): $detail"
+    }
 }
 
 # Lifecycle preamble (US1): concurrent-run guard, in-flight marker, transient-zone cleanup

--- a/tools/automation/invoke-runtime-error-triage.ps1
+++ b/tools/automation/invoke-runtime-error-triage.ps1
@@ -118,8 +118,11 @@ if (-not $hasFixture -and -not $hasInline) {
 if ($EnsureEditor) {
     $launcher = Join-Path $PSScriptRoot 'invoke-launch-editor.ps1'
     # Capture stdout only -- the helper writes a single-line stderr summary that
-    # would corrupt the JSON envelope if 2>&1-merged.
-    $launchOut = & pwsh -NoProfile -File $launcher -ProjectRoot $resolvedRoot
+    # would corrupt the JSON envelope if 2>&1-merged. Thread our own
+    # -MaxCapabilityAgeSeconds through so a stricter caller setting is not
+    # silently relaxed by the launcher's default (300s).
+    $launchOut = & pwsh -NoProfile -File $launcher `
+        -ProjectRoot $resolvedRoot -MaxCapabilityAgeSeconds $MaxCapabilityAgeSeconds
     try {
         $launchEnv = ($launchOut -join [Environment]::NewLine) | ConvertFrom-Json -Depth 20
     }

--- a/tools/automation/invoke-scene-inspection.ps1
+++ b/tools/automation/invoke-scene-inspection.ps1
@@ -61,7 +61,11 @@ param(
 
     [int]$MaxCapabilityAgeSeconds = 300,
 
-    [int]$PollIntervalMilliseconds = 250
+    [int]$PollIntervalMilliseconds = 250,
+
+    # When set, auto-launch a Godot editor against -ProjectRoot before running.
+    # Idempotent: reuses an existing editor if capability.json is fresh.
+    [switch]$EnsureEditor
 )
 
 Set-StrictMode -Version Latest
@@ -116,6 +120,22 @@ function Exit-Failure {
         -Diagnostics $diags -Outcome @{ sceneTreePath = $null; nodeCount = 0 }
     Write-RunbookStderrSummary "FAIL: $Kind; $Message"
     exit 1
+}
+
+# Optional: auto-launch the editor if the caller asked for -EnsureEditor.
+if ($EnsureEditor) {
+    $launcher = Join-Path $PSScriptRoot 'invoke-launch-editor.ps1'
+    $launchOut = & pwsh -NoProfile -File $launcher -ProjectRoot $resolvedRoot 2>&1
+    try {
+        $launchEnv = ($launchOut -join [Environment]::NewLine) | ConvertFrom-Json -Depth 20
+    }
+    catch {
+        Exit-Failure 'editor-not-running' "Auto-launch produced non-JSON output: $($launchOut -join '; ')"
+    }
+    if ($launchEnv.status -ne 'success') {
+        $detail = if ($null -ne $launchEnv.diagnostics -and @($launchEnv.diagnostics).Count -gt 0) { $launchEnv.diagnostics[0] } else { 'no diagnostic' }
+        Exit-Failure 'editor-not-running' "Auto-launch failed (failureKind=$($launchEnv.failureKind)): $detail"
+    }
 }
 
 # Lifecycle preamble (US1): concurrent-run guard, in-flight marker, transient-zone cleanup

--- a/tools/automation/invoke-scene-inspection.ps1
+++ b/tools/automation/invoke-scene-inspection.ps1
@@ -125,7 +125,9 @@ function Exit-Failure {
 # Optional: auto-launch the editor if the caller asked for -EnsureEditor.
 if ($EnsureEditor) {
     $launcher = Join-Path $PSScriptRoot 'invoke-launch-editor.ps1'
-    $launchOut = & pwsh -NoProfile -File $launcher -ProjectRoot $resolvedRoot 2>&1
+    # Capture stdout only -- the helper writes a single-line stderr summary that
+    # would corrupt the JSON envelope if 2>&1-merged.
+    $launchOut = & pwsh -NoProfile -File $launcher -ProjectRoot $resolvedRoot
     try {
         $launchEnv = ($launchOut -join [Environment]::NewLine) | ConvertFrom-Json -Depth 20
     }

--- a/tools/automation/invoke-scene-inspection.ps1
+++ b/tools/automation/invoke-scene-inspection.ps1
@@ -140,78 +140,37 @@ if (-not $cap.Ok) {
     Exit-Failure $cap.FailureKind $cap.Diagnostic
 }
 
-# Step 5: Synthesize payload internally
-# NOTE: expectationFiles is required by the schema even when empty.
-# NOTE: the broker watches the canonical run-request.json path, not a per-request filename.
-$internalPayload = @{
-    requestId        = $requestId
+# Step 5: Synthesize the minimal startup-capture payload and route it through
+# the shared Resolve-RunbookPayload helper, like every other runtime invoker.
+# The helper handles validate-then-rename (C1), forces artifactRoot='' (C2),
+# defaults expectationFiles, and writes to the canonical path the broker
+# watches. Scene-inspection takes no caller-supplied fixture, so we synthesize
+# the fixed payload as inline JSON.
+$inlinePayload = [ordered]@{
+    requestId        = $requestId   # Resolve-RunbookPayload re-stamps this; harmless duplicate.
     scenarioId       = "runbook-scene-inspection-$requestId"
     runId            = $requestId
     targetScene      = $TargetScene
     outputDirectory  = "res://evidence/automation/$requestId"
-    # C2: legacy field. Empty string lets the runtime fall back to outputDirectory
-    # for manifest references (see scenegraph_artifact_writer._resolve_artifact_root).
-    # Schema still satisfied (string, present, no minLength).
-    artifactRoot     = ''
     expectationFiles = @()
-    capturePolicy    = @{ startup = $true; manual = $false; failure = $false }
-    stopPolicy       = @{ stopAfterValidation = $true }
+    capturePolicy    = [ordered]@{ startup = $true; manual = $false; failure = $false }
+    stopPolicy       = [ordered]@{ stopAfterValidation = $true }
     requestedBy      = 'runbook-scene-inspection'
     createdAt        = (Get-Date -Format 'o')
-}
-
-$requestsDir = Join-Path $resolvedRoot 'harness/automation/requests'
-if (-not (Test-Path -LiteralPath $requestsDir)) {
-    New-Item -ItemType Directory -Path $requestsDir -Force | Out-Null
-}
-# Write to the canonical path the editor broker watches (run-request.json),
-# not a per-request filename that the broker would never pick up.
-$canonicalPath = Join-Path $requestsDir 'run-request.json'
-
-# C1: validate-then-rename. The editor broker consumes $canonicalPath the
-# instant FileSystemWatcher fires; validating after the write means the
-# validator's Resolve-Path crashes when the broker has already moved the
-# file. Write to <canonical>.tmp first, validate the temp path (which the
-# broker is not watching), then atomic-rename into place. Mirrors the
-# pattern in Resolve-RunbookPayload. (Pass 2 H3 will fold this script's
-# inline write into Resolve-RunbookPayload via -InlineJson.)
-$tmpPath = "$canonicalPath.tmp"
-$internalPayload | ConvertTo-Json -Depth 10 | Set-Content -LiteralPath $tmpPath -Encoding utf8
-
-$schemaPath = 'specs/003-editor-evidence-loop/contracts/automation-run-request.schema.json'
-$schemaResolved = Resolve-RunbookRepoPath -Path $schemaPath
-$validation = & pwsh -NoProfile -File (Resolve-RunbookRepoPath -Path 'tools/validate-json.ps1') `
-    -InputPath $tmpPath -SchemaPath $schemaResolved -AllowInvalid 2>&1
-$validationExit = $LASTEXITCODE
+} | ConvertTo-Json -Depth 10
 
 try {
-    if ($validationExit -ne 0) {
-        $captured = ($validation | ForEach-Object { [string]$_ }) -join [Environment]::NewLine
-        $captured = [regex]::Replace($captured, "`e\[[0-?]*[ -/]*[@-~]", '')
-        Exit-Failure 'request-invalid' "Schema validator could not run (exit $validationExit): $captured"
-    }
-    $captured = ($validation | ForEach-Object { [string]$_ }) -join [Environment]::NewLine
-    $captured = [regex]::Replace($captured, "`e\[[0-?]*[ -/]*[@-~]", '')
-    $parsed = $captured | ConvertFrom-Json -Depth 20
-    if (-not $parsed.valid) {
-        $errDetail = if ($null -ne $parsed.PSObject.Properties['error']) { $parsed.error } else { 'schema validation failed' }
-        Exit-Failure 'request-invalid' "Run request does not satisfy schema '$schemaPath': $errDetail"
-    }
-    Move-Item -LiteralPath $tmpPath -Destination $canonicalPath -Force
+    $materialized = Resolve-RunbookPayload -InlineJson $inlinePayload `
+        -RequestId $requestId -ProjectRoot $resolvedRoot
 }
 catch {
-    Remove-Item -LiteralPath $tmpPath -Force -ErrorAction SilentlyContinue
-    if ($_.Exception.Message -match '^Run request does not satisfy|^Schema validator could not run') {
-        # Already routed through Exit-Failure; the catch is just for cleanup.
-        throw
-    }
-    Exit-Failure 'request-invalid' "Failed to validate run-request.json: $($_.Exception.Message)"
+    Exit-Failure 'request-invalid' $_.Exception.Message
 }
 
 # Step 6-7: Request + poll
 $runResult = Invoke-RunbookRequest `
     -ProjectRoot $resolvedRoot `
-    -RequestPath $canonicalPath `
+    -RequestPath $materialized.TempRequestPath `
     -ExpectedRequestId $requestId `
     -TimeoutSeconds $TimeoutSeconds `
     -PollIntervalMilliseconds $PollIntervalMilliseconds

--- a/tools/automation/invoke-scene-inspection.ps1
+++ b/tools/automation/invoke-scene-inspection.ps1
@@ -126,8 +126,11 @@ function Exit-Failure {
 if ($EnsureEditor) {
     $launcher = Join-Path $PSScriptRoot 'invoke-launch-editor.ps1'
     # Capture stdout only -- the helper writes a single-line stderr summary that
-    # would corrupt the JSON envelope if 2>&1-merged.
-    $launchOut = & pwsh -NoProfile -File $launcher -ProjectRoot $resolvedRoot
+    # would corrupt the JSON envelope if 2>&1-merged. Thread our own
+    # -MaxCapabilityAgeSeconds through so a stricter caller setting is not
+    # silently relaxed by the launcher's default (300s).
+    $launchOut = & pwsh -NoProfile -File $launcher `
+        -ProjectRoot $resolvedRoot -MaxCapabilityAgeSeconds $MaxCapabilityAgeSeconds
     try {
         $launchEnv = ($launchOut -join [Environment]::NewLine) | ConvertFrom-Json -Depth 20
     }

--- a/tools/automation/invoke-stop-editor.ps1
+++ b/tools/automation/invoke-stop-editor.ps1
@@ -50,27 +50,61 @@ function Exit-Failure {
 
 function Get-EditorProcessesForProject {
     param([Parameter(Mandatory)][string]$ProjectRoot)
+    # Match Godot processes whose command-line carries `--path <ProjectRoot>` as a
+    # discrete argument so we never accidentally stop an unrelated editor when
+    # one project root is a prefix of another (C:\proj vs C:\proj2). Token
+    # boundary required after the path; slash differences normalised on Windows.
     $isWin = $IsWindows -or $env:OS -eq 'Windows_NT'
-    $matches = @()
+
+    $found = [System.Collections.Generic.List[int]]::new()
+
     if ($isWin) {
+        $normRoot = $ProjectRoot.TrimEnd('\', '/').Replace('/', '\')
+        $rootEsc = [regex]::Escape($normRoot)
+        $pattern = '(?i)--path(?:\s+|=)("?)' + $rootEsc + '\1(?=\s|$)'
+
         try {
             $procs = Get-CimInstance -ClassName Win32_Process -Filter "Name LIKE 'Godot%'" -ErrorAction SilentlyContinue
             foreach ($p in @($procs)) {
                 $cmd = [string]$p.CommandLine
                 if ([string]::IsNullOrEmpty($cmd)) { continue }
                 $normCmd = $cmd.Replace('/', '\')
-                $normRoot = $ProjectRoot.Replace('/', '\')
-                if ($normCmd -like "*--path*$normRoot*") {
-                    $matches += [int]$p.ProcessId
+                if ($normCmd -match $pattern) {
+                    [void]$found.Add([int]$p.ProcessId)
                 }
             }
         }
         catch { }
+        return ,@($found)
     }
-    else {
-        $matches = @(Get-Process -Name 'Godot*' -ErrorAction SilentlyContinue | ForEach-Object { $_.Id })
+
+    # POSIX: shell out to ps. Skip Get-Process Godot* fallback -- returning
+    # every Godot editor on the box would risk killing unrelated instances.
+    $normRoot = $ProjectRoot.TrimEnd('/')
+    $rootEsc = [regex]::Escape($normRoot)
+    $pattern = '--path(?:\s+|=)("?)' + $rootEsc + '\1(?=\s|$)'
+
+    $psBinary = (Get-Command ps -CommandType Application -ErrorAction SilentlyContinue | Select-Object -First 1)
+    if ($null -eq $psBinary) { return ,@() }
+
+    $psLines = $null
+    try {
+        $psLines = & $psBinary.Source -eo 'pid=,args=' 2>$null
     }
-    return ,$matches
+    catch { return ,@() }
+
+    foreach ($line in @($psLines)) {
+        $trimmed = $line.Trim()
+        if ([string]::IsNullOrEmpty($trimmed)) { continue }
+        if ($trimmed -notmatch '^\s*\d+\s+') { continue }
+        $procId = [int]([regex]::Match($trimmed, '^\s*(\d+)\s+').Groups[1].Value)
+        $cmd = $trimmed -replace '^\s*\d+\s+', ''
+        if ($cmd -notmatch '(?i)\bGodot') { continue }
+        if ($cmd -match $pattern) {
+            [void]$found.Add($procId)
+        }
+    }
+    return ,@($found)
 }
 
 if (-not (Test-Path -LiteralPath $resolvedRoot)) {

--- a/tools/automation/invoke-stop-editor.ps1
+++ b/tools/automation/invoke-stop-editor.ps1
@@ -1,0 +1,122 @@
+<#
+.SYNOPSIS
+    Stop the Godot editor running against a sandbox project, leaving unrelated
+    Godot instances untouched.
+
+.DESCRIPTION
+    invoke-stop-editor.ps1 finds Godot processes whose command-line includes
+    `--path <ProjectRoot>` and terminates them. Three Godot processes typically
+    spawn from `--editor --path <root>` (project manager, editor, optional
+    console wrapper); the script targets all three.
+
+    Pair with invoke-launch-editor.ps1. The stdout envelope shape mirrors the
+    runtime-verification invokers; manifestPath is always null.
+
+.PARAMETER ProjectRoot
+    Repo-relative or absolute path to the integration-testing sandbox.
+
+.EXAMPLE
+    pwsh ./tools/automation/invoke-stop-editor.ps1 -ProjectRoot integration-testing/probe
+
+    Stops every Godot process for the probe sandbox.
+#>
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)]
+    [string]$ProjectRoot
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$modulePath = Join-Path $PSScriptRoot 'RunbookOrchestration.psm1'
+Import-Module $modulePath -Force
+
+$resolvedRoot = Resolve-RunbookRepoPath -Path $ProjectRoot
+$workflowSlug = 'stop-editor'
+$requestId    = New-RunbookRequestId -Workflow $workflowSlug
+$runId        = $requestId
+
+function Exit-Failure {
+    param([string]$Kind, [string]$Message, [hashtable]$Outcome)
+    if ($null -eq $Outcome) {
+        $Outcome = @{ stoppedPids = @(); remainingPids = @() }
+    }
+    Write-RunbookEnvelope -Status 'failure' -FailureKind $Kind -RunId $runId -RequestId $requestId `
+        -Diagnostics @($Message) -Outcome $Outcome
+    Write-RunbookStderrSummary "FAIL: $Kind; $Message"
+    exit 1
+}
+
+function Get-EditorProcessesForProject {
+    param([Parameter(Mandatory)][string]$ProjectRoot)
+    $isWin = $IsWindows -or $env:OS -eq 'Windows_NT'
+    $matches = @()
+    if ($isWin) {
+        try {
+            $procs = Get-CimInstance -ClassName Win32_Process -Filter "Name LIKE 'Godot%'" -ErrorAction SilentlyContinue
+            foreach ($p in @($procs)) {
+                $cmd = [string]$p.CommandLine
+                if ([string]::IsNullOrEmpty($cmd)) { continue }
+                $normCmd = $cmd.Replace('/', '\')
+                $normRoot = $ProjectRoot.Replace('/', '\')
+                if ($normCmd -like "*--path*$normRoot*") {
+                    $matches += [int]$p.ProcessId
+                }
+            }
+        }
+        catch { }
+    }
+    else {
+        $matches = @(Get-Process -Name 'Godot*' -ErrorAction SilentlyContinue | ForEach-Object { $_.Id })
+    }
+    return ,$matches
+}
+
+if (-not (Test-Path -LiteralPath $resolvedRoot)) {
+    Exit-Failure 'internal' "ProjectRoot '$resolvedRoot' does not exist."
+}
+
+$pidsToStop = Get-EditorProcessesForProject -ProjectRoot $resolvedRoot
+$pidCount = @($pidsToStop).Count
+
+if ($pidCount -eq 0) {
+    $envelope = Write-RunbookEnvelope -Status 'success' -RunId $runId -RequestId $requestId `
+        -Diagnostics @() -Outcome @{
+            stoppedPids   = @()
+            remainingPids = @()
+            noopReason    = 'no-matching-editor'
+        }
+    $envelope
+    Write-RunbookStderrSummary "OK: no Godot processes matched ProjectRoot '$resolvedRoot'."
+    exit 0
+}
+
+$stopped = @()
+foreach ($processId in @($pidsToStop)) {
+    try {
+        Stop-Process -Id $processId -Force -ErrorAction Stop
+        $stopped += $processId
+    }
+    catch { }
+}
+Start-Sleep -Milliseconds 500
+
+# Re-check: anything still running for this project?
+$remaining = Get-EditorProcessesForProject -ProjectRoot $resolvedRoot
+
+if (@($remaining).Count -gt 0) {
+    Exit-Failure 'internal' "Stopped $(@($stopped).Count) of $pidCount editor process(es); $(@($remaining).Count) still running: $(@($remaining) -join ', ')." @{
+        stoppedPids   = @($stopped)
+        remainingPids = @($remaining)
+    }
+}
+
+$envelope = Write-RunbookEnvelope -Status 'success' -RunId $runId -RequestId $requestId `
+    -Diagnostics @() -Outcome @{
+        stoppedPids   = @($stopped)
+        remainingPids = @()
+    }
+$envelope
+Write-RunbookStderrSummary "OK: stopped $(@($stopped).Count) editor process(es)."
+exit 0

--- a/tools/automation/invoke-unpin-run.ps1
+++ b/tools/automation/invoke-unpin-run.ps1
@@ -69,7 +69,11 @@ function Exit-Failure {
         -DryRun $DryRun.IsPresent -Diagnostics @($Message) -PlannedPaths @() -PinName $PinName
     $label = $status.ToUpperInvariant()
     Write-RunbookStderrSummary "${label}: $Kind; $Message"
-    exit 1
+    # Exit 0 for `refused` -- the script ran successfully and correctly declined a
+    # precondition (e.g. pin-target-not-found). Exit 1 only for unexpected failures
+    # the caller should investigate. Envelope `status` field is the authoritative
+    # signal in either case.
+    if ($status -eq 'refused') { exit 0 } else { exit 1 }
 }
 
 $removeResult = Remove-PinnedRun -ProjectRoot $resolvedRoot -PinName $PinName -DryRun:$DryRun

--- a/tools/tests/InvokeLaunchEditor.Tests.ps1
+++ b/tools/tests/InvokeLaunchEditor.Tests.ps1
@@ -1,0 +1,147 @@
+BeforeAll {
+    . (Join-Path $PSScriptRoot 'TestHelpers.ps1')
+
+    $script:RepoRootPath = (Resolve-Path (Join-Path (Join-Path $PSScriptRoot '..') '..')).Path
+    $script:LaunchScript = Join-Path $script:RepoRootPath 'tools/automation/invoke-launch-editor.ps1'
+    $script:StopScript   = Join-Path $script:RepoRootPath 'tools/automation/invoke-stop-editor.ps1'
+    $script:StdoutSchema = 'specs/008-agent-runbook/contracts/orchestration-stdout.schema.json'
+}
+
+Describe 'invoke-launch-editor.ps1' {
+
+    It 'fails with failureKind=internal when ProjectRoot does not exist' {
+        $bogus = Join-Path $TestDrive 'does-not-exist'
+        $result = Invoke-RepoPowerShell -ScriptPath 'tools/automation/invoke-launch-editor.ps1' `
+            -Arguments @('-ProjectRoot', $bogus)
+        $result.ExitCode | Should -Be 1
+        $envelope = $result.Output | ConvertFrom-Json
+        $envelope.status      | Should -Be 'failure'
+        $envelope.failureKind | Should -Be 'internal'
+        $envelope.diagnostics[0] | Should -Match 'does not exist'
+    }
+
+    It 'fails with failureKind=internal when ProjectRoot has no project.godot' {
+        $emptyDir = Join-Path $TestDrive ('empty-' + [guid]::NewGuid().Guid)
+        New-Item -ItemType Directory -Path $emptyDir -Force | Out-Null
+        $result = Invoke-RepoPowerShell -ScriptPath 'tools/automation/invoke-launch-editor.ps1' `
+            -Arguments @('-ProjectRoot', $emptyDir)
+        $result.ExitCode | Should -Be 1
+        $envelope = $result.Output | ConvertFrom-Json
+        $envelope.status      | Should -Be 'failure'
+        $envelope.failureKind | Should -Be 'internal'
+        $envelope.diagnostics[0] | Should -Match 'project\.godot'
+    }
+
+    It 'failure envelope validates against the orchestration-stdout schema' {
+        $bogus = Join-Path $TestDrive 'does-not-exist'
+        $result = Invoke-RepoPowerShell -ScriptPath 'tools/automation/invoke-launch-editor.ps1' `
+            -Arguments @('-ProjectRoot', $bogus)
+        $tmpPath = Join-Path $TestDrive 'launch-editor-failure-envelope.json'
+        $result.Output | Set-Content -LiteralPath $tmpPath -Encoding utf8
+        $validation = Invoke-RepoJsonScript -ScriptPath 'tools/validate-json.ps1' -Arguments @(
+            '-InputPath', $tmpPath,
+            '-SchemaPath', $script:StdoutSchema
+        )
+        $validation.ParsedOutput.valid | Should -BeTrue
+    }
+
+    Context 'live launch (opt-in via $env:HARNESS_LIVE_TESTS=1)' {
+        # These tests spawn a real Godot editor and are slow (~30-60s cold start).
+        # They are intentionally OFF by default -- run them with:
+        #   $env:HARNESS_LIVE_TESTS = '1'; $env:GODOT_BIN = '<godot.exe>'
+        #   pwsh ./tools/tests/run-tool-tests.ps1
+        # The plain `pwsh ./tools/tests/run-tool-tests.ps1` invocation skips them.
+
+        BeforeAll {
+            $script:LiveTestsEnabled = ($env:HARNESS_LIVE_TESTS -eq '1') `
+                -and (-not [string]::IsNullOrWhiteSpace($env:GODOT_BIN)) `
+                -and (Test-Path -LiteralPath $env:GODOT_BIN)
+            $script:LiveSandbox = if ($script:LiveTestsEnabled) {
+                $name = 'launch-test-' + [guid]::NewGuid().Guid.Substring(0, 6)
+                pwsh -NoProfile -File (Join-Path $script:RepoRootPath 'tools/scaffold-sandbox.ps1') `
+                    -Name $name -Force -PassThru | Out-Null
+                Join-Path (Join-Path $script:RepoRootPath 'integration-testing') $name
+            } else { $null }
+        }
+
+        AfterAll {
+            if ($script:LiveSandbox -and (Test-Path -LiteralPath $script:LiveSandbox)) {
+                pwsh -NoProfile -File (Join-Path $script:RepoRootPath 'tools/automation/invoke-stop-editor.ps1') `
+                    -ProjectRoot $script:LiveSandbox -ErrorAction SilentlyContinue | Out-Null
+                Start-Sleep -Milliseconds 500
+                Remove-Item -LiteralPath $script:LiveSandbox -Recurse -Force -ErrorAction SilentlyContinue
+            }
+        }
+
+        It 'launches an editor and reports a fresh capability.json (live)' {
+            if (-not $script:LiveTestsEnabled) {
+                Set-ItResult -Skipped -Because '$env:HARNESS_LIVE_TESTS not set to 1; live editor test skipped'
+                return
+            }
+
+            $result = Invoke-RepoPowerShell -ScriptPath 'tools/automation/invoke-launch-editor.ps1' `
+                -Arguments @('-ProjectRoot', $script:LiveSandbox, '-ReadyTimeoutSeconds', '120')
+            $result.ExitCode | Should -Be 0
+            $envelope = $result.Output | ConvertFrom-Json
+            $envelope.status                       | Should -Be 'success'
+            $envelope.outcome.editorPid            | Should -BeGreaterThan 0
+            $envelope.outcome.capabilityAgeSeconds | Should -BeGreaterOrEqual 0
+            Test-Path -LiteralPath $envelope.outcome.capabilityPath | Should -BeTrue
+        }
+
+        It 'is idempotent — second call reuses the live editor (live)' {
+            if (-not $script:LiveTestsEnabled) {
+                Set-ItResult -Skipped -Because '$env:HARNESS_LIVE_TESTS not set to 1; live editor test skipped'
+                return
+            }
+
+            $result = Invoke-RepoPowerShell -ScriptPath 'tools/automation/invoke-launch-editor.ps1' `
+                -Arguments @('-ProjectRoot', $script:LiveSandbox)
+            $result.ExitCode | Should -Be 0
+            $envelope = $result.Output | ConvertFrom-Json
+            $envelope.status                       | Should -Be 'success'
+            $envelope.outcome.reusedExistingEditor | Should -BeTrue
+        }
+
+        It 'invoke-stop-editor.ps1 reports the stopped PIDs (live)' {
+            if (-not $script:LiveTestsEnabled) {
+                Set-ItResult -Skipped -Because '$env:HARNESS_LIVE_TESTS not set to 1; live editor test skipped'
+                return
+            }
+
+            $result = Invoke-RepoPowerShell -ScriptPath 'tools/automation/invoke-stop-editor.ps1' `
+                -Arguments @('-ProjectRoot', $script:LiveSandbox)
+            $result.ExitCode | Should -Be 0
+            $envelope = $result.Output | ConvertFrom-Json
+            $envelope.status                | Should -Be 'success'
+            @($envelope.outcome.remainingPids).Count | Should -Be 0
+        }
+    }
+}
+
+Describe 'invoke-stop-editor.ps1' {
+
+    It 'fails with failureKind=internal when ProjectRoot does not exist' {
+        $bogus = Join-Path $TestDrive 'does-not-exist'
+        $result = Invoke-RepoPowerShell -ScriptPath 'tools/automation/invoke-stop-editor.ps1' `
+            -Arguments @('-ProjectRoot', $bogus)
+        $result.ExitCode | Should -Be 1
+        $envelope = $result.Output | ConvertFrom-Json
+        $envelope.status      | Should -Be 'failure'
+        $envelope.failureKind | Should -Be 'internal'
+    }
+
+    It 'returns success with noopReason when no editor matches' {
+        $emptyProject = Join-Path $TestDrive ('empty-' + [guid]::NewGuid().Guid)
+        New-Item -ItemType Directory -Path $emptyProject -Force | Out-Null
+        # Doesn't need project.godot — stop helper just checks the dir exists
+        # before scanning processes.
+        $result = Invoke-RepoPowerShell -ScriptPath 'tools/automation/invoke-stop-editor.ps1' `
+            -Arguments @('-ProjectRoot', $emptyProject)
+        $result.ExitCode | Should -Be 0
+        $envelope = $result.Output | ConvertFrom-Json
+        $envelope.status                  | Should -Be 'success'
+        @($envelope.outcome.stoppedPids).Count | Should -Be 0
+        $envelope.outcome.noopReason       | Should -Be 'no-matching-editor'
+    }
+}


### PR DESCRIPTION
## Summary

Resolves the three issues in [prd/02-dry-ergonomics.md](prd/02-dry-ergonomics.md), all built on top of pass 1 ([#30](https://github.com/RJAudas/godot-agent-harness/pull/30)).

- **H2** — no editor-launch helper. Two new scripts ship (`invoke-launch-editor.ps1`, `invoke-stop-editor.ps1`) plus a `-EnsureEditor` opt-in switch on every runtime invoker. Agents no longer rediscover the spawn / poll / kill dance every session.
- **H3** — scene-inspection duplicated payload-write logic. Refactored to call `Resolve-RunbookPayload -InlineJson` like the four fixture-based invokers; ~50 lines deleted, output envelope unchanged.
- **M3** — pin/unpin scripts always exited 1 on refusal. They now exit 0 when the lifecycle envelope's `status=refused` (precondition denial); exit 1 stays for `status=failed`. Envelope is still authoritative; exit code is a fast-path for shell pipelines.

## What's new

### Editor lifecycle helpers (H2)

`tools/automation/invoke-launch-editor.ps1`:
- Idempotent: when an editor for `-ProjectRoot` is already running and `capability.json` is fresh (within `-MaxCapabilityAgeSeconds`, default 300), returns success in <1s with `outcome.reusedExistingEditor=true`.
- Otherwise resolves the Godot binary (`$env:GODOT_BIN` → PATH → `Godot*` discovery, prefers `*_console.exe` for stdout reliability), spawns `--editor --path <root> --verbose` with stdout/stderr redirected to `<ProjectRoot>/.editor-logs/`, and polls `capability.json` until it appears (or `-ReadyTimeoutSeconds`, default 90).
- `-ForceRestart` stops any existing matching editor first.
- Outcome: `editorPid`, `capabilityPath`, `capabilityAgeSeconds`, `reusedExistingEditor`.

`tools/automation/invoke-stop-editor.ps1`:
- Matches Godot processes by command-line `--path <ProjectRoot>` so it leaves unrelated editor instances alone (three Godot processes typically spawn from one `--editor` invocation).
- Outcome: `stoppedPids[]`, `remainingPids[]`, optional `noopReason="no-matching-editor"`.

`-EnsureEditor` switch on every runtime invoker:
- `invoke-scene-inspection.ps1`, `invoke-input-dispatch.ps1`, `invoke-behavior-watch.ps1`, `invoke-build-error-triage.ps1`, `invoke-runtime-error-triage.ps1`.
- Opt-in; default behavior unchanged. When set, delegates to `invoke-launch-editor.ps1` before running the workflow. Auto-launch failure surfaces as the workflow's own `editor-not-running` envelope.
- Captures launcher stdout only (the helper writes a single-line stderr summary that would corrupt the JSON envelope if `2>&1`-merged — fix in last commit caught during live verification).

### Scene-inspection refactor (H3)

`invoke-scene-inspection.ps1` now synthesizes its minimal startup-capture payload as inline JSON and calls `Resolve-RunbookPayload -InlineJson` like every other invoker. The helper handles validate-then-rename (pass 1 C1), forces `artifactRoot=''` (pass 1 C2), and writes to the canonical broker path. Net diff: ~50 lines deleted; envelope unchanged. The `targetScene` UID resolution stays in this script (scene-inspection-specific).

### Pin/unpin exit codes (M3)

`invoke-pin-run.ps1` and `invoke-unpin-run.ps1` exit 0 when the resolved lifecycle envelope `status="refused"` (e.g. `pin-name-collision`, `pin-source-missing`, `pin-target-not-found`, `pin-name-invalid`, `run-in-progress`); exit 1 only when `status="failed"`. RUNBOOK.md has a new "Exit-code convention" section documenting the split.

### Documentation refresh

- `RUNBOOK.md`: new "Editor lifecycle helpers" section with two-step and one-step example flows; Prerequisites updated to recommend `-EnsureEditor` over manual `godot --editor` invocation.
- `addons/agent_runtime_harness/templates/project_root/CLAUDE.runtime-harness.md` (the deploy template that becomes `CLAUDE.md` in every scaffolded sandbox): three example invocations now include `-EnsureEditor`; cleanup line for `invoke-stop-editor.ps1` added.
- Five Claude skills (`godot-inspect`, `godot-press`, `godot-watch`, `godot-debug-build`, `godot-debug-runtime`): Execution sections recommend `-EnsureEditor`; `editor-not-running` failure-table rows rephrased from "tell user to launch godot manually" to "auto-launch failed; read diagnostics[0]".

## Test plan

- [x] `pwsh ./tools/tests/run-tool-tests.ps1` — 243 passed, 0 failed (8 skipped: 5 unrelated pre-existing + 3 new live-launch tests gated behind `$env:HARNESS_LIVE_TESTS=1`).
- [x] New `tools/tests/InvokeLaunchEditor.Tests.ps1` — 5 fast assertions for param validation, schema-validity of failure envelopes, and no-op stop. Live tests cover cold launch, idempotent reuse, and live stop, gated behind `$env:HARNESS_LIVE_TESTS=1` + `$env:GODOT_BIN`.
- [x] Live integration against `integration-testing/probe`:
  - `invoke-launch-editor.ps1` — cold launch in 5s (warm shader cache); idempotent reuse in <1s with `outcome.reusedExistingEditor=true`.
  - `invoke-scene-inspection.ps1` (no `-EnsureEditor`) — `status=success`, 2 nodes captured, manifest path resolves to real on-disk file. Confirms pass-1 H3 refactor preserves behavior.
  - `invoke-input-dispatch.ps1 -EnsureEditor` — `status=success`, 2 events dispatched, idempotent helper reuse.
  - `invoke-stop-editor.ps1` — stopped 1 editor process, `Get-Process Godot*` confirms zero remaining.
- [x] M3 exit-code check: `invoke-pin-run.ps1` against an empty sandbox returned `status=refused, failureKind=pin-source-missing` with `$LASTEXITCODE=0`. Same for `pin-name-invalid`.

## Out of scope (queued)

- **Pass 3** ([prd/03-hardening-tests.md](prd/03-hardening-tests.md)) — clean `requests/` between runs, broker-mocked Pester coverage, silent-wipe diagnostics, decouple from hardcoded `pwsh`.
- **Pass 4** ([prd/04-polish.md](prd/04-polish.md)) — fixture polish (requestId-suffixed `outputDirectory`), `Get-Help` example refresh.
- Cross-platform niceties on `invoke-stop-editor.ps1` (Linux/macOS uses name-only matching; Windows uses CIM command-line filtering).

🤖 Generated with [Claude Code](https://claude.com/claude-code)