### PR TITLE
fix: Pass 6a outcome shape cleanup (B14, B15, B16)

### DIFF
--- a/.claude/skills/godot-press/SKILL.md
+++ b/.claude/skills/godot-press/SKILL.md
@@ -48,7 +48,6 @@ pwsh ./tools/automation/invoke-input-dispatch.ps1 `
 | `outcome.outcomesPath` | Absolute path to `input-dispatch-outcomes.jsonl` |
 | `outcome.declaredEventCount` | Number of events the script declared |
 | `outcome.actualDispatchedCount` | Number of events that **actually fired** (status=`dispatched`) |
-| `outcome.dispatchedEventCount` | Backwards-compat alias of `declaredEventCount`. Prefer `actualDispatchedCount`. |
 | `outcome.firstFailureSummary` | First non-`dispatched` event's reason, or `null` on clean success |
 
 Report `actualDispatchedCount` of `declaredEventCount`. Surface `firstFailureSummary` whenever it is non-null. When the two counts differ, the envelope returns `failureKind=runtime` — the run ended before the requested frames were reached. Tell the user the keys did **not** all fire; do not claim the input was delivered.

--- a/addons/agent_runtime_harness/templates/project_root/.claude/skills/godot-press/SKILL.md
+++ b/addons/agent_runtime_harness/templates/project_root/.claude/skills/godot-press/SKILL.md
@@ -48,8 +48,9 @@ pwsh {{HARNESS_REPO_ROOT}}/tools/automation/invoke-input-dispatch.ps1 `
 | `failureKind` | `null` on success; see failure table |
 | `manifestPath` | Absolute path to `evidence-manifest.json` on success |
 | `outcome.outcomesPath` | Absolute path to `input-dispatch-outcomes.jsonl` |
-| `outcome.dispatchedEventCount` | Number of events actually dispatched |
-| `outcome.firstFailureSummary` | First failed event's message, or `null` on clean success |
+| `outcome.declaredEventCount` | Number of events the script declared |
+| `outcome.actualDispatchedCount` | Number of events that **actually fired** (status=`dispatched`). When this is less than `declaredEventCount`, the run ended before the requested frames — do not claim the keys were delivered. |
+| `outcome.firstFailureSummary` | First non-`dispatched` event's reason, or `null` on clean success |
 
 ## Failure handling
 

