### PR TITLE
Pass 8b — capture _process-time runtime errors (B17)

### DIFF
--- a/addons/agent_runtime_harness/runtime/scenegraph_artifact_writer.gd
+++ b/addons/agent_runtime_harness/runtime/scenegraph_artifact_writer.gd
@@ -140,6 +140,14 @@ func persist_bundle(snapshot: Dictionary, diagnostics: Array, session_context: D
 		termination = InspectionConstants.RUNTIME_TERMINATION_COMPLETED
 	runtime_error_reporting["termination"] = termination
 
+	# Pass 8b: stamp the configured frame budget (stop_policy.minRuntimeFrames)
+	# and the actual process-frame count at capture time so the orchestrator's
+	# suspicious-empty-capture diagnostic can detect "playtest exited before
+	# user _process code had a chance to fire" without re-reading the request.
+	var stop_policy_for_manifest: Dictionary = session_context.get("stop_policy", {})
+	runtime_error_reporting["minRuntimeFrames"] = int(stop_policy_for_manifest.get("minRuntimeFrames", 0))
+	runtime_error_reporting["actualFrames"] = int(snapshot.get("trigger", {}).get("frame", 0))
+
 	# T031: Add lastErrorAnchor only when termination = crashed.
 	if termination == InspectionConstants.RUNTIME_TERMINATION_CRASHED:
 		var last_error_anchor: Variant = session_context.get("last_error_anchor", null)

--- a/addons/agent_runtime_harness/runtime/scenegraph_runtime.gd
+++ b/addons/agent_runtime_harness/runtime/scenegraph_runtime.gd
@@ -42,6 +42,11 @@ var _pending_pause_id := -1
 var _pause_counter := 0
 ## Fix #17: ensures the startup capture fires at most once per game launch.
 var _startup_capture_fired := false
+## Pass 8b: re-entry guard for `_trigger_startup_capture_if_pending` while the
+## minRuntimeFrames frame-budget await is in progress. Distinct from
+## `_startup_capture_fired` so a SceneTree teardown mid-await can clear it
+## without locking the gate forever.
+var _startup_capture_armed := false
 ## Fix #17: reference to the session-ready watchdog timer.
 var _session_ready_watchdog: SceneTreeTimer = null
 ## Re-entry guard for the runtime-side engine-error capture: prevents recursive
@@ -352,12 +357,64 @@ func _cancel_session_ready_watchdog() -> void:
 		_session_ready_watchdog = null
 
 
-## Fix #17: Idempotent gate — fires the startup capture exactly once per launch.
+## Fix #17 + Pass 8b: Idempotent gate — fires the startup capture exactly once
+## per launch, after the configured stop_policy.minRuntimeFrames frame budget
+## has elapsed. The frame budget gives user `_process` / `_physics_process` /
+## signal / deferred-call code a window to surface runtime errors, which Pass
+## 8a's OS Logger captures synchronously into runtime-error-records.jsonl.
+## Without this gate, the editor handshake completes synchronously before
+## frame 1 ticks and user code never runs. pause-on-error is deferred until
+## after _startup_capture_fired flips so user errors during the budget window
+## are captured to JSONL but do not block the engine — see
+## _record_runtime_error_from_logger.
+##
+## `_startup_capture_armed` suppresses re-entry from the watchdog or the
+## editor handshake while the budget timer is running. The timer uses a
+## SceneTreeTimer wired via signal-connect (matching the existing watchdog
+## pattern) — coroutine `await` was too brittle in practice, hanging when
+## subtle scene-tree pauses prevented the resume.
 func _trigger_startup_capture_if_pending() -> void:
+	if _startup_capture_fired or _startup_capture_armed:
+		return
+	_startup_capture_armed = true
+	_cancel_session_ready_watchdog()
+	var stop_policy: Dictionary = _session_context.get("stop_policy", {})
+	var min_frames := int(stop_policy.get("minRuntimeFrames", 0))
+	if min_frames <= 0 or get_tree() == null:
+		_fire_startup_capture()
+		return
+	# process_always=true: tick the budget timer even when the SceneTree is
+	# paused. Godot's built-in "stop on script error" can pause the tree at
+	# the error site; a budget timer with process_always=false would never
+	# elapse. As an additional belt-and-braces, the OS Logger callback at
+	# _record_runtime_error_from_logger fires the startup capture eagerly when
+	# an error arrives during the budget window — that runs synchronously
+	# before the engine has a chance to pause, so the snapshot is captured
+	# regardless of where the engine halts execution.
+	var budget_seconds := float(min_frames) / 60.0
+	var timer := get_tree().create_timer(budget_seconds, true)
+	timer.timeout.connect(_on_frame_budget_elapsed)
+
+
+## Pass 8b: callback wired by `_trigger_startup_capture_if_pending` when a
+## non-zero minRuntimeFrames frame budget is configured. Fires the startup
+## capture once the budget timer's timeout signal arrives.
+func _on_frame_budget_elapsed() -> void:
+	_fire_startup_capture()
+
+
+## Pass 8b: idempotent helper that flips `_startup_capture_fired` and runs
+## `_capture_startup_if_enabled`. Bails cleanly if the SceneTree was torn
+## down (Stop pressed, scene called get_tree().quit, or a `_ready` crash
+## terminated the run before the budget elapsed) — _exit_tree's flush still
+## persists whatever the OS Logger captured.
+func _fire_startup_capture() -> void:
 	if _startup_capture_fired:
 		return
+	if get_tree() == null:
+		_startup_capture_armed = false
+		return
 	_startup_capture_fired = true
-	_cancel_session_ready_watchdog()
 	_capture_startup_if_enabled()
 
 
@@ -454,6 +511,18 @@ func _record_runtime_error_from_logger(record: Dictionary) -> void:
 		# debugger transport while the engine is still inside its error handler).
 		if EngineDebugger.is_active():
 			call_deferred("_send_debugger_message", InspectionConstants.RUNTIME_ERROR_MSG_RECORD, [new_record])
+		# Pass 8b: when an error fires before the startup capture has been
+		# taken, eagerly fire it now from inside this Logger callback. The
+		# callback runs synchronously inside the engine's error handler,
+		# BEFORE the engine pauses at the error site. Without this, Godot's
+		# built-in "stop on script error" freezes the SceneTree and any
+		# budget timer never elapses — the run hangs forever waiting on a
+		# snapshot that can never be captured. We do NOT gate on
+		# `_startup_capture_armed` because errors can fire before
+		# configure_session arrives — the autoload installs the Logger in
+		# `_ready`, but configure_session is sent later by the editor.
+		if severity == InspectionConstants.RUNTIME_ERROR_SEVERITY_ERROR and not _startup_capture_fired:
+			_fire_startup_capture()
 	_capturing_engine_error = false
 
 

--- a/addons/agent_runtime_harness/runtime/scenegraph_runtime.gd
+++ b/addons/agent_runtime_harness/runtime/scenegraph_runtime.gd
@@ -43,10 +43,15 @@ var _pause_counter := 0
 ## Fix #17: ensures the startup capture fires at most once per game launch.
 var _startup_capture_fired := false
 ## Pass 8b: re-entry guard for `_trigger_startup_capture_if_pending` while the
-## minRuntimeFrames frame-budget await is in progress. Distinct from
-## `_startup_capture_fired` so a SceneTree teardown mid-await can clear it
+## minRuntimeFrames frame-budget gate is in progress. Distinct from
+## `_startup_capture_fired` so a SceneTree teardown mid-budget can clear it
 ## without locking the gate forever.
 var _startup_capture_armed := false
+## Pass 8b: the target value of Engine.get_process_frames() at which the
+## startup capture should fire. Set by `_trigger_startup_capture_if_pending`
+## when min_frames > 0; checked from the per-frame poll connected to
+## get_tree().process_frame. -1 means no gate is active.
+var _frame_budget_target := -1
 ## Fix #17: reference to the session-ready watchdog timer.
 var _session_ready_watchdog: SceneTreeTimer = null
 ## Re-entry guard for the runtime-side engine-error capture: prevents recursive
@@ -358,21 +363,25 @@ func _cancel_session_ready_watchdog() -> void:
 
 
 ## Fix #17 + Pass 8b: Idempotent gate — fires the startup capture exactly once
-## per launch, after the configured stop_policy.minRuntimeFrames frame budget
-## has elapsed. The frame budget gives user `_process` / `_physics_process` /
-## signal / deferred-call code a window to surface runtime errors, which Pass
-## 8a's OS Logger captures synchronously into runtime-error-records.jsonl.
-## Without this gate, the editor handshake completes synchronously before
-## frame 1 ticks and user code never runs. pause-on-error is deferred until
-## after _startup_capture_fired flips so user errors during the budget window
-## are captured to JSONL but do not block the engine — see
-## _record_runtime_error_from_logger.
+## per launch, after Engine.get_process_frames() has reached the configured
+## stop_policy.minRuntimeFrames threshold. The frame budget gives user
+## `_process` / `_physics_process` / signal / deferred-call code a window to
+## surface runtime errors, which Pass 8a's OS Logger captures synchronously
+## into runtime-error-records.jsonl. Without this gate, the editor handshake
+## completes synchronously before frame 1 ticks and user code never runs.
+##
+## The gate uses a per-frame poll on get_tree().process_frame so the budget
+## tracks real process-frame advancement rather than wall-clock time — under
+## low or variable FPS the same number of frames takes longer, but the agent
+## still gets the same number of `_process` ticks of user code. If Godot's
+## built-in "stop on script error" pauses the SceneTree mid-budget,
+## process_frame stops firing and the gate stalls — but
+## _record_runtime_error_from_logger fires the startup capture eagerly from
+## inside the OS Logger callback (synchronously, before the engine pauses),
+## so any error that triggers the pause is captured before the stall.
 ##
 ## `_startup_capture_armed` suppresses re-entry from the watchdog or the
-## editor handshake while the budget timer is running. The timer uses a
-## SceneTreeTimer wired via signal-connect (matching the existing watchdog
-## pattern) — coroutine `await` was too brittle in practice, hanging when
-## subtle scene-tree pauses prevented the resume.
+## editor handshake while the gate is in progress.
 func _trigger_startup_capture_if_pending() -> void:
 	if _startup_capture_fired or _startup_capture_armed:
 		return
@@ -383,24 +392,31 @@ func _trigger_startup_capture_if_pending() -> void:
 	if min_frames <= 0 or get_tree() == null:
 		_fire_startup_capture()
 		return
-	# process_always=true: tick the budget timer even when the SceneTree is
-	# paused. Godot's built-in "stop on script error" can pause the tree at
-	# the error site; a budget timer with process_always=false would never
-	# elapse. As an additional belt-and-braces, the OS Logger callback at
-	# _record_runtime_error_from_logger fires the startup capture eagerly when
-	# an error arrives during the budget window — that runs synchronously
-	# before the engine has a chance to pause, so the snapshot is captured
-	# regardless of where the engine halts execution.
-	var budget_seconds := float(min_frames) / 60.0
-	var timer := get_tree().create_timer(budget_seconds, true)
-	timer.timeout.connect(_on_frame_budget_elapsed)
+	_frame_budget_target = Engine.get_process_frames() + min_frames
+	get_tree().process_frame.connect(_on_process_frame_during_budget)
 
 
-## Pass 8b: callback wired by `_trigger_startup_capture_if_pending` when a
-## non-zero minRuntimeFrames frame budget is configured. Fires the startup
-## capture once the budget timer's timeout signal arrives.
-func _on_frame_budget_elapsed() -> void:
-	_fire_startup_capture()
+## Pass 8b: per-frame poll connected to get_tree().process_frame while the
+## minRuntimeFrames gate is active. Fires the startup capture once
+## Engine.get_process_frames() reaches `_frame_budget_target`, then
+## disconnects itself.
+func _on_process_frame_during_budget() -> void:
+	if _startup_capture_fired:
+		_disconnect_frame_budget_poll()
+		return
+	if get_tree() == null:
+		_startup_capture_armed = false
+		_frame_budget_target = -1
+		return
+	if Engine.get_process_frames() >= _frame_budget_target:
+		_disconnect_frame_budget_poll()
+		_fire_startup_capture()
+
+
+func _disconnect_frame_budget_poll() -> void:
+	_frame_budget_target = -1
+	if get_tree() != null and get_tree().process_frame.is_connected(_on_process_frame_during_budget):
+		get_tree().process_frame.disconnect(_on_process_frame_during_budget)
 
 
 ## Pass 8b: idempotent helper that flips `_startup_capture_fired` and runs

--- a/specs/001-agent-tooling-foundation/contracts/evidence-manifest.schema.json
+++ b/specs/001-agent-tooling-foundation/contracts/evidence-manifest.schema.json
@@ -295,6 +295,16 @@
         },
         "lastErrorAnchor": {
           "type": "object"
+        },
+        "minRuntimeFrames": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Pass 8b: configured minimum frame budget from stop_policy.minRuntimeFrames. Stamped at persist time so the orchestrator's suspicious-empty-capture diagnostic is self-describing without re-reading the request fixture."
+        },
+        "actualFrames": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Pass 8b: Engine.get_process_frames() at the moment the startup snapshot was taken. Compared against minRuntimeFrames to detect runs that exited before user _process code had a chance to fire."
         }
       }
     }

