### PR TITLE
fix: expand behavior-watch property allowlist + enrich enum errors (#47)

### DIFF
--- a/addons/agent_runtime_harness/runtime/behavior_watch_sampler.gd
+++ b/addons/agent_runtime_harness/runtime/behavior_watch_sampler.gd
@@ -134,6 +134,15 @@ func _build_row_for_target(node: Node, target: Dictionary, frame: int, timestamp
 					collision.get("overlapFrames", null),
 					overlap_available
 				)
+			_:
+				var generic := _extract_generic_property(node, property_name)
+				_assign_sampled_property(
+					row,
+					node_path,
+					property_name,
+					generic.get("value", null),
+					bool(generic.get("available", false))
+				)
 
 	return row
 
@@ -212,6 +221,28 @@ func _has_property(target: Object, property_name: String) -> bool:
 		if String(property_info.get("name", "")) == property_name:
 			return true
 	return false
+
+
+func _extract_generic_property(node: Object, property_name: String) -> Dictionary:
+	if not _has_property(node, property_name):
+		return {"value": null, "available": false}
+	var raw_value = node.get(property_name)
+	match typeof(raw_value):
+		TYPE_BOOL:
+			return {"value": bool(raw_value), "available": true}
+		TYPE_INT:
+			return {"value": int(raw_value), "available": true}
+		TYPE_FLOAT:
+			return {"value": float(raw_value), "available": true}
+		TYPE_STRING, TYPE_STRING_NAME:
+			return {"value": String(raw_value), "available": true}
+		TYPE_VECTOR2:
+			return {"value": [raw_value.x, raw_value.y], "available": true}
+		TYPE_VECTOR2I:
+			return {"value": [raw_value.x, raw_value.y], "available": true}
+		TYPE_COLOR:
+			return {"value": [raw_value.r, raw_value.g, raw_value.b, raw_value.a], "available": true}
+	return {"value": null, "available": false}
 
 
 func _vector_length(vector_value: Variant) -> Variant:

--- a/addons/agent_runtime_harness/shared/behavior_watch_request_validator.gd
+++ b/addons/agent_runtime_harness/shared/behavior_watch_request_validator.gd
@@ -15,6 +15,13 @@ const SUPPORTED_PROPERTIES := [
 	"movementVector",
 	"speed",
 	"overlapFrames",
+	"text",
+	"linear_velocity",
+	"angular_velocity",
+	"modulate",
+	"visible",
+	"rotation",
+	"scale",
 ]
 const LATER_SLICE_KEYS := [
 	"triggers",
@@ -125,7 +132,7 @@ func _normalize_targets(targets_value: Variant, errors: Array) -> Array:
 					errors.append(_build_error(
 						"unsupported_property",
 						"targets[%d].properties" % index,
-						"Behavior watch property '%s' is not supported in slice 1 or slice 2." % property_name
+						"Behavior watch property '%s' is not in the supported allowlist. Allowed values: %s." % [property_name, ", ".join(SUPPORTED_PROPERTIES)]
 					))
 					continue
 				if seen_properties.has(property_name):

--- a/docs/BEHAVIOR_CAPTURE_SLICES.md
+++ b/docs/BEHAVIOR_CAPTURE_SLICES.md
@@ -326,6 +326,33 @@ If the goal is to debug Pong-like bounce failures quickly with minimal overhead,
 Slice 5 should be added when the game uses custom script-driven motion and the sampled node state is not enough to explain the bug.
 Slice 7 should remain optional until the persisted evidence workflow is proven.
 
+## Watchable properties
+
+Behavior-watch fixtures may name any of the following properties on a target node. The list mixes harness-computed pseudo-properties (camelCase) with direct Godot property reads (snake_case, matching Godot's own naming):
+
+Harness-computed (camelCase):
+
+- `position` — `Node2D.position` serialized as `[x, y]`
+- `velocity` — `CharacterBody2D.velocity` (Vector2 only) serialized as `[x, y]`
+- `intendedVelocity` — `intended_velocity` exported on user scripts (Vector2 only)
+- `movementVector` — `movement_vector` exported on user scripts; falls back to `velocity` if absent
+- `speed` — magnitude of `velocity`
+- `collisionState` — `"contact"` or `"none"` based on `get_slide_collision_count()` (CharacterBody2D)
+- `lastCollider` — node path of the last collider, or `null`
+- `overlapFrames` — frames the same collider has remained in contact
+
+Direct Godot properties (snake_case, read via `node.get(name)`):
+
+- `text` — `Label.text` (and any other `text` property; serialized as a string)
+- `linear_velocity` — `RigidBody2D.linear_velocity` serialized as `[x, y]`
+- `angular_velocity` — `RigidBody2D.angular_velocity` (number)
+- `modulate` — `CanvasItem.modulate` serialized as `[r, g, b, a]`
+- `visible` — `CanvasItem.visible` (boolean)
+- `rotation` — `Node2D.rotation` (number)
+- `scale` — `Node2D.scale` serialized as `[x, y]`
+
+Properties not on this allowlist are rejected at request validation. The error message enumerates the allowed values, both at the JSON-schema layer (`tools/validate-json.ps1` enriches enum violations with allowed values + the offending value) and at the runtime validator layer (`addons/agent_runtime_harness/shared/behavior_watch_request_validator.gd`).
+
 ## First seeded scenario to implement
 
 Use a deterministic Pong fixture that asks for:

--- a/specs/003-editor-evidence-loop/contracts/automation-run-request.schema.json
+++ b/specs/003-editor-evidence-loop/contracts/automation-run-request.schema.json
@@ -192,7 +192,14 @@
               "lastCollider",
               "movementVector",
               "speed",
-              "overlapFrames"
+              "overlapFrames",
+              "text",
+              "linear_velocity",
+              "angular_velocity",
+              "modulate",
+              "visible",
+              "rotation",
+              "scale"
             ]
           }
         }

