### PR TITLE
fix: Pass 4 polish — first-impression cleanup (L1, L2, L3, M6)

### DIFF
--- a/tools/automation/RunbookOrchestration.psm1
+++ b/tools/automation/RunbookOrchestration.psm1
@@ -270,6 +270,15 @@ function Resolve-RunbookPayload {
     $payload = $json | ConvertFrom-Json -Depth 20 -AsHashtable
     $payload['requestId'] = $RequestId
 
+    # Substitute $REQUEST_ID placeholders in outputDirectory so fixtures can declare
+    # collision-free per-run output directories without each invoke script rewriting the
+    # payload. Runs before schema validation so the substituted value is what gets
+    # validated and written to run-request.json. artifactRoot is intentionally excluded:
+    # the C2 block below force-empties it regardless of fixture content.
+    if ($payload.ContainsKey('outputDirectory') -and $payload['outputDirectory'] -is [string]) {
+        $payload['outputDirectory'] = $payload['outputDirectory'].Replace('$REQUEST_ID', $RequestId)
+    }
+
     # C2: artifactRoot is a legacy duplicate of outputDirectory. Every shipped
     # fixture sets it to a path under tools/tests/fixtures/runbook/<workflow>/...
     # and the runtime persisted that string into evidence-manifest.json's

--- a/tools/automation/invoke-behavior-watch.ps1
+++ b/tools/automation/invoke-behavior-watch.ps1
@@ -33,16 +33,20 @@
     Polling interval for run-result.json. Default: 250.
 
 .EXAMPLE
+    # First, scaffold a sandbox to sample (idempotent; -Force re-creates):
+    pwsh ./tools/scaffold-sandbox.ps1 -Name probe
+
+    # Then sample:
     pwsh ./tools/automation/invoke-behavior-watch.ps1 `
-        -ProjectRoot integration-testing/pong `
-        -RequestFixturePath tools/tests/fixtures/runbook/behavior-watch/single-property-window.json
+        -ProjectRoot ./integration-testing/probe `
+        -RequestFixturePath ./tools/tests/fixtures/runbook/behavior-watch/single-property-window.json
 
     Samples the paddle's position over 10 frames and emits a JSON envelope with
     outcome.samplesPath, outcome.sampleCount, and outcome.frameRangeCovered.
 
 .EXAMPLE
     pwsh ./tools/automation/invoke-behavior-watch.ps1 `
-        -ProjectRoot integration-testing/pong `
+        -ProjectRoot ./integration-testing/probe `
         -RequestJson '{"requestId":"x","scenarioId":"s","runId":"r","targetScene":"res://scenes/main.tscn","outputDirectory":"res://evidence/r","artifactRoot":"tools/tests/fixtures","capturePolicy":{"startup":true},"stopPolicy":{"stopAfterValidation":true},"requestedBy":"agent","createdAt":"2026-01-01T00:00:00Z","behaviorWatchRequest":{"targets":[{"nodePath":"/root/Main/Paddle","properties":["position"]}],"frameCount":10}}'
 
     Same as above, using an inline JSON payload.

--- a/tools/automation/invoke-build-error-triage.ps1
+++ b/tools/automation/invoke-build-error-triage.ps1
@@ -40,17 +40,21 @@
     Polling interval for run-result.json. Default: 250.
 
 .EXAMPLE
+    # First, scaffold a sandbox to triage (idempotent; -Force re-creates):
+    pwsh ./tools/scaffold-sandbox.ps1 -Name probe
+
+    # Then triage:
     pwsh ./tools/automation/invoke-build-error-triage.ps1 `
-        -ProjectRoot integration-testing/pong `
-        -RequestFixturePath tools/tests/fixtures/runbook/build-error-triage/build-then-capture.json
+        -ProjectRoot ./integration-testing/probe `
+        -RequestFixturePath ./tools/tests/fixtures/runbook/build-error-triage/build-then-capture.json
 
     Runs the project and emits a JSON envelope. On build failure:
     outcome.firstDiagnostic contains the first error's file, line, and message.
 
 .EXAMPLE
     pwsh ./tools/automation/invoke-build-error-triage.ps1 `
-        -ProjectRoot integration-testing/pong `
-        -RequestFixturePath tools/tests/fixtures/runbook/build-error-triage/build-then-capture.json `
+        -ProjectRoot ./integration-testing/probe `
+        -RequestFixturePath ./tools/tests/fixtures/runbook/build-error-triage/build-then-capture.json `
         -IncludeRawBuildOutput
 
     Same as above, also setting outcome.rawBuildOutputPath.

--- a/tools/automation/invoke-input-dispatch.ps1
+++ b/tools/automation/invoke-input-dispatch.ps1
@@ -38,16 +38,20 @@
     Default: 250.
 
 .EXAMPLE
+    # First, scaffold a sandbox to dispatch into (idempotent; -Force re-creates):
+    pwsh ./tools/scaffold-sandbox.ps1 -Name probe
+
+    # Then dispatch:
     pwsh ./tools/automation/invoke-input-dispatch.ps1 `
-        -ProjectRoot integration-testing/pong `
-        -RequestFixturePath tools/tests/fixtures/runbook/input-dispatch/press-enter.json
+        -ProjectRoot ./integration-testing/probe `
+        -RequestFixturePath ./tools/tests/fixtures/runbook/input-dispatch/press-enter.json
 
     Dispatches the Enter key once and emits a JSON envelope with
     outcome.dispatchedEventCount and outcome.outcomesPath.
 
 .EXAMPLE
     pwsh ./tools/automation/invoke-input-dispatch.ps1 `
-        -ProjectRoot integration-testing/pong `
+        -ProjectRoot ./integration-testing/probe `
         -RequestJson '{"requestId":"x","scenarioId":"s","runId":"r","targetScene":"res://scenes/main.tscn","outputDirectory":"res://evidence/r","artifactRoot":"tools/tests/fixtures","capturePolicy":{"startup":true},"stopPolicy":{"stopAfterValidation":true},"requestedBy":"agent","createdAt":"2026-01-01T00:00:00Z","inputDispatchScript":{"events":[{"kind":"key","identifier":"ENTER","phase":"press","frame":30},{"kind":"key","identifier":"ENTER","phase":"release","frame":32}]}}'
 
     Same as above, using an inline JSON payload instead of a fixture file.

--- a/tools/automation/invoke-list-pinned-runs.ps1
+++ b/tools/automation/invoke-list-pinned-runs.ps1
@@ -21,7 +21,7 @@
 
 .EXAMPLE
     pwsh ./tools/automation/invoke-list-pinned-runs.ps1 `
-        -ProjectRoot integration-testing/pong
+        -ProjectRoot ./integration-testing/probe
 
     Emits a lifecycle envelope with pinnedRunIndex[] listing every named pin.
 #>

--- a/tools/automation/invoke-pin-run.ps1
+++ b/tools/automation/invoke-pin-run.ps1
@@ -33,14 +33,14 @@
 
 .EXAMPLE
     pwsh ./tools/automation/invoke-pin-run.ps1 `
-        -ProjectRoot integration-testing/pong `
+        -ProjectRoot ./integration-testing/probe `
         -PinName bug-repro-jumpscare
 
     Pins the most recent run. Emits a lifecycle envelope with plannedPaths[].
 
 .EXAMPLE
     pwsh ./tools/automation/invoke-pin-run.ps1 `
-        -ProjectRoot integration-testing/pong `
+        -ProjectRoot ./integration-testing/probe `
         -PinName bug-repro-jumpscare `
         -DryRun
 

--- a/tools/automation/invoke-runtime-error-triage.ps1
+++ b/tools/automation/invoke-runtime-error-triage.ps1
@@ -39,9 +39,13 @@
     Polling interval for run-result.json. Default: 250.
 
 .EXAMPLE
+    # First, scaffold a sandbox to run (idempotent; -Force re-creates):
+    pwsh ./tools/scaffold-sandbox.ps1 -Name probe
+
+    # Then triage:
     pwsh ./tools/automation/invoke-runtime-error-triage.ps1 `
-        -ProjectRoot integration-testing/pong `
-        -RequestFixturePath tools/tests/fixtures/runbook/runtime-error-triage/run-and-watch-for-errors.json
+        -ProjectRoot ./integration-testing/probe `
+        -RequestFixturePath ./tools/tests/fixtures/runbook/runtime-error-triage/run-and-watch-for-errors.json
 
     Runs the project with pauseOnError enabled and emits a JSON envelope.
     On runtime error: outcome.latestErrorSummary contains the offending file, line,
@@ -49,8 +53,8 @@
 
 .EXAMPLE
     pwsh ./tools/automation/invoke-runtime-error-triage.ps1 `
-        -ProjectRoot integration-testing/pong `
-        -RequestFixturePath tools/tests/fixtures/runbook/runtime-error-triage/run-and-watch-for-errors.json `
+        -ProjectRoot ./integration-testing/probe `
+        -RequestFixturePath ./tools/tests/fixtures/runbook/runtime-error-triage/run-and-watch-for-errors.json `
         -IncludeFullStack
 
     Same as above, with full stack trace in outcome.latestErrorSummary.message.

--- a/tools/automation/invoke-scene-inspection.ps1
+++ b/tools/automation/invoke-scene-inspection.ps1
@@ -45,15 +45,8 @@
         -ProjectRoot ./integration-testing/probe
 
     Captures the startup scene tree and emits a JSON envelope with
-    outcome.sceneTreePath and outcome.nodeCount.
-
-.EXAMPLE
-    pwsh ./tools/automation/invoke-scene-inspection.ps1 `
-        -ProjectRoot ./integration-testing/probe `
-        -TargetScene res://main.tscn
-
-    Same as above, but for a project whose main scene lives at the repo root
-    (i.e., a non-default scene path passed via -TargetScene).
+    outcome.sceneTreePath and outcome.nodeCount. To inspect a scene other
+    than the project's main_scene, see -TargetScene above.
 #>
 [CmdletBinding()]
 param(

--- a/tools/automation/invoke-scene-inspection.ps1
+++ b/tools/automation/invoke-scene-inspection.ps1
@@ -37,18 +37,23 @@
     Default: 250.
 
 .EXAMPLE
+    # First, scaffold a sandbox to inspect (idempotent; -Force re-creates):
+    pwsh ./tools/scaffold-sandbox.ps1 -Name probe
+
+    # Then capture:
     pwsh ./tools/automation/invoke-scene-inspection.ps1 `
-        -ProjectRoot integration-testing/pong
+        -ProjectRoot ./integration-testing/probe
 
     Captures the startup scene tree and emits a JSON envelope with
     outcome.sceneTreePath and outcome.nodeCount.
 
 .EXAMPLE
     pwsh ./tools/automation/invoke-scene-inspection.ps1 `
-        -ProjectRoot D:/gameDev/pong `
+        -ProjectRoot ./integration-testing/probe `
         -TargetScene res://main.tscn
 
-    Same as above, but for a project whose main scene is at the repo root.
+    Same as above, but for a project whose main scene lives at the repo root
+    (i.e., a non-default scene path passed via -TargetScene).
 #>
 [CmdletBinding()]
 param(

--- a/tools/automation/invoke-unpin-run.ps1
+++ b/tools/automation/invoke-unpin-run.ps1
@@ -28,14 +28,14 @@
 
 .EXAMPLE
     pwsh ./tools/automation/invoke-unpin-run.ps1 `
-        -ProjectRoot integration-testing/pong `
+        -ProjectRoot ./integration-testing/probe `
         -PinName bug-repro-jumpscare
 
     Removes the named pin and emits a lifecycle envelope.
 
 .EXAMPLE
     pwsh ./tools/automation/invoke-unpin-run.ps1 `
-        -ProjectRoot integration-testing/pong `
+        -ProjectRoot ./integration-testing/probe `
         -PinName bug-repro-jumpscare `
         -DryRun
 

--- a/tools/check-addon-parse.ps1
+++ b/tools/check-addon-parse.ps1
@@ -69,6 +69,12 @@ if (-not (Test-Path -LiteralPath $projectAddonLink)) {
     if (-not (Test-Path -LiteralPath $projectAddons)) {
         New-Item -ItemType Directory -Path $projectAddons | Out-Null
     }
+    # Windows uses a directory junction (`mklink /J`) instead of `New-Item -SymbolicLink`.
+    # Junctions don't require Developer Mode or admin elevation; symlinks do, so a casual
+    # "simplification" to New-Item would break parse-checks on every contributor machine
+    # without those privileges enabled. Junctions are restricted to same-volume directories,
+    # which is fine here — addon source and project both live in this repo. POSIX uses real
+    # symlinks (no elevation issue).
     if ($IsWindows -or $env:OS -eq 'Windows_NT') {
         cmd /c mklink /J "`"$projectAddonLink`"" "`"$addonSource`"" | Out-Null
     } else {
@@ -136,7 +142,9 @@ finally {
     Remove-Item -LiteralPath $stdoutPath -ErrorAction SilentlyContinue
     Remove-Item -LiteralPath $stderrPath -ErrorAction SilentlyContinue
     if ($createdLink -and (Test-Path -LiteralPath $projectAddonLink)) {
-        # Junctions on Windows must be removed with rmdir, not Remove-Item -Recurse.
+        # Junctions on Windows must be removed with `rmdir`, which removes the link entry
+        # only. Remove-Item -Recurse -Force would follow the junction and delete the actual
+        # addon source under addons/agent_runtime_harness/ — never use that here.
         if ($IsWindows -or $env:OS -eq 'Windows_NT') {
             cmd /c rmdir "`"$projectAddonLink`"" | Out-Null
         } else {

--- a/tools/scaffold-sandbox.ps1
+++ b/tools/scaffold-sandbox.ps1
@@ -75,6 +75,12 @@ if (-not $DisplayName) {
     $DisplayName = $Name
 }
 
+# Minimal project.godot — only the [application] section. The harness-required
+# [autoload] and [editor_plugins] blocks are intentionally absent here; they reference
+# addon paths and class names that scaffold-sandbox does not own. The chained
+# tools/deploy-game-harness.ps1 call below appends both blocks. Consequence: this
+# script is not a standalone tool — the deploy step is required to produce a
+# functional harness project.
 $projectGodot = @"
 ; Engine configuration file.
 
@@ -112,6 +118,9 @@ if ($PSCmdlet.ShouldProcess($mainScenePath, 'Write scenes/main.tscn')) {
     Write-Utf8NoBomFile -Path $mainScenePath -Content ($mainScene + [Environment]::NewLine)
 }
 
+# Deploy step completes project.godot with the [autoload] and [editor_plugins] blocks
+# (and installs the addon, agent docs, etc.). Without this, the scaffolded project opens
+# in Godot but has no harness wiring.
 $deployScript = Join-Path $repoRoot 'tools/deploy-game-harness.ps1'
 $deployResult = & $deployScript -GameRoot $sandboxPath -TargetScene $TargetScene -PassThru
 

--- a/tools/tests/InvokeRunbookScripts.Tests.ps1
+++ b/tools/tests/InvokeRunbookScripts.Tests.ps1
@@ -174,6 +174,25 @@ Describe 'Resolve-RunbookPayload validate-then-rename (C1)' {
         $written = Get-Content -LiteralPath $script:C1Canonical -Raw | ConvertFrom-Json
         $written.artifactRoot | Should -Be ''
     }
+
+    It 'M6: substitutes $REQUEST_ID placeholder in outputDirectory with the resolved RequestId' {
+        # Fixtures declare outputDirectory as "res://evidence/automation/<workflow>-$REQUEST_ID"
+        # so each run lands in its own collision-free directory. Resolve-RunbookPayload must
+        # perform the substitution before schema validation and before writing run-request.json.
+        $requestId = 'runbook-input-dispatch-m6-test'
+        $result = Resolve-RunbookPayload `
+            -FixturePath 'tools/tests/fixtures/runbook/input-dispatch/press-enter.json' `
+            -RequestId $requestId `
+            -ProjectRoot $script:C1Root
+
+        $expected = "res://evidence/automation/runbook-input-dispatch-$requestId"
+        $result.Payload['outputDirectory'] | Should -Be $expected
+
+        # The persisted run-request.json must carry the substituted value (no literal token).
+        $written = Get-Content -LiteralPath $script:C1Canonical -Raw | ConvertFrom-Json
+        $written.outputDirectory | Should -Be $expected
+        $written.outputDirectory | Should -Not -Match '\$REQUEST_ID'
+    }
 }
 
 # ---------------------------------------------------------------------------
@@ -307,6 +326,33 @@ Describe 'RUNBOOK static checks' {
             $help = Get-Help $script.FullName -Full 2>$null
             $help.Synopsis | Should -Not -BeNullOrEmpty -Because "$($script.Name) must have .SYNOPSIS"
             $help.Description | Should -Not -BeNullOrEmpty -Because "$($script.Name) must have .DESCRIPTION"
+        }
+    }
+
+    It 'L2: every invoke-*.ps1 .EXAMPLE -ProjectRoot points at the canonical probe sandbox' {
+        # Fresh agents copy-paste these examples verbatim. integration-testing/ is git-ignored,
+        # so we cannot assert "path exists on disk" in CI; instead we pin every example to
+        # ./integration-testing/probe (the scaffold-sandbox.ps1 default). Anyone running
+        # `tools/scaffold-sandbox.ps1 -Name probe` will produce a directory that satisfies
+        # every example without further setup.
+        $scripts = Get-ChildItem -LiteralPath (Join-Path $script:RepoRootPath 'tools/automation') -Filter 'invoke-*.ps1' -File
+        $allowed = @('integration-testing/probe', './integration-testing/probe')
+        foreach ($script in $scripts) {
+            $help = Get-Help $script.FullName -Full 2>$null
+            $examples = @()
+            if ($help.Examples -and $help.Examples.Example) {
+                $examples = @($help.Examples.Example)
+            }
+            foreach ($example in $examples) {
+                $code = if ($example.Code) { $example.Code } else { '' }
+                $remarks = ($example.Remarks | ForEach-Object { $_.Text }) -join "`n"
+                $exampleText = "$code`n$remarks"
+                $rootMatches = [regex]::Matches($exampleText, '-ProjectRoot\s+([^\s`]+)')
+                foreach ($m in $rootMatches) {
+                    $captured = $m.Groups[1].Value.Trim()
+                    $captured | Should -BeIn $allowed -Because "$($script.Name) example references '$captured' for -ProjectRoot; expected canonical probe sandbox"
+                }
+            }
         }
     }
 

--- a/tools/tests/fixtures/runbook/behavior-watch/single-property-window.json
+++ b/tools/tests/fixtures/runbook/behavior-watch/single-property-window.json
@@ -3,7 +3,7 @@
   "scenarioId": "runbook-behavior-watch-scenario",
   "runId": "runbook-behavior-watch-run",
   "targetScene": "res://scenes/main.tscn",
-  "outputDirectory": "res://evidence/automation/runbook-behavior-watch",
+  "outputDirectory": "res://evidence/automation/runbook-behavior-watch-$REQUEST_ID",
   "artifactRoot": "tools/tests/fixtures/runbook/behavior-watch/evidence",
   "capturePolicy": {
     "startup": true,

--- a/tools/tests/fixtures/runbook/build-error-triage/build-then-capture.json
+++ b/tools/tests/fixtures/runbook/build-error-triage/build-then-capture.json
@@ -3,7 +3,7 @@
   "scenarioId": "runbook-build-error-triage-scenario",
   "runId": "runbook-build-error-triage-run",
   "targetScene": "res://scenes/main.tscn",
-  "outputDirectory": "res://evidence/automation/runbook-build-error-triage",
+  "outputDirectory": "res://evidence/automation/runbook-build-error-triage-$REQUEST_ID",
   "artifactRoot": "tools/tests/fixtures/runbook/build-error-triage/evidence",
   "capturePolicy": {
     "startup": true,

--- a/tools/tests/fixtures/runbook/input-dispatch/press-action.json
+++ b/tools/tests/fixtures/runbook/input-dispatch/press-action.json
@@ -3,7 +3,7 @@
   "scenarioId": "runbook-input-dispatch-action-scenario",
   "runId": "runbook-input-dispatch-action-run",
   "targetScene": "res://scenes/main.tscn",
-  "outputDirectory": "res://evidence/automation/runbook-input-dispatch-action",
+  "outputDirectory": "res://evidence/automation/runbook-input-dispatch-action-$REQUEST_ID",
   "artifactRoot": "tools/tests/fixtures/runbook/input-dispatch/evidence",
   "capturePolicy": {
     "startup": true,

--- a/tools/tests/fixtures/runbook/input-dispatch/press-arrow-keys.json
+++ b/tools/tests/fixtures/runbook/input-dispatch/press-arrow-keys.json
@@ -3,7 +3,7 @@
   "scenarioId": "runbook-input-dispatch-arrow-keys-scenario",
   "runId": "runbook-input-dispatch-arrow-keys-run",
   "targetScene": "res://scenes/main.tscn",
-  "outputDirectory": "res://evidence/automation/runbook-input-dispatch-arrow",
+  "outputDirectory": "res://evidence/automation/runbook-input-dispatch-arrow-$REQUEST_ID",
   "artifactRoot": "tools/tests/fixtures/runbook/input-dispatch/evidence",
   "capturePolicy": {
     "startup": true,

--- a/tools/tests/fixtures/runbook/input-dispatch/press-enter.json
+++ b/tools/tests/fixtures/runbook/input-dispatch/press-enter.json
@@ -3,7 +3,7 @@
   "scenarioId": "runbook-input-dispatch-scenario",
   "runId": "runbook-input-dispatch-run",
   "targetScene": "res://scenes/main.tscn",
-  "outputDirectory": "res://evidence/automation/runbook-input-dispatch",
+  "outputDirectory": "res://evidence/automation/runbook-input-dispatch-$REQUEST_ID",
   "artifactRoot": "tools/tests/fixtures/runbook/input-dispatch/evidence",
   "capturePolicy": {
     "startup": true,

--- a/tools/tests/fixtures/runbook/inspect-scene-tree/startup-capture.json
+++ b/tools/tests/fixtures/runbook/inspect-scene-tree/startup-capture.json
@@ -4,7 +4,7 @@
   "scenarioId": "runbook-inspect-scene-tree-scenario",
   "runId": "runbook-inspect-scene-tree-run",
   "targetScene": "res://scenes/main.tscn",
-  "outputDirectory": "res://evidence/automation/runbook-inspect-scene-tree",
+  "outputDirectory": "res://evidence/automation/runbook-inspect-scene-tree-$REQUEST_ID",
   "artifactRoot": "tools/tests/fixtures/runbook/inspect-scene-tree/evidence",
   "capturePolicy": {
     "startup": true,

--- a/tools/tests/fixtures/runbook/runtime-error-triage/run-and-watch-for-errors.json
+++ b/tools/tests/fixtures/runbook/runtime-error-triage/run-and-watch-for-errors.json
@@ -3,7 +3,7 @@
   "scenarioId": "runbook-runtime-error-triage-scenario",
   "runId": "runbook-runtime-error-triage-run",
   "targetScene": "res://scenes/main.tscn",
-  "outputDirectory": "res://evidence/automation/runbook-runtime-error-triage",
+  "outputDirectory": "res://evidence/automation/runbook-runtime-error-triage-$REQUEST_ID",
   "artifactRoot": "tools/tests/fixtures/runbook/runtime-error-triage/evidence",
   "capturePolicy": {
     "startup": true,


### PR DESCRIPTION
## Summary

Closes the four low-impact polish items in `prd/04-polish.md` so the harness reads cleanly to a fresh agent.

- **L1** — `scaffold-sandbox.ps1`: comment explains why `[autoload]` / `[editor_plugins]` are deferred to the chained `deploy-game-harness.ps1` (avoids a future "consolidation" PR breaking the wiring).
- **L2** — Every `invoke-*.ps1` `.EXAMPLE` block now points at `./integration-testing/probe` (the canonical scaffold default) instead of the non-existent `integration-testing/pong`. Runtime invokers' first examples chain a `scaffold-sandbox.ps1 -Name probe` preamble so copy-paste works end-to-end. New Pester guard enforces this going forward.
- **L3** — `check-addon-parse.ps1`: documents *why* the Windows path uses `mklink /J` (no Developer Mode/admin needed) and *why* cleanup uses `rmdir` (`Remove-Item -Recurse` would follow the junction and wipe the addon source).
- **M6** — Introduces a `$REQUEST_ID` placeholder substituted by `Resolve-RunbookPayload` before schema validation. All seven runbook fixtures migrated to `res://evidence/automation/runbook-<workflow>-$REQUEST_ID`, making evidence directories collision-free per request even if a future `-SkipCleanup` flag bypasses transient-zone wiping.

No runtime / broker-protocol / schema changes. 19 files: 123 insertions, 30 deletions.

## Test plan

- [x] `pwsh ./tools/tests/run-tool-tests.ps1` → 253 passed, 0 failed, 8 pre-existing fixture-absence skips
- [x] `pwsh ./tools/check-addon-parse.ps1` → exit 0 (L3 is comment-only)
- [x] `Get-Help` smoke test → 0/10 invoke scripts still mention `pong`; every script has at least one example
- [x] New `It 'L2: ...'` Pester guard passes — pins every example `-ProjectRoot` to `(./)?integration-testing/probe`
- [x] New `It 'M6: ...'` Pester test passes — substitution lands in both in-memory payload and persisted `run-request.json`; literal `$REQUEST_ID` does not leak through
- [ ] Live integration smoke (post-merge or follow-up): `scaffold-sandbox.ps1 -Name probe -Force` → `invoke-input-dispatch.ps1 -ProjectRoot ./integration-testing/probe -RequestFixturePath ./tools/tests/fixtures/runbook/input-dispatch/press-enter.json` twice → confirm each `manifestPath` ends in a distinct requestId-suffixed directory

🤖 Generated with [Claude Code](https://claude.com/claude-code)