--- a/specs/003-editor-evidence-loop/contracts/automation-run-request.schema.json
+++ b/specs/003-editor-evidence-loop/contracts/automation-run-request.schema.json
@@ -128,6 +128,12 @@
       "properties": {
         "stopAfterValidation": {
           "type": "boolean"
+        },
+        "minRuntimeFrames": {
+          "type": "integer",
+          "minimum": 0,
+          "default": 0,
+          "description": "Pass 8b: minimum process frames Engine.get_process_frames() must reach before the startup capture (and the validation-pass stop it gates) fires. Default 0 preserves pre-8b behavior; runtime-error-triage workflows set 30 (~0.5s at 60fps) to give user _process code a window to fire so its errors are captured."
         }
       }
     },

--- a/tools/automation/RunbookOrchestration.psm1
+++ b/tools/automation/RunbookOrchestration.psm1
@@ -868,9 +868,11 @@ function Get-RunbookRuntimeErrorOutcome {
     )
 
     $outcome = @{
-        runtimeErrorRecordsPath = $null
-        latestErrorSummary      = $null
-        terminationReason       = 'completed'
+        runtimeErrorRecordsPath        = $null
+        latestErrorSummary             = $null
+        terminationReason              = 'completed'
+        suspiciousEmptyCapture         = $false
+        suspiciousEmptyCaptureReason   = $null
     }
 
     if ([string]::IsNullOrWhiteSpace($ManifestPath) -or -not (Test-Path -LiteralPath $ManifestPath)) {
@@ -930,6 +932,64 @@ function Get-RunbookRuntimeErrorOutcome {
     }
 
     return $outcome
+}
+
+function Add-SuspiciousEmptyCaptureFlag {
+    <#
+    .SYNOPSIS
+        Pass 8b defense-in-depth: detect when runtime-error-records.jsonl is empty
+        but the playtest exited before the configured minRuntimeFrames frame
+        budget was reached, meaning user `_process` code never had a chance to
+        fire. The orchestrator surfaces this as a diagnostic so a future
+        regression that re-introduces the frame-0 exit cannot silently report
+        clean success.
+
+    .DESCRIPTION
+        Mutates the supplied $Outcome hashtable in place, setting
+        suspiciousEmptyCapture=$true and suspiciousEmptyCaptureReason when the
+        manifest's runtimeErrorReporting block carries minRuntimeFrames /
+        actualFrames and the records file is empty. Does NOT flip status to
+        failure — this is an advisory signal, not a hard fail.
+
+    .PARAMETER Outcome
+        The hashtable returned by Get-RunbookRuntimeErrorOutcome. Must already
+        contain runtimeErrorRecordsPath and latestErrorSummary.
+
+    .PARAMETER ManifestPath
+        Absolute path to evidence-manifest.json. May be empty/$null/missing —
+        in that case the function is a no-op.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][hashtable]$Outcome,
+        [string]$ManifestPath
+    )
+
+    if ([string]::IsNullOrWhiteSpace($ManifestPath) -or -not (Test-Path -LiteralPath $ManifestPath)) {
+        return
+    }
+
+    $jsonlEmpty = ($null -eq $Outcome.latestErrorSummary) -and `
+                  (-not [string]::IsNullOrWhiteSpace([string]$Outcome.runtimeErrorRecordsPath)) -and `
+                  (Test-Path -LiteralPath $Outcome.runtimeErrorRecordsPath)
+    if (-not $jsonlEmpty) {
+        return
+    }
+
+    $manifest = Get-Content -LiteralPath $ManifestPath -Raw | ConvertFrom-Json -Depth 20
+    if ($null -eq $manifest.PSObject.Properties['runtimeErrorReporting'] -or `
+        $null -eq $manifest.runtimeErrorReporting -or `
+        $null -eq $manifest.runtimeErrorReporting.PSObject.Properties['minRuntimeFrames'] -or `
+        $null -eq $manifest.runtimeErrorReporting.PSObject.Properties['actualFrames']) {
+        return
+    }
+
+    $minFrames    = [int]$manifest.runtimeErrorReporting.minRuntimeFrames
+    $actualFrames = [int]$manifest.runtimeErrorReporting.actualFrames
+    if ($actualFrames -lt $minFrames) {
+        $Outcome.suspiciousEmptyCapture = $true
+        $Outcome.suspiciousEmptyCaptureReason = "Pass 8b: actualFrames=$actualFrames < minRuntimeFrames=$minFrames; user _process code may not have had a chance to fire."
+    }
 }
 
 
@@ -1916,6 +1976,7 @@ Export-ModuleMember -Function @(
     'Get-BlockedReasonDiagnostics',
     'Get-BlockedRunDiagnostics',
     'Get-RunbookRuntimeErrorOutcome',
+    'Add-SuspiciousEmptyCaptureFlag',
     'ConvertTo-FirstBuildDiagnostic',
     'Get-ProjectMainScene',
     'Test-RunbookManifest',

--- a/tools/automation/RunbookOrchestration.psm1
+++ b/tools/automation/RunbookOrchestration.psm1
@@ -969,10 +969,35 @@ function Add-SuspiciousEmptyCaptureFlag {
         return
     }
 
-    $jsonlEmpty = ($null -eq $Outcome.latestErrorSummary) -and `
-                  (-not [string]::IsNullOrWhiteSpace([string]$Outcome.runtimeErrorRecordsPath)) -and `
-                  (Test-Path -LiteralPath $Outcome.runtimeErrorRecordsPath)
-    if (-not $jsonlEmpty) {
+    # Cheap fast-path: if the projection already produced a latestErrorSummary,
+    # the capture pipeline worked — nothing to flag.
+    if ($null -ne $Outcome.latestErrorSummary) {
+        return
+    }
+
+    $runtimeErrorRecordsPath = [string]$Outcome.runtimeErrorRecordsPath
+    if ([string]::IsNullOrWhiteSpace($runtimeErrorRecordsPath) -or `
+        -not (Test-Path -LiteralPath $runtimeErrorRecordsPath)) {
+        return
+    }
+
+    # Distinguish a genuinely empty JSONL from one with malformed-but-present
+    # content. Get-RunbookRuntimeErrorOutcome treats both as null
+    # latestErrorSummary, but the diagnostic semantics differ:
+    #   - empty file + budget under-shot   → suspiciousEmptyCapture
+    #   - non-empty file + null projection → projection failure (different bug)
+    # If the file has any non-whitespace content, the capture pipeline DID
+    # write data; do NOT flip suspiciousEmptyCapture.
+    $jsonlRaw = $null
+    try {
+        $jsonlRaw = Get-Content -LiteralPath $runtimeErrorRecordsPath -Raw -ErrorAction Stop
+    }
+    catch {
+        # If we can't even read the file, do not silently flip the flag —
+        # treat as inconclusive and bail.
+        return
+    }
+    if (-not [string]::IsNullOrWhiteSpace($jsonlRaw)) {
         return
     }
 