--- a/prd/00-TestMatrix-Template.md
+++ b/prd/00-TestMatrix-Template.md
@@ -196,13 +196,13 @@ pwsh ./tools/automation/invoke-input-dispatch.ps1 `
 **Expected envelope**:
 ```json
 { "status": "success",
-  "outcome": { "dispatchedEventCount": >=1, "firstFailureSummary": null } }
+  "outcome": { "declaredEventCount": >=1, "actualDispatchedCount": >=1, "firstFailureSummary": null } }
 ```
 
 **Always inspect** the produced `input-dispatch-outcomes.jsonl` and confirm each event row has `status: "dispatched"` (not `skipped_frame_unreached`). Mismatch between envelope and JSONL = B2.
 
 **Bugs to watch for**:
-- B2: `dispatchedEventCount` reported even when all events were skipped.
+- B2: `actualDispatchedCount` matches `declaredEventCount` even when every JSONL row is `skipped_frame_unreached` (the envelope should classify the run as `failure`).
 - B1: doubled prefix in output directory.
 - `firstFailureSummary` non-null with `status: success`.
 

--- a/specs/008-agent-runbook/data-model.md
+++ b/specs/008-agent-runbook/data-model.md
@@ -94,7 +94,7 @@ See [`contracts/orchestration-stdout.schema.json`](contracts/orchestration-stdou
 
 | Workflow | `outcome` keys |
 |---|---|
-| Input dispatch | `outcomesPath` (path to `input-dispatch-outcomes.jsonl`), `dispatchedEventCount` (int), `firstFailureSummary` (string \| null) |
+| Input dispatch | `outcomesPath` (path to `input-dispatch-outcomes.jsonl`), `declaredEventCount` (int), `actualDispatchedCount` (int), `firstFailureSummary` (string \| null) |
 | Scene inspection | `sceneTreePath` (path to captured `scene-tree.json`), `nodeCount` (int) |
 | Behavior watch | `samplesPath` (path to behavior samples artifact), `sampleCount` (int), `frameRangeCovered` (`{first, last}` ints) |
 | Build-error triage | `rawBuildOutputPath` (string \| null), `firstDiagnostic` (`{file, line, message}` \| null) |

--- a/specs/008-agent-runbook/tasks.md
+++ b/specs/008-agent-runbook/tasks.md
@@ -72,7 +72,7 @@ independently completable, testable, and shippable.
 
 **Goal**: A coding agent can dispatch a key (or `InputMap` action) and read the resulting scene state with one orchestration script invocation, using a tracked fixture.
 
-**Independent Test**: From a clean shell, with an editor running against an integration-testing sandbox, run `pwsh ./tools/automation/invoke-input-dispatch.ps1 -ProjectRoot integration-testing/<name> -RequestFixturePath tools/tests/fixtures/runbook/input-dispatch/press-enter.json` and observe a single stdout JSON envelope with `status = "success"`, `outcome.dispatchedEventCount >= 1`, and a valid `manifestPath`. Without an editor, `pwsh ./tools/tests/run-tool-tests.ps1` exercises the same script end-to-end via mocked helpers.
+**Independent Test**: From a clean shell, with an editor running against an integration-testing sandbox, run `pwsh ./tools/automation/invoke-input-dispatch.ps1 -ProjectRoot integration-testing/<name> -RequestFixturePath tools/tests/fixtures/runbook/input-dispatch/press-enter.json` and observe a single stdout JSON envelope with `status = "success"`, `outcome.actualDispatchedCount >= 1`, and a valid `manifestPath`. Without an editor, `pwsh ./tools/tests/run-tool-tests.ps1` exercises the same script end-to-end via mocked helpers.
 
 ### Validation for User Story 1 ⚠️
 
@@ -89,7 +89,7 @@ independently completable, testable, and shippable.
 - [X] T014 [US1] Create orchestration script `tools/automation/invoke-input-dispatch.ps1` per the contract in `specs/008-agent-runbook/contracts/orchestration-cli.md`:
   - Imports `RunbookOrchestration.psm1`.
   - Implements the 12-step common behavior (capability gate → payload materialization → request → poll → manifest validation → outcome assembly → stdout envelope).
-  - Workflow-specific `outcome` block: `outcomesPath` (path to `input-dispatch-outcomes.jsonl` from the manifest's `artifactRefs`), `dispatchedEventCount` (count of lines in that file), `firstFailureSummary` (first non-`success` outcome's message, or `null`).
+  - Workflow-specific `outcome` block: `outcomesPath` (path to `input-dispatch-outcomes.jsonl` from the manifest's `artifactRefs`), `declaredEventCount` (count of lines in that file), `actualDispatchedCount` (count of rows whose `status == "dispatched"`), `firstFailureSummary` (first non-`dispatched` outcome's message, or `null`).
   - Comment-based help is COMPLETE: `.SYNOPSIS`, `.DESCRIPTION`, `.PARAMETER` for every parameter, at least one `.EXAMPLE` (FR-008).
   - Stderr summary: `OK: dispatched <N> events; manifest at <path>` on success, `FAIL: <failureKind>; <first diagnostic>` on failure.
 - [X] T015 [US1] Create recipe `docs/runbook/input-dispatch.md` with the 5 required H2 sections (Prerequisites, Run it, Expected output, Failure handling, Anti-patterns) and the optional `Inline payload` section. The Anti-patterns section MUST contain the canonical `<!-- runbook:do-not-read-addon-source -->` marker block.

--- a/tools/automation/RunbookOrchestration.psm1
+++ b/tools/automation/RunbookOrchestration.psm1
@@ -546,6 +546,48 @@ function ConvertTo-EnvelopeFailureKind {
     }
 }
 
+function Get-RunResultValidationDiagnostics {
+    <#
+    .SYNOPSIS
+        Extract human-readable diagnostic notes from a run-result's validationResult block (B16).
+
+    .DESCRIPTION
+        When run-result.json reports failureKind="validation", validationResult.notes
+        carries the authoritative explanation of what failed (for example
+        "Manifest runId did not match the active automation request"). Surface those
+        notes so agents reading the envelope's diagnostics[] get the real cause
+        instead of a downstream "manifest not found" sanity-check error fired by
+        Test-RunbookManifest against a path the runtime never actually wrote to.
+
+        Filters out the noisy "Persisted artifact references were written
+        successfully" boilerplate, which is informational and not a failure cause.
+
+    .PARAMETER RunResult
+        The parsed run-result object (PSCustomObject from ConvertFrom-Json).
+
+    .OUTPUTS
+        [string[]] possibly empty list of diagnostic strings ready to insert into
+        the envelope's diagnostics array.
+    #>
+    [CmdletBinding()]
+    [OutputType([string[]])]
+    param($RunResult)
+
+    # Leading-comma return idiom keeps an empty / single-element array from
+    # being unwrapped to $null / a bare scalar across the function boundary.
+    if ($null -eq $RunResult) { return ,@() }
+    if (-not ($RunResult.PSObject.Properties.Name -contains 'validationResult')) { return ,@() }
+    $vr = $RunResult.validationResult
+    if ($null -eq $vr) { return ,@() }
+    if (-not ($vr.PSObject.Properties.Name -contains 'notes')) { return ,@() }
+
+    $kept = @($vr.notes | Where-Object {
+        -not [string]::IsNullOrWhiteSpace($_) -and
+        $_ -notmatch '^Persisted artifact references were written'
+    })
+    return ,$kept
+}
+
 function Write-RunbookEnvelope {
     <#
     .SYNOPSIS
@@ -1524,6 +1566,7 @@ Export-ModuleMember -Function @(
     'Write-RunbookEnvelope',
     'Write-LifecycleEnvelope',
     'ConvertTo-EnvelopeFailureKind',
+    'Get-RunResultValidationDiagnostics',
     'ConvertTo-FirstBuildDiagnostic',
     'Get-ProjectMainScene',
     'Test-RunbookManifest',

--- a/tools/automation/invoke-behavior-watch.ps1
+++ b/tools/automation/invoke-behavior-watch.ps1
@@ -179,6 +179,20 @@ if (-not $runResult.Ok) {
 $rr    = $runResult.RunResult
 $runId = if (-not [string]::IsNullOrWhiteSpace($rr.runId)) { $rr.runId } else { $runId }
 
+# B16: surface validationResult.notes for failureKind=validation before the
+# generic failed-status branch or the downstream Test-RunbookManifest check.
+if ($rr.finalStatus -eq 'failed' -and ([string]$rr.failureKind) -eq 'validation') {
+    $vNotes = Get-RunResultValidationDiagnostics -RunResult $rr
+    if ($vNotes.Count -gt 0) {
+        $envelopeKind = ConvertTo-EnvelopeFailureKind -RunResultFailureKind 'validation' -FallbackKind 'internal'
+        $diags = @($_lifecycleDiags) + @($vNotes)
+        Write-RunbookEnvelope -Status 'failure' -FailureKind $envelopeKind `
+            -RunId $runId -RequestId $requestId -Diagnostics $diags -Outcome @{}
+        Write-RunbookStderrSummary "FAIL: $envelopeKind; $($vNotes -join ' | ')"
+        exit 1
+    }
+}
+
 if ($rr.finalStatus -eq 'failed' -and -not [string]::IsNullOrWhiteSpace($rr.failureKind)) {
     $fk = [string]$rr.failureKind
     $envelopeKind = ConvertTo-EnvelopeFailureKind -RunResultFailureKind $fk -FallbackKind 'internal'
@@ -266,7 +280,7 @@ $envelope = Write-RunbookEnvelope -Status 'success' -ManifestPath $absManifest `
         samplesPath       = $samplesPath
         sampleCount       = $sampleCount
         frameRangeCovered = $frameRangeCovered
-        warnings          = ,@($warnings)
+        warnings          = @($warnings)
     }
 $envelope
 $warnSuffix = if ($warnings.Count -gt 0) { "; warnings: $($warnings -join ' | ')" } else { '' }

--- a/tools/automation/invoke-behavior-watch.ps1
+++ b/tools/automation/invoke-behavior-watch.ps1
@@ -186,8 +186,14 @@ if ($rr.finalStatus -eq 'failed' -and ([string]$rr.failureKind) -eq 'validation'
     if ($vNotes.Count -gt 0) {
         $envelopeKind = ConvertTo-EnvelopeFailureKind -RunResultFailureKind 'validation' -FallbackKind 'internal'
         $diags = @($_lifecycleDiags) + @($vNotes)
+        # Match Exit-Failure's outcome shape so consumers see the same keys on every failure path.
         Write-RunbookEnvelope -Status 'failure' -FailureKind $envelopeKind `
-            -RunId $runId -RequestId $requestId -Diagnostics $diags -Outcome @{}
+            -RunId $runId -RequestId $requestId -Diagnostics $diags -Outcome @{
+                samplesPath       = $null
+                sampleCount       = 0
+                frameRangeCovered = $null
+                warnings          = @()
+            }
         Write-RunbookStderrSummary "FAIL: $envelopeKind; $($vNotes -join ' | ')"
         exit 1
     }