--- a/specs/005-behavior-watch-sampling/contracts/behavior-trace-row.schema.json
+++ b/specs/005-behavior-watch-sampling/contracts/behavior-trace-row.schema.json
@@ -59,6 +59,39 @@
         "null"
       ],
       "minimum": 0
+    },
+    "text": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "linear_velocity": {
+      "$ref": "#/$defs/vector2"
+    },
+    "angular_velocity": {
+      "type": [
+        "number",
+        "null"
+      ]
+    },
+    "modulate": {
+      "$ref": "#/$defs/color"
+    },
+    "visible": {
+      "type": [
+        "boolean",
+        "null"
+      ]
+    },
+    "rotation": {
+      "type": [
+        "number",
+        "null"
+      ]
+    },
+    "scale": {
+      "$ref": "#/$defs/vector2"
     }
   },
   "$defs": {
@@ -72,6 +105,17 @@
       },
       "minItems": 2,
       "maxItems": 2
+    },
+    "color": {
+      "type": [
+        "array",
+        "null"
+      ],
+      "items": {
+        "type": "number"
+      },
+      "minItems": 4,
+      "maxItems": 4
     }
   }
 }

--- a/specs/005-behavior-watch-sampling/contracts/behavior-watch-request.schema.json
+++ b/specs/005-behavior-watch-sampling/contracts/behavior-watch-request.schema.json
@@ -56,7 +56,14 @@
               "lastCollider",
               "movementVector",
               "speed",
-              "overlapFrames"
+              "overlapFrames",
+              "text",
+              "linear_velocity",
+              "angular_velocity",
+              "modulate",
+              "visible",
+              "rotation",
+              "scale"
             ]
           }
         }

--- a/tools/tests/InvokeRunbookScripts.Tests.ps1
+++ b/tools/tests/InvokeRunbookScripts.Tests.ps1
@@ -137,6 +137,44 @@ Describe 'Resolve-RunbookPayload validate-then-rename (C1)' {
         Test-Path -LiteralPath $script:C1Tmp       | Should -BeFalse
     }
 