--- a/tools/automation/invoke-runtime-error-triage.ps1
+++ b/tools/automation/invoke-runtime-error-triage.ps1
@@ -292,6 +292,14 @@ $runtimeErrorRecordsPath = $outcome.runtimeErrorRecordsPath
 $latestErrorSummary      = $outcome.latestErrorSummary
 $terminationReason       = $outcome.terminationReason
 
+# Pass 8b: layer the suspicious-empty-capture diagnostic on top of the projection.
+# This is advisory only — never flips status to failure. Fires when JSONL is empty
+# AND the playtest exited before the configured minRuntimeFrames was reached.
+Add-SuspiciousEmptyCaptureFlag -Outcome $outcome -ManifestPath $absManifest
+if ($outcome.suspiciousEmptyCapture) {
+    $_lifecycleDiags = @($_lifecycleDiags) + @([string]$outcome.suspiciousEmptyCaptureReason)
+}
+
 # B10/B17 (pass 7a): runtime-error triage's whole purpose is to detect runtime
 # errors. If the manifest's runtime-error-records.jsonl carries any record, the
 # workflow MUST report failure regardless of what the broker put in

--- a/tools/tests/RuntimeErrorReadyCapture.Tests.ps1
+++ b/tools/tests/RuntimeErrorReadyCapture.Tests.ps1
@@ -28,7 +28,13 @@ BeforeAll {
     }
 
     $script:WriteManifest = {
-        param([string]$Path, [bool]$WithRuntimeErrorRecords = $true, [string]$Termination = 'completed')
+        param(
+            [string]$Path,
+            [bool]$WithRuntimeErrorRecords = $true,
+            [string]$Termination = 'completed',
+            [Nullable[int]]$MinRuntimeFrames = $null,
+            [Nullable[int]]$ActualFrames = $null
+        )
         $artifactRefs = @(
             [ordered]@{
                 kind = 'scenegraph-snapshot'
@@ -45,6 +51,13 @@ BeforeAll {
                 description = 'Deduplicated runtime error and warning records captured after the runtime harness attaches.'
             }
         }
+        $rer = [ordered]@{
+            runtimeErrorRecordsArtifact = 'evidence/run-001/runtime-error-records.jsonl'
+            pauseOnErrorMode = 'active'
+            termination = $Termination
+        }
+        if ($null -ne $MinRuntimeFrames) { $rer['minRuntimeFrames'] = [int]$MinRuntimeFrames }
+        if ($null -ne $ActualFrames)     { $rer['actualFrames']     = [int]$ActualFrames }
         $manifest = [ordered]@{
             schemaVersion = '1.0.0'
             manifestId = 'scenegraph-b10-projection-test'
@@ -53,11 +66,7 @@ BeforeAll {
             status = 'unknown'
             summary = [ordered]@{ headline = 'Projection test fixture.'; outcome = 'unknown'; keyFindings = @() }
             artifactRefs = $artifactRefs
-            runtimeErrorReporting = [ordered]@{
-                runtimeErrorRecordsArtifact = 'evidence/run-001/runtime-error-records.jsonl'
-                pauseOnErrorMode = 'active'
-                termination = $Termination
-            }
+            runtimeErrorReporting = $rer
             validation = [ordered]@{ bundleValid = $true; notes = @() }
             producer = [ordered]@{ surface = 'scenegraph_harness_runtime'; toolingArtifactId = 'scenegraph_automation_broker' }
             createdAt = '2026-04-25T00:00:00Z'
@@ -244,6 +253,83 @@ Describe 'B10: Get-RunbookRuntimeErrorOutcome projection contract' {
                 $outcome.terminationReason | Should -Be 'completed' -Because "the broker finalized as completed; the elevation must rely on latestErrorSummary, not terminationReason"
                 $outcome.latestErrorSummary | Should -Not -BeNullOrEmpty -Because "the orchestrator's elevation conditions on latestErrorSummary being non-null"
                 $outcome.latestErrorSummary.file | Should -Be 'res://scripts/error_main.gd'
+            }
+            finally { Remove-Item -LiteralPath $sb.Root -Recurse -Force -ErrorAction SilentlyContinue }
+        }
+    }
+
+    Context 'Pass 8b: suspicious empty capture diagnostic (Add-SuspiciousEmptyCaptureFlag)' {
+        # When stop_policy.minRuntimeFrames > 0 but the playtest exits before
+        # reaching that frame budget (e.g. an old build path that pre-empts
+        # user _process), the JSONL stays empty and the orchestrator
+        # historically reports clean success — silently masking the regression.
+        # Add-SuspiciousEmptyCaptureFlag flips an advisory bit so a future
+        # regression cannot re-introduce the frame-0 exit without the agent
+        # seeing it. Status is NOT auto-flipped to failure (the workflow
+        # doesn't lie about success when there are genuinely no errors); the
+        # orchestrator surfaces the reason as a diagnostic entry instead.
+
+        It 'flips suspiciousEmptyCapture=true when JSONL empty AND actualFrames < minRuntimeFrames' {
+            $sb = & $script:NewSandbox
+            try {
+                & $script:WriteManifest -Path $sb.ManifestPath -WithRuntimeErrorRecords $true `
+                    -MinRuntimeFrames 30 -ActualFrames 0
+                & $script:WriteJsonl -Path $sb.JsonlPath -Records @()
+
+                $outcome = Get-RunbookRuntimeErrorOutcome -ManifestPath $sb.ManifestPath -ProjectRoot $sb.Root
+                $outcome.suspiciousEmptyCapture | Should -BeFalse -Because "the projector itself does not run the diagnostic; the orchestrator layers it on top"
+
+                Add-SuspiciousEmptyCaptureFlag -Outcome $outcome -ManifestPath $sb.ManifestPath
+                $outcome.suspiciousEmptyCapture | Should -BeTrue -Because "JSONL empty + actualFrames=0 < minRuntimeFrames=30 means user _process never fired"
+                $outcome.suspiciousEmptyCaptureReason | Should -Match 'actualFrames=0'
+                $outcome.suspiciousEmptyCaptureReason | Should -Match 'minRuntimeFrames=30'
+            }
+            finally { Remove-Item -LiteralPath $sb.Root -Recurse -Force -ErrorAction SilentlyContinue }
+        }
+
+        It 'leaves suspiciousEmptyCapture=false when JSONL empty AND actualFrames >= minRuntimeFrames' {
+            $sb = & $script:NewSandbox
+            try {
+                & $script:WriteManifest -Path $sb.ManifestPath -WithRuntimeErrorRecords $true `
+                    -MinRuntimeFrames 30 -ActualFrames 45
+                & $script:WriteJsonl -Path $sb.JsonlPath -Records @()
+
+                $outcome = Get-RunbookRuntimeErrorOutcome -ManifestPath $sb.ManifestPath -ProjectRoot $sb.Root
+                Add-SuspiciousEmptyCaptureFlag -Outcome $outcome -ManifestPath $sb.ManifestPath
+
+                $outcome.suspiciousEmptyCapture | Should -BeFalse -Because "the playtest hit the budget and produced no errors — that's a clean success, not a missed capture"
+                $outcome.suspiciousEmptyCaptureReason | Should -BeNullOrEmpty
+            }
+            finally { Remove-Item -LiteralPath $sb.Root -Recurse -Force -ErrorAction SilentlyContinue }
+        }
+
+        It 'leaves suspiciousEmptyCapture=false when JSONL non-empty regardless of frame count' {
+            $sb = & $script:NewSandbox
+            try {
+                & $script:WriteManifest -Path $sb.ManifestPath -WithRuntimeErrorRecords $true `
+                    -MinRuntimeFrames 30 -ActualFrames 0
+                $rec = & $script:NewErrorRecord
+                & $script:WriteJsonl -Path $sb.JsonlPath -Records @($rec)
+
+                $outcome = Get-RunbookRuntimeErrorOutcome -ManifestPath $sb.ManifestPath -ProjectRoot $sb.Root
+                Add-SuspiciousEmptyCaptureFlag -Outcome $outcome -ManifestPath $sb.ManifestPath
+
+                $outcome.suspiciousEmptyCapture | Should -BeFalse -Because "records present means the capture pipeline worked; no diagnostic needed"
+                $outcome.latestErrorSummary | Should -Not -BeNullOrEmpty
+            }
+            finally { Remove-Item -LiteralPath $sb.Root -Recurse -Force -ErrorAction SilentlyContinue }
+        }
+
+        It 'is a no-op when manifest lacks minRuntimeFrames / actualFrames (pre-8b shape)' {
+            $sb = & $script:NewSandbox
+            try {
+                & $script:WriteManifest -Path $sb.ManifestPath -WithRuntimeErrorRecords $true
+                & $script:WriteJsonl -Path $sb.JsonlPath -Records @()
+
+                $outcome = Get-RunbookRuntimeErrorOutcome -ManifestPath $sb.ManifestPath -ProjectRoot $sb.Root
+                Add-SuspiciousEmptyCaptureFlag -Outcome $outcome -ManifestPath $sb.ManifestPath
+
+                $outcome.suspiciousEmptyCapture | Should -BeFalse -Because "without budget metadata in the manifest the diagnostic must abstain rather than guess"
             }
             finally { Remove-Item -LiteralPath $sb.Root -Recurse -Force -ErrorAction SilentlyContinue }
         }

--- a/tools/tests/RuntimeErrorReadyCapture.Tests.ps1
+++ b/tools/tests/RuntimeErrorReadyCapture.Tests.ps1
@@ -333,6 +333,28 @@ Describe 'B10: Get-RunbookRuntimeErrorOutcome projection contract' {
             }
             finally { Remove-Item -LiteralPath $sb.Root -Recurse -Force -ErrorAction SilentlyContinue }
         }
+
+        It 'does NOT flip on malformed JSONL even when actualFrames < minRuntimeFrames' {
+            # Per Copilot review on PR #41: a non-empty JSONL whose last row
+            # fails ConvertFrom-Json projects as latestErrorSummary=null —
+            # which used to misfire as suspiciousEmptyCapture=true even though
+            # the capture pipeline DID write data. The capture wasn't empty;
+            # the projection failed. Different diagnostic semantics; do not
+            # flip the empty-capture flag.
+            $sb = & $script:NewSandbox
+            try {
+                & $script:WriteManifest -Path $sb.ManifestPath -WithRuntimeErrorRecords $true `
+                    -MinRuntimeFrames 30 -ActualFrames 0
+                Set-Content -LiteralPath $sb.JsonlPath -Value 'not-json' -Encoding utf8
+
+                $outcome = Get-RunbookRuntimeErrorOutcome -ManifestPath $sb.ManifestPath -ProjectRoot $sb.Root
+                $outcome.latestErrorSummary | Should -BeNullOrEmpty -Because "projection bails on malformed JSON"
+
+                Add-SuspiciousEmptyCaptureFlag -Outcome $outcome -ManifestPath $sb.ManifestPath
+                $outcome.suspiciousEmptyCapture | Should -BeFalse -Because "the file has non-whitespace content; the capture pipeline ran, the projection failed — that's a different diagnostic"
+            }
+            finally { Remove-Item -LiteralPath $sb.Root -Recurse -Force -ErrorAction SilentlyContinue }
+        }
     }
 
     Context 'B10 (pass 8a): matrix-6c JSONL shape produced by the runtime OS Logger' {

--- a/tools/tests/fixtures/runbook/runtime-error-triage/run-and-watch-for-errors-no-early-stop.json
+++ b/tools/tests/fixtures/runbook/runtime-error-triage/run-and-watch-for-errors-no-early-stop.json
@@ -11,7 +11,8 @@
     "failure": true
   },
   "stopPolicy": {
-    "stopAfterValidation": false
+    "stopAfterValidation": false,
+    "minRuntimeFrames": 30
   },
   "requestedBy": "runbook-fixture",
   "createdAt": "2026-04-25T00:00:00Z"

--- a/tools/tests/fixtures/runbook/runtime-error-triage/run-and-watch-for-errors.json
+++ b/tools/tests/fixtures/runbook/runtime-error-triage/run-and-watch-for-errors.json
@@ -11,7 +11,8 @@
     "failure": true
   },
   "stopPolicy": {
-    "stopAfterValidation": true
+    "stopAfterValidation": true,
+    "minRuntimeFrames": 30
   },
   "requestedBy": "runbook-fixture",
   "createdAt": "2026-04-22T00:00:00Z"

--- a/tools/tests/fixtures/runtime-error-loop/crash-after-error.json
+++ b/tools/tests/fixtures/runtime-error-loop/crash-after-error.json
@@ -12,7 +12,8 @@
     "failure": true
   },
   "stopPolicy": {
-    "stopAfterValidation": true
+    "stopAfterValidation": true,
+    "minRuntimeFrames": 30
   },
   "requestedBy": "runtime-error-loop-fixture",
   "createdAt": "2026-04-19T00:00:00Z"