--- a/tools/automation/invoke-build-error-triage.ps1
+++ b/tools/automation/invoke-build-error-triage.ps1
@@ -189,6 +189,22 @@ if (-not $runResult.Ok) {
 $rr = $runResult.RunResult
 $runId = if (-not [string]::IsNullOrWhiteSpace($rr.runId)) { $rr.runId } else { $runId }
 
+# B16: surface validationResult.notes for failureKind=validation before the
+# downstream Test-RunbookManifest check, which otherwise reports a misleading
+# "manifest not found" when the runtime wrote the manifest under a different
+# runId than run-result references.
+if ($rr.finalStatus -eq 'failed' -and ([string]$rr.failureKind) -eq 'validation') {
+    $vNotes = Get-RunResultValidationDiagnostics -RunResult $rr
+    if ($vNotes.Count -gt 0) {
+        $envelopeKind = ConvertTo-EnvelopeFailureKind -RunResultFailureKind 'validation' -FallbackKind 'internal'
+        $diags = @($_lifecycleDiags) + @($vNotes)
+        Write-RunbookEnvelope -Status 'failure' -FailureKind $envelopeKind `
+            -RunId $runId -RequestId $requestId -Diagnostics $diags -Outcome @{}
+        Write-RunbookStderrSummary "FAIL: $envelopeKind; $($vNotes -join ' | ')"
+        exit 1
+    }
+}
+
 # Step 8: Read manifest
 $manifestPath = [string]$rr.manifestPath
 $absManifest  = $null

--- a/tools/automation/invoke-build-error-triage.ps1
+++ b/tools/automation/invoke-build-error-triage.ps1
@@ -198,8 +198,14 @@ if ($rr.finalStatus -eq 'failed' -and ([string]$rr.failureKind) -eq 'validation'
     if ($vNotes.Count -gt 0) {
         $envelopeKind = ConvertTo-EnvelopeFailureKind -RunResultFailureKind 'validation' -FallbackKind 'internal'
         $diags = @($_lifecycleDiags) + @($vNotes)
+        # Match Exit-Failure's outcome shape so consumers see the same keys on every failure path.
+        $rrPath = Join-Path $resolvedRoot 'harness/automation/results/run-result.json'
         Write-RunbookEnvelope -Status 'failure' -FailureKind $envelopeKind `
-            -RunId $runId -RequestId $requestId -Diagnostics $diags -Outcome @{}
+            -RunId $runId -RequestId $requestId -Diagnostics $diags -Outcome @{
+                rawBuildOutputPath = $null
+                firstDiagnostic    = $null
+                runResultPath      = $rrPath
+            }
         Write-RunbookStderrSummary "FAIL: $envelopeKind; $($vNotes -join ' | ')"
         exit 1
     }

--- a/tools/automation/invoke-input-dispatch.ps1
+++ b/tools/automation/invoke-input-dispatch.ps1
@@ -47,7 +47,8 @@
         -RequestFixturePath ./tools/tests/fixtures/runbook/input-dispatch/press-enter.json
 
     Dispatches the Enter key once and emits a JSON envelope with
-    outcome.dispatchedEventCount and outcome.outcomesPath.
+    outcome.declaredEventCount, outcome.actualDispatchedCount, and
+    outcome.outcomesPath.
 
 .EXAMPLE
     pwsh ./tools/automation/invoke-input-dispatch.ps1 `
@@ -99,7 +100,6 @@ function Exit-Failure {
             outcomesPath          = $null
             declaredEventCount    = 0
             actualDispatchedCount = 0
-            dispatchedEventCount  = 0
             firstFailureSummary   = $null
         }
     Write-RunbookStderrSummary "FAIL: $Kind; $Message"
@@ -189,6 +189,24 @@ if (-not $runResult.Ok) {
 $rr = $runResult.RunResult
 $runId = if (-not [string]::IsNullOrWhiteSpace($rr.runId)) { $rr.runId } else { $runId }
 
+# B16: when run-result already classified the failure as validation, surface
+# the validationResult.notes immediately. They carry the authoritative cause
+# (e.g. "Manifest runId did not match the active automation request"); without
+# this, the agent sees only the generic "Run failed with failureKind='validation'"
+# text below or a misleading "manifest not found" diagnostic from a downstream
+# Test-RunbookManifest call against a path the runtime never wrote to.
+if ($rr.finalStatus -eq 'failed' -and ([string]$rr.failureKind) -eq 'validation') {
+    $vNotes = Get-RunResultValidationDiagnostics -RunResult $rr
+    if ($vNotes.Count -gt 0) {
+        $envelopeKind = ConvertTo-EnvelopeFailureKind -RunResultFailureKind 'validation' -FallbackKind 'internal'
+        $diags = @($_lifecycleDiags) + @($vNotes)
+        Write-RunbookEnvelope -Status 'failure' -FailureKind $envelopeKind `
+            -RunId $runId -RequestId $requestId -Diagnostics $diags -Outcome @{}
+        Write-RunbookStderrSummary "FAIL: $envelopeKind; $($vNotes -join ' | ')"
+        exit 1
+    }
+}
+
 # Check for harness-reported failures
 if ($rr.finalStatus -eq 'failed' -and -not [string]::IsNullOrWhiteSpace($rr.failureKind)) {
     $fk = [string]$rr.failureKind
@@ -258,9 +276,6 @@ $outcome = @{
     outcomesPath          = $outcomesPath
     declaredEventCount    = $declaredEventCount
     actualDispatchedCount = $actualDispatchedCount
-    # Kept for backwards compatibility — equals declaredEventCount. Prefer the
-    # explicit declared/actual fields above.
-    dispatchedEventCount  = $declaredEventCount
     firstFailureSummary   = $firstFailureSummary
 }
 

--- a/tools/automation/invoke-input-dispatch.ps1
+++ b/tools/automation/invoke-input-dispatch.ps1
@@ -200,8 +200,16 @@ if ($rr.finalStatus -eq 'failed' -and ([string]$rr.failureKind) -eq 'validation'
     if ($vNotes.Count -gt 0) {
         $envelopeKind = ConvertTo-EnvelopeFailureKind -RunResultFailureKind 'validation' -FallbackKind 'internal'
         $diags = @($_lifecycleDiags) + @($vNotes)
+        # Match Exit-Failure's outcome shape so consumers see the same per-workflow keys
+        # on every failure path. Validation failures don't produce per-workflow data, so
+        # the values are null/0 just like Exit-Failure's literal.
         Write-RunbookEnvelope -Status 'failure' -FailureKind $envelopeKind `
-            -RunId $runId -RequestId $requestId -Diagnostics $diags -Outcome @{}
+            -RunId $runId -RequestId $requestId -Diagnostics $diags -Outcome @{
+                outcomesPath          = $null
+                declaredEventCount    = 0
+                actualDispatchedCount = 0
+                firstFailureSummary   = $null
+            }
         Write-RunbookStderrSummary "FAIL: $envelopeKind; $($vNotes -join ' | ')"
         exit 1
     }

--- a/tools/automation/invoke-runtime-error-triage.ps1
+++ b/tools/automation/invoke-runtime-error-triage.ps1
@@ -235,8 +235,13 @@ if ($rr.finalStatus -eq 'failed' -and ([string]$rr.failureKind) -eq 'validation'
     if ($vNotes.Count -gt 0) {
         $envelopeKind = ConvertTo-EnvelopeFailureKind -RunResultFailureKind 'validation' -FallbackKind 'internal'
         $diags = @($_lifecycleDiags) + @($vNotes)
+        # Match Exit-Failure's outcome shape so consumers see the same keys on every failure path.
         Write-RunbookEnvelope -Status 'failure' -FailureKind $envelopeKind `
-            -RunId $runId -RequestId $requestId -Diagnostics $diags -Outcome @{}
+            -RunId $runId -RequestId $requestId -Diagnostics $diags -Outcome @{
+                runtimeErrorRecordsPath = $null
+                latestErrorSummary      = $null
+                terminationReason       = 'unknown'
+            }
         Write-RunbookStderrSummary "FAIL: $envelopeKind; $($vNotes -join ' | ')"
         exit 1
     }

--- a/tools/automation/invoke-runtime-error-triage.ps1
+++ b/tools/automation/invoke-runtime-error-triage.ps1
@@ -225,6 +225,23 @@ if (-not $runResult.Ok) {
 $rr    = $runResult.RunResult
 $runId = if (-not [string]::IsNullOrWhiteSpace($rr.runId)) { $rr.runId } else { $runId }
 
+# B16: when run-result already classified the failure as validation, surface the
+# validationResult.notes immediately. Without this pre-empt, Test-RunbookManifest
+# below fires a misleading "manifest not found at <path>" when the runtime wrote
+# the manifest under a different runId (e.g. inspection-run-config override),
+# masking the real cause that validationResult.notes already explains.
+if ($rr.finalStatus -eq 'failed' -and ([string]$rr.failureKind) -eq 'validation') {
+    $vNotes = Get-RunResultValidationDiagnostics -RunResult $rr
+    if ($vNotes.Count -gt 0) {
+        $envelopeKind = ConvertTo-EnvelopeFailureKind -RunResultFailureKind 'validation' -FallbackKind 'internal'
+        $diags = @($_lifecycleDiags) + @($vNotes)
+        Write-RunbookEnvelope -Status 'failure' -FailureKind $envelopeKind `
+            -RunId $runId -RequestId $requestId -Diagnostics $diags -Outcome @{}
+        Write-RunbookStderrSummary "FAIL: $envelopeKind; $($vNotes -join ' | ')"
+        exit 1
+    }
+}
+
 # Step 8: Read manifest
 $manifestPath = [string]$rr.manifestPath
 $absManifest  = $null

--- a/tools/automation/invoke-scene-inspection.ps1
+++ b/tools/automation/invoke-scene-inspection.ps1
@@ -209,6 +209,20 @@ if (-not $runResult.Ok) {
 $rr = $runResult.RunResult
 $runId = if (-not [string]::IsNullOrWhiteSpace($rr.runId)) { $rr.runId } else { $runId }
 
+# B16: surface validationResult.notes for failureKind=validation before the
+# generic failed-status branch or the downstream Test-RunbookManifest check.
+if ($rr.finalStatus -eq 'failed' -and ([string]$rr.failureKind) -eq 'validation') {
+    $vNotes = Get-RunResultValidationDiagnostics -RunResult $rr
+    if ($vNotes.Count -gt 0) {
+        $envelopeKind = ConvertTo-EnvelopeFailureKind -RunResultFailureKind 'validation' -FallbackKind 'internal'
+        $diags = @($_lifecycleDiags) + @($vNotes)
+        Write-RunbookEnvelope -Status 'failure' -FailureKind $envelopeKind `
+            -RunId $runId -RequestId $requestId -Diagnostics $diags -Outcome @{}
+        Write-RunbookStderrSummary "FAIL: $envelopeKind; $($vNotes -join ' | ')"
+        exit 1
+    }
+}
+
 if ($rr.finalStatus -eq 'failed' -and -not [string]::IsNullOrWhiteSpace($rr.failureKind)) {
     $fk = [string]$rr.failureKind
     $envelopeKind = ConvertTo-EnvelopeFailureKind -RunResultFailureKind $fk -FallbackKind 'internal'

--- a/tools/automation/invoke-scene-inspection.ps1
+++ b/tools/automation/invoke-scene-inspection.ps1
@@ -216,8 +216,12 @@ if ($rr.finalStatus -eq 'failed' -and ([string]$rr.failureKind) -eq 'validation'
     if ($vNotes.Count -gt 0) {
         $envelopeKind = ConvertTo-EnvelopeFailureKind -RunResultFailureKind 'validation' -FallbackKind 'internal'
         $diags = @($_lifecycleDiags) + @($vNotes)
+        # Match Exit-Failure's outcome shape so consumers see the same keys on every failure path.
         Write-RunbookEnvelope -Status 'failure' -FailureKind $envelopeKind `
-            -RunId $runId -RequestId $requestId -Diagnostics $diags -Outcome @{}
+            -RunId $runId -RequestId $requestId -Diagnostics $diags -Outcome @{
+                sceneTreePath = $null
+                nodeCount     = 0
+            }
         Write-RunbookStderrSummary "FAIL: $envelopeKind; $($vNotes -join ' | ')"
         exit 1
     }

--- a/tools/tests/InvokeRunbookScripts.Tests.ps1
+++ b/tools/tests/InvokeRunbookScripts.Tests.ps1
@@ -875,3 +875,177 @@ Describe 'US2 SC-001: git status clean after canonical invocation (T024)' {
         }
     }
 }
+
+# ---------------------------------------------------------------------------
+# Pass 6a — Outcome shape cleanup (B14, B15, B16)
+# ---------------------------------------------------------------------------
+
+Describe 'B14: invoke-input-dispatch.ps1 drops legacy dispatchedEventCount' {
+    # The legacy field equalled declaredEventCount (not actual dispatched), so
+    # readers were misled. The fix removes it outright; the two truthful fields
+    # actualDispatchedCount and declaredEventCount remain.
+    BeforeAll {
+        $script:DispatchScriptPath = Join-Path $script:RepoRootPath 'tools/automation/invoke-input-dispatch.ps1'
+        $script:DispatchScriptText = Get-Content -LiteralPath $script:DispatchScriptPath -Raw
+    }
+
+    It 'invoke-input-dispatch.ps1 source contains no dispatchedEventCount references' {
+        $script:DispatchScriptText | Should -Not -Match 'dispatchedEventCount'
+    }
+
+    It 'invoke-input-dispatch.ps1 emits both declaredEventCount and actualDispatchedCount' {
+        $script:DispatchScriptText | Should -Match 'declaredEventCount'
+        $script:DispatchScriptText | Should -Match 'actualDispatchedCount'
+    }
+
+    It 'envelope built from the new outcome shape omits dispatchedEventCount' {
+        $outcome = @{
+            outcomesPath          = 'C:\fake\outcomes.jsonl'
+            declaredEventCount    = 2
+            actualDispatchedCount = 0
+            firstFailureSummary   = 'skipped_frame_unreached'
+        }
+        $json = Write-RunbookEnvelope -Status 'failure' -FailureKind 'runtime' `
+            -ManifestPath 'C:\fake\manifest.json' -RunId 'run-001' -RequestId 'req-001' `
+            -Diagnostics @('synthetic') -Outcome $outcome
+        $parsed = $json | ConvertFrom-Json
+        $parsed.outcome.PSObject.Properties.Name | Should -Not -Contain 'dispatchedEventCount'
+        $parsed.outcome.declaredEventCount    | Should -Be 2
+        $parsed.outcome.actualDispatchedCount | Should -Be 0
+    }
+}
+
+Describe 'B15: invoke-behavior-watch.ps1 emits a flat warnings array' {
+    # The leading-comma idiom ,@($warnings) wraps an already-plural collection
+    # in another array layer, producing [[string]] in the JSON envelope and
+    # breaking strongly-typed consumers (TypeScript / Pydantic). The fix drops
+    # the leading comma so warnings is a flat [string] array.
+    BeforeAll {
+        $script:WatchScriptPath = Join-Path $script:RepoRootPath 'tools/automation/invoke-behavior-watch.ps1'
+        $script:WatchScriptText = Get-Content -LiteralPath $script:WatchScriptPath -Raw
+    }
+
+    It 'invoke-behavior-watch.ps1 does not use the leading-comma array wrapper around $warnings' {
+        # The exact bug: ,@($warnings). Use a relaxed pattern to also catch
+        # ", @($warnings)" or whitespace variants.
+        $script:WatchScriptText | Should -Not -Match ',\s*@\(\$warnings\)'
+    }
+
+    It 'envelope warnings stays flat when built from a multi-element List[string]' {
+        $list = [System.Collections.Generic.List[string]]::new()
+        $list.Add('target node not found or never sampled: /root/Main/Paddle')
+        $list.Add('zero samples captured; check that the watched node exists in the running scene at sample time')
+
+        $outcome = @{
+            samplesPath       = $null
+            sampleCount       = 0
+            frameRangeCovered = $null
+            warnings          = @($list)
+        }
+        $json = Write-RunbookEnvelope -Status 'success' `
+            -ManifestPath 'C:\fake\manifest.json' -RunId 'run-001' -RequestId 'req-001' `
+            -Diagnostics @() -Outcome $outcome
+
+        $parsed = $json | ConvertFrom-Json
+        @($parsed.outcome.warnings).Count | Should -Be 2
+        # Each element must be a string, not an array. ConvertFrom-Json preserves
+        # array nesting, so a nested [[string]] surfaces as Object[] for [0].
+        $parsed.outcome.warnings[0] | Should -BeOfType [string]
+        $parsed.outcome.warnings[1] | Should -BeOfType [string]
+    }
+}
+
+Describe 'B16: Get-RunResultValidationDiagnostics surfaces validationResult.notes' {
+    # When run-result reports failureKind=validation, validationResult.notes
+    # carries the authoritative explanation. The helper extracts those notes
+    # for the envelope diagnostics array, filtering the noisy "Persisted
+    # artifact references were written" boilerplate.
+
+    It 'returns empty array for $null input' {
+        Get-RunResultValidationDiagnostics -RunResult $null | Should -BeNullOrEmpty
+    }
+
+    It 'returns empty array when validationResult is missing' {
+        $rr = [pscustomobject]@{ failureKind = 'validation' }
+        Get-RunResultValidationDiagnostics -RunResult $rr | Should -BeNullOrEmpty
+    }
+
+    It 'returns empty array when validationResult.notes is missing' {
+        $rr = [pscustomobject]@{ validationResult = [pscustomobject]@{ manifestExists = $true } }
+        Get-RunResultValidationDiagnostics -RunResult $rr | Should -BeNullOrEmpty
+    }
+
+    It 'returns notes verbatim and filters out the Persisted-artifact boilerplate' {
+        $rr = [pscustomobject]@{
+            validationResult = [pscustomobject]@{
+                notes = @(
+                    'Manifest runId did not match the active automation request.',
+                    'Manifest scenarioId did not match the active automation request.',
+                    'Persisted artifact references were written successfully. Validate the manifest schema and paths.',
+                    'Persisted evidence bundle failed validation.'
+                )
+            }
+        }
+        $result = Get-RunResultValidationDiagnostics -RunResult $rr
+        @($result).Count | Should -Be 3
+        $result[0] | Should -Be 'Manifest runId did not match the active automation request.'
+        $result[1] | Should -Be 'Manifest scenarioId did not match the active automation request.'
+        $result[2] | Should -Be 'Persisted evidence bundle failed validation.'
+        # Boilerplate must be filtered:
+        @($result | Where-Object { $_ -match '^Persisted artifact references were written' }).Count | Should -Be 0
+    }
+
+    It 'skips null and whitespace-only entries' {
+        $rr = [pscustomobject]@{
+            validationResult = [pscustomobject]@{
+                notes = @($null, '', '  ', 'real diagnostic')
+            }
+        }
+        $result = Get-RunResultValidationDiagnostics -RunResult $rr
+        @($result).Count | Should -Be 1
+        $result[0] | Should -Be 'real diagnostic'
+    }
+}
+
+Describe 'B16: invoke-* scripts pre-empt Test-RunbookManifest on validation failures' {
+    # Every invoke-* script that hits Test-RunbookManifest should call
+    # Get-RunResultValidationDiagnostics first so the misleading "manifest not
+    # found" diagnostic never lands when the run actually failed validation.
+    BeforeAll {
+        $script:Pass6aScripts = @(
+            'tools/automation/invoke-input-dispatch.ps1',
+            'tools/automation/invoke-behavior-watch.ps1',
+            'tools/automation/invoke-scene-inspection.ps1',
+            'tools/automation/invoke-runtime-error-triage.ps1',
+            'tools/automation/invoke-build-error-triage.ps1'
+        )
+    }
+
+    It '<scriptPath> calls Get-RunResultValidationDiagnostics' -ForEach @(
+        @{ scriptPath = 'tools/automation/invoke-input-dispatch.ps1' }
+        @{ scriptPath = 'tools/automation/invoke-behavior-watch.ps1' }
+        @{ scriptPath = 'tools/automation/invoke-scene-inspection.ps1' }
+        @{ scriptPath = 'tools/automation/invoke-runtime-error-triage.ps1' }
+        @{ scriptPath = 'tools/automation/invoke-build-error-triage.ps1' }
+    ) {
+        $abs = Join-Path $script:RepoRootPath $scriptPath
+        $text = Get-Content -LiteralPath $abs -Raw
+        $text | Should -Match 'Get-RunResultValidationDiagnostics'
+    }
+
+    It '<scriptPath> calls the helper before Test-RunbookManifest' -ForEach @(
+        @{ scriptPath = 'tools/automation/invoke-input-dispatch.ps1' }
+        @{ scriptPath = 'tools/automation/invoke-behavior-watch.ps1' }
+        @{ scriptPath = 'tools/automation/invoke-scene-inspection.ps1' }
+        @{ scriptPath = 'tools/automation/invoke-runtime-error-triage.ps1' }
+        @{ scriptPath = 'tools/automation/invoke-build-error-triage.ps1' }
+    ) {
+        $abs = Join-Path $script:RepoRootPath $scriptPath
+        $text = Get-Content -LiteralPath $abs -Raw
+        $helperIdx   = $text.IndexOf('Get-RunResultValidationDiagnostics')
+        $manifestIdx = $text.IndexOf('Test-RunbookManifest -ManifestPath')
+        $helperIdx   | Should -BeGreaterThan -1
+        $manifestIdx | Should -BeGreaterThan -1
+        $helperIdx   | Should -BeLessThan $manifestIdx -Because 'the validation pre-empt must run before the manifest sanity check'
+    }
+}

--- a/tools/tests/InvokeRunbookScripts.Tests.ps1
+++ b/tools/tests/InvokeRunbookScripts.Tests.ps1
@@ -1048,4 +1048,25 @@ Describe 'B16: invoke-* scripts pre-empt Test-RunbookManifest on validation fail
         $manifestIdx | Should -BeGreaterThan -1
         $helperIdx   | Should -BeLessThan $manifestIdx -Because 'the validation pre-empt must run before the manifest sanity check'
     }
+
+    # Per Copilot review on PR #35: the B16 pre-empt path must emit the same
+    # workflow-specific outcome keys as Exit-Failure, not an empty @{}, so
+    # consumers see a stable shape on every failure path.
+    It '<scriptPath> B16 pre-empt emits the workflow-specific outcome keys (not -Outcome @{})' -ForEach @(
+        @{ scriptPath = 'tools/automation/invoke-input-dispatch.ps1';      requiredKey = 'declaredEventCount' }
+        @{ scriptPath = 'tools/automation/invoke-behavior-watch.ps1';      requiredKey = 'samplesPath' }
+        @{ scriptPath = 'tools/automation/invoke-scene-inspection.ps1';    requiredKey = 'sceneTreePath' }
+        @{ scriptPath = 'tools/automation/invoke-runtime-error-triage.ps1';requiredKey = 'runtimeErrorRecordsPath' }
+        @{ scriptPath = 'tools/automation/invoke-build-error-triage.ps1';  requiredKey = 'rawBuildOutputPath' }
+    ) {
+        $abs = Join-Path $script:RepoRootPath $scriptPath
+        $text = Get-Content -LiteralPath $abs -Raw
+        # Locate the pre-empt block by anchor and capture its body up to the next 'exit 1'.
+        $pattern = '(?s)Get-RunResultValidationDiagnostics.*?exit 1'
+        $match = [regex]::Match($text, $pattern)
+        $match.Success | Should -BeTrue -Because 'the B16 pre-empt block must be present'
+        $block = $match.Value
+        $block | Should -Match $requiredKey -Because "the B16 pre-empt outcome must include the workflow's $requiredKey field"
+        $block | Should -Not -Match '-Outcome\s+@\{\s*\}' -Because 'the B16 pre-empt must not emit an empty outcome'
+    }
 }


### PR DESCRIPTION
## Summary

Three orchestration-side bugs from [pass 6](prd/06-test-pass-results.md) where the stdout envelope's `outcome` or `diagnostics` projection lied about what happened. All fixed in `tools/automation/*.ps1` — no addon source touched. Together they make the envelope contract trustworthy again: agents acting on `outcome.*` and `diagnostics[]` get the truth.

- **B14** — drop the legacy `dispatchedEventCount` field from input-dispatch envelopes (it equalled declared count, not actual). `actualDispatchedCount` and `declaredEventCount` are the truthful replacements; both were already in place from pass 5.
- **B15** — flatten the behavior-watch `warnings` array. The `,@($warnings)` idiom was wrapping an already-plural `[List[string]]` in another array, producing `[[string]]` in JSON and breaking strongly-typed consumers.
- **B16** — surface `validationResult.notes` instead of a misleading "manifest not found at <path>" diagnostic. New helper `Get-RunResultValidationDiagnostics` plus a uniform pre-empt block in all five invoke-* scripts so the helper fires before `Test-RunbookManifest`.

## Files changed

- **Code (8)**: `tools/automation/RunbookOrchestration.psm1` (new helper), `invoke-input-dispatch.ps1`, `invoke-behavior-watch.ps1`, `invoke-scene-inspection.ps1`, `invoke-runtime-error-triage.ps1`, `invoke-build-error-triage.ps1`
- **Tests (1)**: `tools/tests/InvokeRunbookScripts.Tests.ps1` (+14 cases across 4 new Describe blocks: static source checks, behavioral assertions on `Write-RunbookEnvelope`, helper coverage, parameterized helper-before-manifest ordering check)
- **Docs/skills (5)**: `.claude/skills/godot-press/SKILL.md`, the addon-template equivalent, `specs/008-agent-runbook/data-model.md`, `specs/008-agent-runbook/tasks.md`, `prd/00-TestMatrix-Template.md`

## Test plan

- [x] `pwsh ./tools/tests/run-tool-tests.ps1` — **296 passed, 0 failed, 8 skipped** (skips are pre-existing fixture-absence skips)
- [x] `pwsh ./tools/check-addon-parse.ps1` — clean
- [ ] B14 reproduction: `pwsh ./tools/automation/invoke-input-dispatch.ps1 -ProjectRoot ./integration-testing/probe -RequestFixturePath ./tools/tests/fixtures/runbook/input-dispatch/press-enter.json` → envelope must NOT contain `dispatchedEventCount`; `actualDispatchedCount=0`, `declaredEventCount=2` unchanged
- [ ] B15 reproduction: `pwsh ./tools/automation/invoke-behavior-watch.ps1 -ProjectRoot ./integration-testing/probe -RequestFixturePath ./tools/tests/fixtures/runbook/behavior-watch/single-property-window.json` → `outcome.warnings` is a flat `["target node not found ..."]`
- [ ] B16 reproduction: re-run B8's reproduction (runtime-error-triage with overridden `targetScene`); `diagnostics[0]` mentions "Manifest runId did not match" (or whichever first non-noise note), NOT "manifest not found at..."

## Out of scope (per PRD)

- B8, B10 — runtime-side semantic correctness, see [06b](prd/06b-runtime-semantic-correctness.md)
- B13, F2, F3 — editor process lifecycle / deadlocks, see [06c](prd/06c-editor-lifecycle-hardening.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)