+    It 'C1: schema-failure diagnostic enumerates allowed values for enum violations (issue #47)' {
+        # Behavior-watch fixture with a deliberately bogus property name. The orchestrator's
+        # schema-validation diagnostic must now name the offending value AND list the allowed
+        # set so a fixture author can correct it without leaving the diagnostic.
+        $bad = @{
+            requestId       = 'will-be-overwritten'
+            scenarioId      = 'enrichment-test'
+            runId           = 'r'
+            targetScene     = 'res://scenes/main.tscn'
+            outputDirectory = 'res://evidence/automation/x'
+            artifactRoot    = ''
+            capturePolicy   = @{ startup = $true; manual = $true; failure = $true }
+            stopPolicy      = @{ stopAfterValidation = $true }
+            requestedBy     = 'enrichment-test'
+            createdAt       = '2026-05-02T00:00:00Z'
+            behaviorWatchRequest = @{
+                targets = @(@{ nodePath = '/root/Main/Foo'; properties = @('position_xyz') })
+                frameCount = 5
+            }
+        } | ConvertTo-Json -Depth 6
+
+        $err = $null
+        try {
+            Resolve-RunbookPayload `
+                -InlineJson $bad `
+                -RequestId 'runbook-c1-enum-enriched' `
+                -ProjectRoot $script:C1Root
+        }
+        catch {
+            $err = $_.Exception.Message
+        }
+
+        $err | Should -Not -BeNullOrEmpty
+        $err | Should -Match 'does not satisfy schema'
+        $err | Should -Match "has value 'position_xyz'"
+        $err | Should -Match 'allowed values:.*text.*linear_velocity'
+    }
+
     It 'C2 follow-up: Resolve-RunbookEvidencePath joins relative paths against ProjectRoot' {
         # Evidence paths from run-result/manifest are project-relative, not repo-relative.
         # Use TestDrive so the assertion holds on any OS (Windows / macOS / Linux),

--- a/tools/tests/ValidateJson.Tests.ps1
+++ b/tools/tests/ValidateJson.Tests.ps1
@@ -90,4 +90,75 @@ Describe 'tools/validate-json.ps1' {
         $result.valid | Should -BeFalse
         $result.error | Should -Not -BeNullOrEmpty
     }
+
+    Context 'enum-violation enrichment' {
+        BeforeAll {
+            $script:EnrichSchema = @'
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "properties": {
+    "props": {
+      "type": "array",
+      "items": { "type": "string", "enum": ["a", "b", "c"] }
+    },
+    "ref": { "$ref": "#/$defs/refTarget" }
+  },
+  "$defs": {
+    "refTarget": { "type": "string", "enum": ["alpha", "beta"] }
+  }
+}
+'@
+        }
+
+        It 'appends offending value and allowed values when an enum is violated' {
+            $jsonPath = Join-Path $TestDrive 'enum-bad.json'
+            $schemaPath = Join-Path $TestDrive 'enum-schema.json'
+            Set-Content -LiteralPath $jsonPath -Value '{"props":["a","x","b"]}' -NoNewline
+            Set-Content -LiteralPath $schemaPath -Value $script:EnrichSchema -NoNewline
+
+            $result = Invoke-RepoJsonScript -ScriptPath 'tools/validate-json.ps1' -Arguments @(
+                '-InputPath', $jsonPath,
+                '-SchemaPath', $schemaPath,
+                '-AllowInvalid'
+            )
+
+            $result.ParsedOutput.valid | Should -BeFalse
+            $result.ParsedOutput.error | Should -Match "Property at '/props/1' has value 'x'"
+            $result.ParsedOutput.error | Should -Match 'allowed values: a, b, c'
+        }
+
+        It 'walks $ref into $defs to find the enum' {
+            $jsonPath = Join-Path $TestDrive 'enum-ref-bad.json'
+            $schemaPath = Join-Path $TestDrive 'enum-ref-schema.json'
+            Set-Content -LiteralPath $jsonPath -Value '{"ref":"gamma"}' -NoNewline
+            Set-Content -LiteralPath $schemaPath -Value $script:EnrichSchema -NoNewline
+
+            $result = Invoke-RepoJsonScript -ScriptPath 'tools/validate-json.ps1' -Arguments @(
+                '-InputPath', $jsonPath,
+                '-SchemaPath', $schemaPath,
+                '-AllowInvalid'
+            )
+
+            $result.ParsedOutput.valid | Should -BeFalse
+            $result.ParsedOutput.error | Should -Match "Property at '/ref' has value 'gamma'"
+            $result.ParsedOutput.error | Should -Match 'allowed values: alpha, beta'
+        }
+
+        It 'leaves non-enum failures unenriched' {
+            $jsonPath = Join-Path $TestDrive 'type-bad.json'
+            $schemaPath = Join-Path $TestDrive 'type-schema.json'
+            Set-Content -LiteralPath $jsonPath -Value '{"props":42}' -NoNewline
+            Set-Content -LiteralPath $schemaPath -Value $script:EnrichSchema -NoNewline
+
+            $result = Invoke-RepoJsonScript -ScriptPath 'tools/validate-json.ps1' -Arguments @(
+                '-InputPath', $jsonPath,
+                '-SchemaPath', $schemaPath,
+                '-AllowInvalid'
+            )
+
+            $result.ParsedOutput.valid | Should -BeFalse
+            $result.ParsedOutput.error | Should -Not -Match 'allowed values:'
+        }
+    }
 }

--- a/tools/tests/fixtures/issue-47/bogus-property-pong.json
+++ b/tools/tests/fixtures/issue-47/bogus-property-pong.json
@@ -1,0 +1,27 @@
+{
+  "requestId": "issue-47-bogus-property-FIXTURE",
+  "scenarioId": "issue-47-error-enrichment-test",
+  "runId": "issue-47-bogus-property-run",
+  "targetScene": "res://scenes/main.tscn",
+  "outputDirectory": "res://evidence/automation/$REQUEST_ID",
+  "artifactRoot": "res://evidence/automation/$REQUEST_ID",
+  "capturePolicy": {
+    "startup": true,
+    "manual": true,
+    "failure": true
+  },
+  "stopPolicy": {
+    "stopAfterValidation": true
+  },
+  "requestedBy": "issue-47-error-enrichment",
+  "createdAt": "2026-05-02T00:00:00Z",
+  "behaviorWatchRequest": {
+    "targets": [
+      {
+        "nodePath": "/root/Main/HUD/ScoreLeftLabel",
+        "properties": ["position_xyz"]
+      }
+    ],
+    "frameCount": 5
+  }
+}

--- a/tools/tests/fixtures/issue-47/expected-after/bogus-property-pong-envelope.json
+++ b/tools/tests/fixtures/issue-47/expected-after/bogus-property-pong-envelope.json
@@ -1,0 +1,8 @@
+{
+  "_comment": "Captured 2026-05-02T21:01 against D:/gameDev/pong after applying issue #47 fix. Diagnostic now names the offending value AND enumerates all 15 allowed values inline.",
+  "status": "failure",
+  "failureKind": "request-invalid",
+  "diagnostics": [
+    "Run request does not satisfy schema 'specs/003-editor-evidence-loop/contracts/automation-run-request.schema.json': The JSON is not valid with the schema: Value should match one of the values specified by the enum at '/behaviorWatchRequest/targets/0/properties/0'\nProperty at '/behaviorWatchRequest/targets/0/properties/0' has value 'position_xyz'; allowed values: position, velocity, intendedVelocity, collisionState, lastCollider, movementVector, speed, overlapFrames, text, linear_velocity, angular_velocity, modulate, visible, rotation, scale."
+  ]
+}

--- a/tools/tests/fixtures/issue-47/expected-after/linear-velocity-watch-pong-trace-excerpt.jsonl
+++ b/tools/tests/fixtures/issue-47/expected-after/linear-velocity-watch-pong-trace-excerpt.jsonl
@@ -1,0 +1,3 @@
+{"frame":2,"linear_velocity":[-324.388610839844,-223.694885253906],"nodePath":"/root/Main/Ball","timestampMs":0}
+{"frame":3,"linear_velocity":[-323.847961425781,-223.322067260742],"nodePath":"/root/Main/Ball","timestampMs":18}
+{"frame":4,"linear_velocity":[-323.308227539063,-222.949859619141],"nodePath":"/root/Main/Ball","timestampMs":30}

--- a/tools/tests/fixtures/issue-47/expected-after/text-watch-pong-trace-excerpt.jsonl
+++ b/tools/tests/fixtures/issue-47/expected-after/text-watch-pong-trace-excerpt.jsonl
@@ -1,0 +1,2 @@
+{"frame":4,"nodePath":"/root/Main/HUD/ScoreLeftLabel","text":"0","timestampMs":17}
+{"frame":5,"nodePath":"/root/Main/HUD/ScoreLeftLabel","text":"0","timestampMs":26}

--- a/tools/tests/fixtures/issue-47/expected-before/linear-velocity-watch-pong-envelope.json
+++ b/tools/tests/fixtures/issue-47/expected-before/linear-velocity-watch-pong-envelope.json
@@ -1,0 +1,8 @@
+{
+  "_comment": "Captured 2026-05-02T20:27 against D:/gameDev/pong using harness commit 62b76aa. Phase A reproduction of issue #47.",
+  "status": "failure",
+  "failureKind": "request-invalid",
+  "diagnostics": [
+    "Run request does not satisfy schema 'specs/003-editor-evidence-loop/contracts/automation-run-request.schema.json': The JSON is not valid with the schema: Value should match one of the values specified by the enum at '/behaviorWatchRequest/targets/0/properties/0'"
+  ]
+}

--- a/tools/tests/fixtures/issue-47/expected-before/text-watch-pong-envelope.json
+++ b/tools/tests/fixtures/issue-47/expected-before/text-watch-pong-envelope.json
@@ -1,0 +1,8 @@
+{
+  "_comment": "Captured 2026-05-02T20:27 against D:/gameDev/pong using harness commit 62b76aa. Phase A reproduction of issue #47. Diagnostic surfaces only the JSON pointer with no allowed-values hint, demonstrating the bug.",
+  "status": "failure",
+  "failureKind": "request-invalid",
+  "diagnostics": [
+    "Run request does not satisfy schema 'specs/003-editor-evidence-loop/contracts/automation-run-request.schema.json': The JSON is not valid with the schema: Value should match one of the values specified by the enum at '/behaviorWatchRequest/targets/0/properties/0'"
+  ]
+}

--- a/tools/tests/fixtures/issue-47/linear-velocity-watch-pong.json
+++ b/tools/tests/fixtures/issue-47/linear-velocity-watch-pong.json
@@ -1,0 +1,27 @@
+{
+  "requestId": "issue-47-linear-velocity-pong-FIXTURE",
+  "scenarioId": "issue-47-linear-velocity-watch",
+  "runId": "issue-47-linear-velocity-run",
+  "targetScene": "res://scenes/main.tscn",
+  "outputDirectory": "res://evidence/automation/$REQUEST_ID",
+  "artifactRoot": "res://evidence/automation/$REQUEST_ID",
+  "capturePolicy": {
+    "startup": true,
+    "manual": true,
+    "failure": true
+  },
+  "stopPolicy": {
+    "stopAfterValidation": true
+  },
+  "requestedBy": "issue-47-repro",
+  "createdAt": "2026-05-02T00:00:00Z",
+  "behaviorWatchRequest": {
+    "targets": [
+      {
+        "nodePath": "/root/Main/Ball",
+        "properties": ["linear_velocity"]
+      }
+    ],
+    "frameCount": 30
+  }
+}

--- a/tools/tests/fixtures/issue-47/regression-original-props-pong.json
+++ b/tools/tests/fixtures/issue-47/regression-original-props-pong.json
@@ -1,0 +1,27 @@
+{
+  "requestId": "issue-47-regression-FIXTURE",
+  "scenarioId": "issue-47-regression-original-props",
+  "runId": "issue-47-regression-run",
+  "targetScene": "res://scenes/main.tscn",
+  "outputDirectory": "res://evidence/automation/$REQUEST_ID",
+  "artifactRoot": "res://evidence/automation/$REQUEST_ID",
+  "capturePolicy": {
+    "startup": true,
+    "manual": true,
+    "failure": true
+  },
+  "stopPolicy": {
+    "stopAfterValidation": true
+  },
+  "requestedBy": "issue-47-regression",
+  "createdAt": "2026-05-02T00:00:00Z",
+  "behaviorWatchRequest": {
+    "targets": [
+      {
+        "nodePath": "/root/Main/Ball",
+        "properties": ["position", "velocity", "collisionState", "lastCollider", "speed"]
+      }
+    ],
+    "frameCount": 30
+  }
+}

--- a/tools/tests/fixtures/issue-47/text-watch-pong.json
+++ b/tools/tests/fixtures/issue-47/text-watch-pong.json
@@ -1,0 +1,27 @@
+{
+  "requestId": "issue-47-text-watch-pong-FIXTURE",
+  "scenarioId": "issue-47-text-watch",
+  "runId": "issue-47-text-watch-run",
+  "targetScene": "res://scenes/main.tscn",
+  "outputDirectory": "res://evidence/automation/$REQUEST_ID",
+  "artifactRoot": "res://evidence/automation/$REQUEST_ID",
+  "capturePolicy": {
+    "startup": true,
+    "manual": true,
+    "failure": true
+  },
+  "stopPolicy": {
+    "stopAfterValidation": true
+  },
+  "requestedBy": "issue-47-repro",
+  "createdAt": "2026-05-02T00:00:00Z",
+  "behaviorWatchRequest": {
+    "targets": [
+      {
+        "nodePath": "/root/Main/HUD/ScoreLeftLabel",
+        "properties": ["text"]
+      }
+    ],
+    "frameCount": 30
+  }
+}

--- a/tools/tests/fixtures/runbook/behavior-watch/label-text-window.json
+++ b/tools/tests/fixtures/runbook/behavior-watch/label-text-window.json
@@ -1,0 +1,27 @@
+{
+  "requestId": "runbook-behavior-watch-label-text-FIXTURE",
+  "scenarioId": "runbook-behavior-watch-label-text",
+  "runId": "runbook-behavior-watch-label-text-run",
+  "targetScene": "res://scenes/main.tscn",
+  "outputDirectory": "res://evidence/automation/$REQUEST_ID",
+  "artifactRoot": "tools/tests/fixtures/runbook/behavior-watch/evidence",
+  "capturePolicy": {
+    "startup": true,
+    "manual": true,
+    "failure": true
+  },
+  "stopPolicy": {
+    "stopAfterValidation": true
+  },
+  "requestedBy": "runbook-fixture",
+  "createdAt": "2026-05-02T00:00:00Z",
+  "behaviorWatchRequest": {
+    "targets": [
+      {
+        "nodePath": "/root/Main/HUD/ScoreLeftLabel",
+        "properties": ["text", "visible"]
+      }
+    ],
+    "frameCount": 10
+  }
+}

--- a/tools/validate-json.ps1
+++ b/tools/validate-json.ps1
@@ -28,11 +28,123 @@ function Resolve-RepoPath {
     return (Resolve-Path -LiteralPath (Join-Path $repoRoot $Path)).Path
 }
 
+function ConvertTo-PointerToken {
+    param([Parameter(Mandatory = $true)][string]$RawToken)
+    return $RawToken.Replace('~1', '/').Replace('~0', '~')
+}
+
+function Resolve-JsonPointer {
+    param(
+        [Parameter(Mandatory = $true)] $Root,
+        [Parameter(Mandatory = $true)] [string[]]$Tokens
+    )
+
+    $cursor = $Root
+    foreach ($token in $Tokens) {
+        if ($null -eq $cursor) { return $null }
+        if ($cursor -is [System.Collections.IList] -and $cursor -isnot [string]) {
+            if ($token -notmatch '^\d+$') { return $null }
+            $idx = [int]$token
+            if ($idx -lt 0 -or $idx -ge $cursor.Count) { return $null }
+            $cursor = $cursor[$idx]
+            continue
+        }
+        if ($cursor -is [psobject]) {
+            $prop = $cursor.PSObject.Properties[$token]
+            if ($null -eq $prop) { return $null }
+            $cursor = $prop.Value
+            continue
+        }
+        return $null
+    }
+    return $cursor
+}
+
+function Resolve-SchemaForInstancePointer {
+    param(
+        [Parameter(Mandatory = $true)] $RootSchema,
+        [Parameter(Mandatory = $true)] [string[]]$InstanceTokens
+    )
+
+    $node = $RootSchema
+    $node = Resolve-SchemaRefs -RootSchema $RootSchema -Node $node
+    foreach ($token in $InstanceTokens) {
+        if ($null -eq $node) { return $null }
+        if ($token -match '^\d+$' -and $node.PSObject.Properties['items']) {
+            $node = $node.items
+        }
+        elseif ($node.PSObject.Properties['properties'] -and $node.properties.PSObject.Properties[$token]) {
+            $node = $node.properties.$token
+        }
+        else {
+            return $null
+        }
+        $node = Resolve-SchemaRefs -RootSchema $RootSchema -Node $node
+    }
+    return $node
+}
+
+function Resolve-SchemaRefs {
+    param(
+        [Parameter(Mandatory = $true)] $RootSchema,
+        $Node
+    )
+
+    $guard = 0
+    while ($null -ne $Node -and $Node -is [psobject] -and $Node.PSObject.Properties['$ref']) {
+        $guard++
+        if ($guard -gt 16) { return $Node }
+        $ref = [string]$Node.'$ref'
+        if (-not $ref.StartsWith('#/')) { return $Node }
+        $tokens = $ref.Substring(2).Split('/') | ForEach-Object { ConvertTo-PointerToken -RawToken $_ }
+        $Node = Resolve-JsonPointer -Root $RootSchema -Tokens $tokens
+    }
+    return $Node
+}
+
+function Get-EnumEnrichment {
+    param(
+        [Parameter(Mandatory = $true)] [string]$ValidationMessage,
+        [Parameter(Mandatory = $true)] [string]$InputJsonText,
+        [Parameter(Mandatory = $true)] [string]$SchemaJsonText
+    )
+
+    $match = [regex]::Match($ValidationMessage, "enum at '(?<pointer>[^']*)'")
+    if (-not $match.Success) { return $null }
+
+    $pointer = $match.Groups['pointer'].Value
+    $tokens = @()
+    if ($pointer.StartsWith('/')) {
+        $tokens = $pointer.Substring(1).Split('/') | ForEach-Object { ConvertTo-PointerToken -RawToken $_ }
+    }
+
+    $schemaRoot = $null
+    $inputRoot = $null
+    try {
+        $schemaRoot = $SchemaJsonText | ConvertFrom-Json -Depth 100
+        $inputRoot = $InputJsonText | ConvertFrom-Json -Depth 100
+    }
+    catch {
+        return $null
+    }
+
+    $offendingValue = Resolve-JsonPointer -Root $inputRoot -Tokens $tokens
+    $subSchema = Resolve-SchemaForInstancePointer -RootSchema $schemaRoot -InstanceTokens $tokens
+    if ($null -eq $subSchema -or -not ($subSchema -is [psobject]) -or -not $subSchema.PSObject.Properties['enum']) {
+        return $null
+    }
+
+    $allowed = @($subSchema.enum | ForEach-Object { [string]$_ })
+    $offendingDisplay = if ($null -eq $offendingValue) { '<missing>' } else { [string]$offendingValue }
+    return "Property at '$pointer' has value '$offendingDisplay'; allowed values: $($allowed -join ', ')."
+}
+
 $resolvedInputPath = Resolve-RepoPath -Path $InputPath
 $resolvedSchemaPath = Resolve-RepoPath -Path $SchemaPath
 
 $isValid = $true
 $validationError = $null
+$jsonText = $null
 
 try {
     $jsonText = Get-Content -LiteralPath $resolvedInputPath -Raw
@@ -51,12 +163,27 @@ $result = [ordered]@{
 }
 
 if (-not $isValid) {
-    $result.error = if ($null -ne $validationError) {
+    $message = if ($null -ne $validationError) {
         $validationError
     }
     else {
         'JSON validation failed against the supplied schema.'
     }
+
+    if ($null -ne $jsonText -and $message -match "enum at '") {
+        try {
+            $schemaText = Get-Content -LiteralPath $resolvedSchemaPath -Raw
+            $enriched = Get-EnumEnrichment -ValidationMessage $message -InputJsonText $jsonText -SchemaJsonText $schemaText
+            if ($null -ne $enriched) {
+                $message = "$message`n$enriched"
+            }
+        }
+        catch {
+            # Enrichment is best-effort; fall through to the raw message on any failure.
+        }
+    }
+
+    $result.error = $message
 }
 
 if ($PassThru) {


### PR DESCRIPTION
## Summary

Closes #47.

- Expands the behavior-watch property allowlist with `text`, `linear_velocity`, `angular_velocity`, `modulate`, `visible`, `rotation`, `scale` across both schemas, the editor-side validator, and the trace-row schema.
- Adds a generic-property fallback to the runtime sampler that serializes Variant types (bool / int / float / String / Vector2 / Vector2i / Color) so future direct property reads land in one branch instead of four touch-points per property.
- Enriches `tools/validate-json.ps1` to walk JSON pointers (with `\$ref`/`\$defs` resolution) and append `Property at 'X' has value 'Y'; allowed values: ...` to enum violations, so fixture authors no longer need to leave the diagnostic to fix a request.

## Why this matters

Before this fix, the harness rejected `text` on Label and `linear_velocity` on RigidBody2D with diagnostics that named only the JSON pointer. In Pong this actively hid a shipping bug: the goal-scoring code was visibly broken (score labels stayed at \"0\"), but the proxy verification (watch ball-position resets) reported PASS. The harness silently agreed that a broken game was working — exactly the failure mode an evidence harness must not have. With direct \`text\` watching, the trace would have shown labels stuck at \"0\" while resets fired, and the bug would have been impossible to miss.

## Verified end-to-end against D:/gameDev/pong

- \`text\` watch on \`/root/Main/HUD/ScoreLeftLabel\` → \`trace.jsonl\` rows: \`{\"text\":\"0\", ...}\`
- \`linear_velocity\` on \`/root/Main/Ball\` → \`trace.jsonl\` rows: \`{\"linear_velocity\":[-324.39,-223.69], ...}\`
- bogus property \`position_xyz\` → diagnostic now reads: \`Property at '...' has value 'position_xyz'; allowed values: position, velocity, intendedVelocity, ..., text, linear_velocity, ...\`
- regression: original computed properties (\`position\`, \`velocity\`, \`collisionState\`, \`lastCollider\`, \`speed\`) unchanged.

Before/after evidence is checked in under [tools/tests/fixtures/issue-47/expected-before/](tools/tests/fixtures/issue-47/expected-before/) and [tools/tests/fixtures/issue-47/expected-after/](tools/tests/fixtures/issue-47/expected-after/).

## Mixed casing — deliberate

\`text\`, \`linear_velocity\`, etc. are snake_case because that's what Godot uses for engine properties; \`intendedVelocity\`, \`collisionState\`, etc. stay camelCase because they are harness-computed pseudo-properties (collision-state derivation, velocity-magnitude speed, snake_case alias support, etc.). Documented in the new \"Watchable properties\" section of [docs/BEHAVIOR_CAPTURE_SLICES.md](docs/BEHAVIOR_CAPTURE_SLICES.md).

## Test plan

- [x] \`pwsh ./tools/check-addon-parse.ps1\` — addon parses cleanly
- [x] \`pwsh ./tools/tests/run-tool-tests.ps1\` — 349/349 Pester tests pass (4 new: 3 in \`ValidateJson.Tests.ps1\` for enum enrichment + ref-walking + non-enum fall-through, 1 in \`InvokeRunbookScripts.Tests.ps1\` for orchestrator-level enriched diagnostic)
- [x] Live integration on D:/gameDev/pong: text-watch, linear_velocity-watch, bogus-property error enrichment, regression on original properties

🤖 Generated with [Claude Code](https://claude.com/claude-code)