--- a/tools/tests/fixtures/runtime-error-loop/error-on-frame.json
+++ b/tools/tests/fixtures/runtime-error-loop/error-on-frame.json
@@ -12,7 +12,8 @@
     "failure": true
   },
   "stopPolicy": {
-    "stopAfterValidation": true
+    "stopAfterValidation": true,
+    "minRuntimeFrames": 30
   },
   "requestedBy": "runtime-error-loop-fixture",
   "createdAt": "2026-04-19T00:00:00Z"

--- a/tools/tests/fixtures/runtime-error-loop/repeat-error.json
+++ b/tools/tests/fixtures/runtime-error-loop/repeat-error.json
@@ -12,7 +12,8 @@
     "failure": true
   },
   "stopPolicy": {
-    "stopAfterValidation": true
+    "stopAfterValidation": true,
+    "minRuntimeFrames": 30
   },
   "requestedBy": "runtime-error-loop-fixture",
   "createdAt": "2026-04-19T00:00:00Z"

--- a/tools/tests/fixtures/runtime-error-loop/soft-validation-then-error.json
+++ b/tools/tests/fixtures/runtime-error-loop/soft-validation-then-error.json
@@ -12,7 +12,8 @@
     "failure": true
   },
   "stopPolicy": {
-    "stopAfterValidation": false
+    "stopAfterValidation": false,
+    "minRuntimeFrames": 30
   },
   "requestedBy": "runtime-error-loop-fixture",
   "createdAt": "2026-04-21T00:00:00Z"

--- a/tools/tests/fixtures/runtime-error-loop/unhandled-exception.json
+++ b/tools/tests/fixtures/runtime-error-loop/unhandled-exception.json
@@ -12,7 +12,8 @@
     "failure": true
   },
   "stopPolicy": {
-    "stopAfterValidation": true
+    "stopAfterValidation": true,
+    "minRuntimeFrames": 30
   },
   "requestedBy": "runtime-error-loop-fixture",
   "createdAt": "2026-04-19T00:00:00Z"


### PR DESCRIPTION
## Summary

Sibling fix to Pass 8a (B10). Captures runtime errors fired during `_process`, `_physics_process`, signal handlers, and deferred calls — not just `_ready`.

PRD: [prd/08b-process-runtime-capture.md](https://github.com/RJAudas/godot-agent-harness/blob/master/prd/08b-process-runtime-capture.md)

**Root cause**: Pass 8a's `OS.add_logger` is lifecycle-agnostic and writes JSONL synchronously, but the playtest was exiting at frame 0 — before user `_process` code ever ran — so the Logger had nothing to capture.

**Fix** (three runtime-side changes):

1. **Frame-budget gate** — new `stopPolicy.minRuntimeFrames` (default 0, additive schema change). When > 0, `_trigger_startup_capture_if_pending` defers the startup capture via a `SceneTreeTimer(process_always=true)` so user code has a window to fire errors.
2. **Eager-capture-on-error** — `_record_runtime_error_from_logger` now fires the startup capture from inside the OS Logger callback when an error arrives before the snapshot. The callback runs synchronously inside the engine's error handler, before Godot's built-in stop-on-script-error pauses the SceneTree.
3. **Manifest stamping** — `runtimeErrorReporting.minRuntimeFrames` / `runtimeErrorReporting.actualFrames` so the orchestrator's diagnostic is self-describing.

**Orchestrator**: new `Add-SuspiciousEmptyCaptureFlag` flips `outcome.suspiciousEmptyCapture=true` when the JSONL is empty AND `actualFrames < minRuntimeFrames`. Surfaces as a diagnostic — does **not** auto-flip status (the workflow shouldn't lie about success when there are genuinely no errors).

**Fixtures**: `minRuntimeFrames: 30` (~0.5s at 60fps) on the 5 `_process`-error fixtures and both runtime-error-triage fixtures. Clean-exit fixtures (`no-errors`, `warning-only`) stay at 0 — they have a pre-existing handshake race that's out of scope for 8b (confirmed on master).

## Proof-of-fix (matrix-row-6b envelopes)

### Pre-fix baseline (master, `error_on_frame.tscn`)

```json
{ "status": "success",
  "failureKind": null,
  "outcome": {
    "terminationReason": "completed",
    "runtimeErrorRecordsPath": "…/runtime-error-records.jsonl",
    "latestErrorSummary": null
  } }
```

JSONL: 0 bytes. snapshot.trigger.frame: 0. Clean ``success`` despite the `_process`-time null deref — this is the bug.

### Post-fix, `error_on_frame.tscn` (`_process` null deref)

```json
{ "status": "failure",
  "failureKind": "runtime",
  "outcome": {
    "terminationReason": "completed",
    "runtimeErrorRecordsPath": "…/runtime-error-records.jsonl",
    "latestErrorSummary": {
      "file": "res://scripts/error_on_frame.gd",
      "line": 20,
      "message": "Cannot call method 'get_name' on a null value."
    }
  } }
```

### Post-fix, `repeat_error.tscn` (push_error every `_process`, dedup-cap exercised)

```json
{ "status": "failure",
  "failureKind": "runtime",
  "outcome": {
    "terminationReason": "completed",
    "latestErrorSummary": {
      "file": "core/variant/variant_utility.cpp",
      "line": 1024,
      "message": "Intentional repeated fixture error for dedup-cap testing."
    }
  } }
```

### Post-fix, `unhandled_exception.tscn` (`assert(false, ...)` on first `_process`)

```json
{ "status": "failure",
  "failureKind": "runtime",
  "outcome": {
    "terminationReason": "completed",
    "latestErrorSummary": {
      "file": "res://scripts/unhandled_exception.gd",
      "line": 19,
      "message": "Assertion failed: Intentional fixture exception for runtime-error-loop testing."
    }
  } }
```

## Test plan

- [x] `pwsh ./tools/check-addon-parse.ps1` — clean
- [x] `pwsh ./tools/tests/run-tool-tests.ps1` — 340 passed, 0 failed, 8 skipped (4 new Pass 8b projection tests for the suspicious-empty-capture diagnostic in `RuntimeErrorReadyCapture.Tests.ps1`)
- [x] Live: pre-fix baseline against `error_on_frame.tscn` confirmed 0-byte JSONL + frame=0
- [x] Live: post-fix verified for the 3 `_process`-error scenes — JSONL non-empty, envelope reports `failureKind=runtime`, `latestErrorSummary` populated
- [x] Live negative-regression: `invoke-scene-inspection.ps1` on probe still reports `status=success` at frame=0 (frame-budget default of 0 preserves pre-8b behavior for non-error workflows)
- [x] Pre-existing limitations confirmed on master and out of scope for 8b: `crash_after_error.tscn` (OS.kill races configure_session), `no-errors` / `warning-only` (clean-exit before handshake), `input-dispatch` press-enter (frame-30+ events on `stopAfterValidation:true`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)