### PR TITLE
fix: reject behavior-watch with insufficient minRuntimeFrames (#46)

### DIFF
--- a/.claude/skills/godot-watch/SKILL.md
+++ b/.claude/skills/godot-watch/SKILL.md
@@ -31,8 +31,16 @@ Or with inline JSON (when no fixture fits):
 ```powershell
 pwsh ./tools/automation/invoke-behavior-watch.ps1 `
   -ProjectRoot "<project-root>" `
-  -RequestJson '{"requestId":"placeholder","scenarioId":"runbook-behavior-watch","runId":"runbook-behavior-watch","targetScene":"<main scene>","outputDirectory":"res://evidence/automation/agent","artifactRoot":"evidence/automation/agent","capturePolicy":{"startup":true},"stopPolicy":{"stopAfterValidation":true},"requestedBy":"agent","createdAt":"<UTC ISO-8601>","behaviorWatchRequest":{"targets":[{"nodePath":"/root/Main/Paddle","properties":["position"]}],"frameCount":10}}'
+  -RequestJson '{"requestId":"placeholder","scenarioId":"runbook-behavior-watch","runId":"runbook-behavior-watch","targetScene":"<main scene>","outputDirectory":"res://evidence/automation/agent","artifactRoot":"evidence/automation/agent","capturePolicy":{"startup":true},"stopPolicy":{"stopAfterValidation":true,"minRuntimeFrames":10},"requestedBy":"agent","createdAt":"<UTC ISO-8601>","behaviorWatchRequest":{"targets":[{"nodePath":"/root/Main/Paddle","properties":["position"]}],"frameCount":10}}'
 ```
+
+## Lifetime requirement
+
+A behavior watch needs the playtest to live `startFrameOffset + frameCount` process frames after launch. The B18 fix made the post-validation stop unconditional, so `stopAfterValidation: false` does **not** by itself buy you more frames. The only knob that does is `stopPolicy.minRuntimeFrames`:
+
+- Set `stopPolicy.minRuntimeFrames` ≥ `startFrameOffset + frameCount` — this delays the validation-pass stop until the watch window has filled. The shipped fixtures use this shape.
+
+If you forget, the harness rejects the request with a diagnostic containing `incompatible_stop_policy` that names the required value. The pre-existing silent-truncation behavior (request 30 frames, get 2 rows, status: success) was fixed in issue #46.
 
 ## Envelope fields
 

--- a/addons/agent_runtime_harness/editor/scenegraph_run_coordinator.gd
+++ b/addons/agent_runtime_harness/editor/scenegraph_run_coordinator.gd
@@ -941,7 +941,11 @@ func _resolve_request(config: Dictionary, request: Dictionary, capability: Dicti
 
 	var behavior_watch_request := _resolve_behavior_watch_request(default_overrides, request, overrides)
 	if not behavior_watch_request.is_empty():
-		var watch_validation := _watch_request_validator.normalize_request(behavior_watch_request, String(resolved.get("runId", "")))
+		var watch_validation := _watch_request_validator.normalize_request(
+			behavior_watch_request,
+			String(resolved.get("runId", "")),
+			resolved.get("stopPolicy", {})
+		)
 		resolved["behaviorWatchValidation"] = watch_validation
 		if bool(watch_validation.get("accepted", false)):
 			resolved["behaviorWatchRequest"] = watch_validation.get("request", {}).duplicate(true)

--- a/addons/agent_runtime_harness/shared/behavior_watch_request_validator.gd
+++ b/addons/agent_runtime_harness/shared/behavior_watch_request_validator.gd
@@ -33,7 +33,7 @@ const LATER_SLICE_KEYS := [
 ]
 
 
-func normalize_request(request_value: Variant, run_id: String) -> Dictionary:
+func normalize_request(request_value: Variant, run_id: String, stop_policy: Dictionary = {}) -> Dictionary:
 	if typeof(request_value) != TYPE_DICTIONARY:
 		return _build_rejection([
 			_build_error("invalid_request", "behaviorWatchRequest", "Behavior watch request must be an object."),
@@ -59,6 +59,20 @@ func normalize_request(request_value: Variant, run_id: String) -> Dictionary:
 		"Behavior watch frameCount must be a positive integer.",
 		errors
 	)
+
+	if frame_count > 0:
+		# B18 made the post-validation stop unconditional regardless of
+		# stopAfterValidation, so minRuntimeFrames is the only knob that
+		# actually grants the playtest enough frames to fill the watch window.
+		# The constraint is therefore independent of stopAfterValidation.
+		var min_runtime_frames := int(stop_policy.get("minRuntimeFrames", 0))
+		var required_frames := start_frame_offset + frame_count
+		if min_runtime_frames < required_frames:
+			errors.append(_build_error(
+				"incompatible_stop_policy",
+				"stopPolicy.minRuntimeFrames",
+				"behaviorWatchRequest needs the playtest to live at least %d frame(s) (startFrameOffset=%d + frameCount=%d). Set stopPolicy.minRuntimeFrames>=%d to delay the validation-pass stop until the watch window has filled. Current: minRuntimeFrames=%d." % [required_frames, start_frame_offset, frame_count, required_frames, min_runtime_frames]
+			))
 
 	if not errors.is_empty():
 		return _build_rejection(errors)

--- a/addons/agent_runtime_harness/templates/project_root/.claude/skills/godot-watch/SKILL.md
+++ b/addons/agent_runtime_harness/templates/project_root/.claude/skills/godot-watch/SKILL.md
@@ -33,8 +33,12 @@ Or with inline JSON:
 ```powershell
 pwsh {{HARNESS_REPO_ROOT}}/tools/automation/invoke-behavior-watch.ps1 `
   -ProjectRoot "<project-root>" -EnsureEditor `
-  -RequestJson '{"requestId":"placeholder","scenarioId":"runbook-behavior-watch","runId":"runbook-behavior-watch","targetScene":"<main scene>","outputDirectory":"res://evidence/automation/agent","artifactRoot":"evidence/automation/agent","capturePolicy":{"startup":true},"stopPolicy":{"stopAfterValidation":true},"requestedBy":"agent","createdAt":"<UTC ISO-8601>","behaviorWatchRequest":{"targets":[{"nodePath":"/root/Main/Paddle","properties":["position"]}],"frameCount":10}}'
+  -RequestJson '{"requestId":"placeholder","scenarioId":"runbook-behavior-watch","runId":"runbook-behavior-watch","targetScene":"<main scene>","outputDirectory":"res://evidence/automation/agent","artifactRoot":"evidence/automation/agent","capturePolicy":{"startup":true},"stopPolicy":{"stopAfterValidation":true,"minRuntimeFrames":10},"requestedBy":"agent","createdAt":"<UTC ISO-8601>","behaviorWatchRequest":{"targets":[{"nodePath":"/root/Main/Paddle","properties":["position"]}],"frameCount":10}}'
 ```
+
+## Lifetime requirement
+
+A behavior watch needs the playtest to live `startFrameOffset + frameCount` process frames. The post-validation stop is unconditional (B18 fix), so the only knob that grants more frames is `stopPolicy.minRuntimeFrames`. Set it to ≥ `startFrameOffset + frameCount`. If you forget, the harness rejects the request with a diagnostic containing `incompatible_stop_policy` naming the required value.
 
 ## Envelope fields
 

--- a/tools/tests/BehaviorWatchStopPolicyGate.Tests.ps1
+++ b/tools/tests/BehaviorWatchStopPolicyGate.Tests.ps1
@@ -1,0 +1,142 @@
+Describe 'issue #46: behavior-watch + stopAfterValidation cross-field gate' {
+    BeforeAll {
+        . (Join-Path $PSScriptRoot 'TestHelpers.ps1')
+        $script:RequestSchemaPath = 'specs/003-editor-evidence-loop/contracts/automation-run-request.schema.json'
+    }
+
+    # The cross-field rule "stopAfterValidation=true requires minRuntimeFrames >=
+    # startFrameOffset + frameCount when behaviorWatchRequest is present" is
+    # enforced inside Godot by behavior_watch_request_validator.normalize_request,
+    # NOT by JSON Schema. These Pester tests assert the schema layer is
+    # intentionally permissive so that the GDScript validator's diagnostic
+    # (failureKind=request-invalid, code=incompatible_stop_policy) is the single
+    # source of truth for this constraint. The actual rejection is exercised by
+    # the live-editor integration tests (see tools/tests/fixtures/issue-46/).
+    It 'schema accepts the bad combination (rejection lives in GDScript validator)' {
+        $payload = @{
+            requestId            = 'issue-46-schema-permissive'
+            scenarioId           = 'issue-46'
+            runId                = 'issue-46-run'
+            targetScene          = 'res://scenes/main.tscn'
+            outputDirectory      = 'res://evidence/automation/x'
+            artifactRoot         = ''
+            expectationFiles     = @()
+            capturePolicy        = @{ startup = $true; manual = $true; failure = $true }
+            stopPolicy           = @{ stopAfterValidation = $true }
+            requestedBy          = 'issue-46'
+            createdAt            = '2026-05-02T00:00:00Z'
+            behaviorWatchRequest = @{
+                targets    = @(@{ nodePath = '/root/Main/Ball'; properties = @('linear_velocity') })
+                frameCount = 30
+            }
+        } | ConvertTo-Json -Depth 8
+
+        $tmpPath = Join-Path $TestDrive 'issue-46-schema-bad-combo.json'
+        Set-Content -LiteralPath $tmpPath -Value $payload -NoNewline -Encoding utf8
+
+        $result = & (Get-RepoPath -Path 'tools/validate-json.ps1') -InputPath $tmpPath -SchemaPath $script:RequestSchemaPath -PassThru -AllowInvalid
+        $result.valid | Should -BeTrue
+    }
+
+    It 'schema accepts the minRuntimeFrames remediation' {
+        $payload = @{
+            requestId            = 'issue-46-min-runtime-frames'
+            scenarioId           = 'issue-46'
+            runId                = 'issue-46-run'
+            targetScene          = 'res://scenes/main.tscn'
+            outputDirectory      = 'res://evidence/automation/x'
+            artifactRoot         = ''
+            expectationFiles     = @()
+            capturePolicy        = @{ startup = $true; manual = $true; failure = $true }
+            stopPolicy           = @{ stopAfterValidation = $true; minRuntimeFrames = 30 }
+            requestedBy          = 'issue-46'
+            createdAt            = '2026-05-02T00:00:00Z'
+            behaviorWatchRequest = @{
+                targets    = @(@{ nodePath = '/root/Main/Ball'; properties = @('linear_velocity') })
+                frameCount = 30
+            }
+        } | ConvertTo-Json -Depth 8
+
+        $tmpPath = Join-Path $TestDrive 'issue-46-schema-fixed-min-runtime.json'
+        Set-Content -LiteralPath $tmpPath -Value $payload -NoNewline -Encoding utf8
+
+        $result = & (Get-RepoPath -Path 'tools/validate-json.ps1') -InputPath $tmpPath -SchemaPath $script:RequestSchemaPath -PassThru -AllowInvalid
+        $result.valid | Should -BeTrue
+    }
+
+    It 'schema accepts startFrameOffset > 0 with matching minRuntimeFrames' {
+        $payload = @{
+            requestId            = 'issue-46-with-offset'
+            scenarioId           = 'issue-46'
+            runId                = 'issue-46-run'
+            targetScene          = 'res://scenes/main.tscn'
+            outputDirectory      = 'res://evidence/automation/x'
+            artifactRoot         = ''
+            expectationFiles     = @()
+            capturePolicy        = @{ startup = $true; manual = $true; failure = $true }
+            stopPolicy           = @{ stopAfterValidation = $true; minRuntimeFrames = 16 }
+            requestedBy          = 'issue-46'
+            createdAt            = '2026-05-02T00:00:00Z'
+            behaviorWatchRequest = @{
+                targets           = @(@{ nodePath = '/root/Main/Ball'; properties = @('linear_velocity') })
+                startFrameOffset  = 12
+                frameCount        = 4
+            }
+        } | ConvertTo-Json -Depth 8
+
+        $tmpPath = Join-Path $TestDrive 'issue-46-schema-fixed-offset.json'
+        Set-Content -LiteralPath $tmpPath -Value $payload -NoNewline -Encoding utf8
+
+        $result = & (Get-RepoPath -Path 'tools/validate-json.ps1') -InputPath $tmpPath -SchemaPath $script:RequestSchemaPath -PassThru -AllowInvalid
+        $result.valid | Should -BeTrue
+    }
+
+    It 'every shipped behavior-watch fixture satisfies the lifetime constraint' {
+        # Defense in depth: scan every fixture that ships with a behaviorWatchRequest
+        # and assert the lifetime constraint holds, so a future fixture author
+        # cannot reintroduce the silent-truncation bug without breaking this test.
+        $repoRoot = $script:RepoRoot
+        $fixtureRoots = @(
+            (Join-Path $repoRoot 'tools/tests/fixtures/runbook/behavior-watch'),
+            (Join-Path $repoRoot 'tools/tests/fixtures/pong-testbed/harness/automation/requests'),
+            (Join-Path $repoRoot 'tools/tests/fixtures/issue-46'),
+            (Join-Path $repoRoot 'tools/tests/fixtures/issue-47')
+        )
+
+        $offending = New-Object System.Collections.Generic.List[string]
+        foreach ($root in $fixtureRoots) {
+            if (-not (Test-Path -LiteralPath $root)) { continue }
+            Get-ChildItem -LiteralPath $root -Filter '*.json' -Recurse -File | ForEach-Object {
+                # Skip envelope-style fixtures under expected-before/expected-after dirs;
+                # those describe orchestrator outputs, not requests.
+                if ($_.FullName -match '\\expected-(before|after)\\') { return }
+                $raw = Get-Content -LiteralPath $_.FullName -Raw
+                $obj = $null
+                try { $obj = $raw | ConvertFrom-Json -Depth 20 } catch { return }
+                if ($null -eq $obj) { return }
+                $watch = $null
+                if ($obj.PSObject.Properties['behaviorWatchRequest']) { $watch = $obj.behaviorWatchRequest }
+                elseif ($obj.PSObject.Properties['overrides'] -and $obj.overrides.PSObject.Properties['behaviorWatchRequest']) { $watch = $obj.overrides.behaviorWatchRequest }
+                if ($null -eq $watch) { return }
+                $frameCount = if ($watch.PSObject.Properties['frameCount']) { [int]$watch.frameCount } else { 0 }
+                if ($frameCount -le 0) { return }
+                $startOffset = if ($watch.PSObject.Properties['startFrameOffset']) { [int]$watch.startFrameOffset } else { 0 }
+                $required = $startOffset + $frameCount
+                $stopAfter = $true
+                $minRuntime = 0
+                if ($obj.PSObject.Properties['stopPolicy']) {
+                    if ($obj.stopPolicy.PSObject.Properties['stopAfterValidation']) { $stopAfter = [bool]$obj.stopPolicy.stopAfterValidation }
+                    if ($obj.stopPolicy.PSObject.Properties['minRuntimeFrames']) { $minRuntime = [int]$obj.stopPolicy.minRuntimeFrames }
+                }
+                # The deliberate truncation-repro fixture is the one expected
+                # offender — it exists to demonstrate the rejection diagnostic.
+                if ($_.Name -eq 'truncation-repro-pong.json') { return }
+                if ($stopAfter -and $minRuntime -lt $required) {
+                    $offending.Add(("{0} (required={1}, minRuntimeFrames={2}, stopAfterValidation=true)" -f $_.FullName, $required, $minRuntime))
+                }
+            }
+        }
+
+        $offending | Should -BeNullOrEmpty -Because 'shipped behavior-watch fixtures must either set stopAfterValidation=false OR minRuntimeFrames >= startFrameOffset + frameCount, otherwise they silently truncate the watch window'
+    }
+}

--- a/tools/tests/BehaviorWatchStopPolicyGate.Tests.ps1
+++ b/tools/tests/BehaviorWatchStopPolicyGate.Tests.ps1
@@ -1,17 +1,20 @@
-Describe 'issue #46: behavior-watch + stopAfterValidation cross-field gate' {
+Describe 'issue #46: behavior-watch lifetime cross-field gate' {
     BeforeAll {
         . (Join-Path $PSScriptRoot 'TestHelpers.ps1')
         $script:RequestSchemaPath = 'specs/003-editor-evidence-loop/contracts/automation-run-request.schema.json'
     }
 
-    # The cross-field rule "stopAfterValidation=true requires minRuntimeFrames >=
-    # startFrameOffset + frameCount when behaviorWatchRequest is present" is
-    # enforced inside Godot by behavior_watch_request_validator.normalize_request,
-    # NOT by JSON Schema. These Pester tests assert the schema layer is
-    # intentionally permissive so that the GDScript validator's diagnostic
-    # (failureKind=request-invalid, code=incompatible_stop_policy) is the single
-    # source of truth for this constraint. The actual rejection is exercised by
-    # the live-editor integration tests (see tools/tests/fixtures/issue-46/).
+    # The cross-field rule "minRuntimeFrames >= startFrameOffset + frameCount
+    # when behaviorWatchRequest is present" is enforced inside Godot by
+    # behavior_watch_request_validator.normalize_request, NOT by JSON Schema.
+    # The constraint is independent of stopAfterValidation: the B18 fix in
+    # scenegraph_run_coordinator.gd:295-304 made the post-validation stop
+    # unconditional, so minRuntimeFrames is the only knob that actually grants
+    # the playtest enough frames to fill the watch window. These Pester tests
+    # assert the schema layer is intentionally permissive so that the GDScript
+    # validator's diagnostic (code=incompatible_stop_policy) is the single
+    # source of truth. The actual rejection is exercised by the live-editor
+    # integration tests (see tools/tests/fixtures/issue-46/).
     It 'schema accepts the bad combination (rejection lives in GDScript validator)' {
         $payload = @{
             requestId            = 'issue-46-schema-permissive'
@@ -114,29 +117,37 @@ Describe 'issue #46: behavior-watch + stopAfterValidation cross-field gate' {
                 $obj = $null
                 try { $obj = $raw | ConvertFrom-Json -Depth 20 } catch { return }
                 if ($null -eq $obj) { return }
+                # Resolve behaviorWatchRequest with the same precedence as
+                # _resolve_request in scenegraph_run_coordinator.gd: overrides
+                # take precedence over the top-level request fields.
                 $watch = $null
-                if ($obj.PSObject.Properties['behaviorWatchRequest']) { $watch = $obj.behaviorWatchRequest }
-                elseif ($obj.PSObject.Properties['overrides'] -and $obj.overrides.PSObject.Properties['behaviorWatchRequest']) { $watch = $obj.overrides.behaviorWatchRequest }
+                if ($obj.PSObject.Properties['overrides'] -and $obj.overrides.PSObject.Properties['behaviorWatchRequest']) { $watch = $obj.overrides.behaviorWatchRequest }
+                elseif ($obj.PSObject.Properties['behaviorWatchRequest']) { $watch = $obj.behaviorWatchRequest }
                 if ($null -eq $watch) { return }
                 $frameCount = if ($watch.PSObject.Properties['frameCount']) { [int]$watch.frameCount } else { 0 }
                 if ($frameCount -le 0) { return }
                 $startOffset = if ($watch.PSObject.Properties['startFrameOffset']) { [int]$watch.startFrameOffset } else { 0 }
                 $required = $startOffset + $frameCount
-                $stopAfter = $true
+                # Same precedence for stopPolicy: overrides > top-level. The
+                # coordinator merges nested overrides at scenegraph_run_coordinator.gd:932-940
+                # so the audit must look in both places to match what the
+                # validator will actually see at runtime.
                 $minRuntime = 0
-                if ($obj.PSObject.Properties['stopPolicy']) {
-                    if ($obj.stopPolicy.PSObject.Properties['stopAfterValidation']) { $stopAfter = [bool]$obj.stopPolicy.stopAfterValidation }
-                    if ($obj.stopPolicy.PSObject.Properties['minRuntimeFrames']) { $minRuntime = [int]$obj.stopPolicy.minRuntimeFrames }
+                if ($obj.PSObject.Properties['stopPolicy'] -and $obj.stopPolicy.PSObject.Properties['minRuntimeFrames']) {
+                    $minRuntime = [int]$obj.stopPolicy.minRuntimeFrames
+                }
+                if ($obj.PSObject.Properties['overrides'] -and $obj.overrides.PSObject.Properties['stopPolicy'] -and $obj.overrides.stopPolicy.PSObject.Properties['minRuntimeFrames']) {
+                    $minRuntime = [int]$obj.overrides.stopPolicy.minRuntimeFrames
                 }
                 # The deliberate truncation-repro fixture is the one expected
                 # offender — it exists to demonstrate the rejection diagnostic.
                 if ($_.Name -eq 'truncation-repro-pong.json') { return }
-                if ($stopAfter -and $minRuntime -lt $required) {
-                    $offending.Add(("{0} (required={1}, minRuntimeFrames={2}, stopAfterValidation=true)" -f $_.FullName, $required, $minRuntime))
+                if ($minRuntime -lt $required) {
+                    $offending.Add(("{0} (required={1}, minRuntimeFrames={2})" -f $_.FullName, $required, $minRuntime))
                 }
             }
         }
 
-        $offending | Should -BeNullOrEmpty -Because 'shipped behavior-watch fixtures must either set stopAfterValidation=false OR minRuntimeFrames >= startFrameOffset + frameCount, otherwise they silently truncate the watch window'
+        $offending | Should -BeNullOrEmpty -Because 'shipped behavior-watch fixtures must set minRuntimeFrames >= startFrameOffset + frameCount, otherwise the GDScript validator will reject them at runtime (incompatible_stop_policy) — see the corrected rule in behavior_watch_request_validator.gd'
     }
 }

--- a/tools/tests/fixtures/issue-46/expected-after/full-window-captured-trace-excerpt.jsonl
+++ b/tools/tests/fixtures/issue-46/expected-after/full-window-captured-trace-excerpt.jsonl
@@ -1,0 +1,6 @@
+{"frame":2,"linear_velocity":[374.714324951172,-119.747383117676],"nodePath":"/root/Main/Ball","timestampMs":0}
+{"frame":3,"linear_velocity":[374.089813232422,-119.547805786133],"nodePath":"/root/Main/Ball","timestampMs":13}
+{"frame":4,"linear_velocity":[373.466339111328,-119.348556518555],"nodePath":"/root/Main/Ball","timestampMs":45}
+{"frame":27,"linear_velocity":[378.483428955078,-120.951858520508],"nodePath":"/root/Main/Ball","timestampMs":412}
+{"frame":28,"linear_velocity":[377.852630615234,-120.750274658203],"nodePath":"/root/Main/Ball","timestampMs":429}
+{"frame":29,"linear_velocity":[377.222869873047,-120.549026489258],"nodePath":"/root/Main/Ball","timestampMs":445}

--- a/tools/tests/fixtures/issue-46/expected-after/rejected-envelope.json
+++ b/tools/tests/fixtures/issue-46/expected-after/rejected-envelope.json
@@ -1,0 +1,8 @@
+{
+  "_comment": "Captured 2026-05-02T21:40 against D:/gameDev/pong after applying issue #46 fix. The bad combination (frameCount:30 + stopAfterValidation:true + minRuntimeFrames:0) is now rejected with a diagnostic that names the constraint, the remediation, and the current values. failureKind=runtime because the validator rejection surfaces through the editor's runtime path, not the schema layer.",
+  "status": "failure",
+  "failureKind": "runtime",
+  "diagnostics": [
+    "Behavior watch rejection: incompatible_stop_policy [stopPolicy.minRuntimeFrames] behaviorWatchRequest needs the playtest to live at least 30 frame(s) (startFrameOffset=0 + frameCount=30). Set stopPolicy.minRuntimeFrames>=30 to delay the validation-pass stop until the watch window has filled. Current: minRuntimeFrames=0."
+  ]
+}

--- a/tools/tests/fixtures/issue-46/expected-after/wall-bounce-full-window-trace.jsonl
+++ b/tools/tests/fixtures/issue-46/expected-after/wall-bounce-full-window-trace.jsonl
@@ -1,0 +1,4 @@
+{"collisionState":null,"frame":12,"lastCollider":null,"nodePath":"/root/Main/Ball","position":[477.861480712891,286.195648193359],"timestampMs":141,"velocity":null}
+{"collisionState":null,"frame":13,"lastCollider":null,"nodePath":"/root/Main/Ball","position":[471.814361572266,283.8662109375],"timestampMs":159,"velocity":null}
+{"collisionState":null,"frame":14,"lastCollider":null,"nodePath":"/root/Main/Ball","position":[465.777313232422,281.540649414063],"timestampMs":169,"velocity":null}
+{"collisionState":null,"frame":15,"lastCollider":null,"nodePath":"/root/Main/Ball","position":[459.750335693359,279.218963623047],"timestampMs":187,"velocity":null}

--- a/tools/tests/fixtures/issue-46/expected-before/truncated-trace-and-envelope.md
+++ b/tools/tests/fixtures/issue-46/expected-before/truncated-trace-and-envelope.md
@@ -1,0 +1,30 @@
+# Issue #46 — pre-fix evidence
+
+Captured 2026-05-02T21:28 against `D:/gameDev/pong` using harness commit `26253bc`.
+
+The fixture [truncation-repro-pong.json](../truncation-repro-pong.json) asks for
+`behaviorWatchRequest.frameCount: 30` with `stopPolicy.stopAfterValidation: true`.
+The orchestrator returns `status: success`, but the trace contains only 2 rows —
+the playtest was killed at validation (~frame 5) before the watch's 30-frame
+window could populate.
+
+## Envelope (success)
+
+```json
+{
+  "status": "success",
+  "failureKind": null,
+  "manifestPath": "D:/gameDev/pong/evidence/automation/runbook-behavior-watch-20260502T212837Z-a25d10/evidence-manifest.json",
+  "diagnostics": []
+}
+```
+
+## Trace (2 rows of 30 requested = 7% capture)
+
+```jsonl
+{"frame":1,"linear_velocity":[389.147125244141,-65.9605102539063],"nodePath":"/root/Main/Ball","timestampMs":1}
+{"frame":2,"linear_velocity":[388.49853515625,-65.8505783081055],"nodePath":"/root/Main/Ball","timestampMs":20}
+```
+
+The harness silently agreed that a request for 30 frames was satisfied by 2.
+This is the verification gap the fix closes.

--- a/tools/tests/fixtures/issue-46/full-window-min-runtime-frames-pong.json
+++ b/tools/tests/fixtures/issue-46/full-window-min-runtime-frames-pong.json
@@ -1,7 +1,7 @@
 {
-  "requestId": "issue-47-linear-velocity-pong-FIXTURE",
-  "scenarioId": "issue-47-linear-velocity-watch",
-  "runId": "issue-47-linear-velocity-run",
+  "requestId": "issue-46-full-window-min-runtime-FIXTURE",
+  "scenarioId": "issue-46-full-window-min-runtime",
+  "runId": "issue-46-full-window-min-runtime-run",
   "targetScene": "res://scenes/main.tscn",
   "outputDirectory": "res://evidence/automation/$REQUEST_ID",
   "artifactRoot": "res://evidence/automation/$REQUEST_ID",
@@ -14,7 +14,7 @@
     "stopAfterValidation": true,
     "minRuntimeFrames": 30
   },
-  "requestedBy": "issue-47-repro",
+  "requestedBy": "issue-46-verify",
   "createdAt": "2026-05-02T00:00:00Z",
   "behaviorWatchRequest": {
     "targets": [

--- a/tools/tests/fixtures/issue-46/truncation-repro-pong.json
+++ b/tools/tests/fixtures/issue-46/truncation-repro-pong.json
@@ -1,7 +1,7 @@
 {
-  "requestId": "issue-47-linear-velocity-pong-FIXTURE",
-  "scenarioId": "issue-47-linear-velocity-watch",
-  "runId": "issue-47-linear-velocity-run",
+  "requestId": "issue-46-truncation-repro-FIXTURE",
+  "scenarioId": "issue-46-silent-truncation",
+  "runId": "issue-46-truncation-repro-run",
   "targetScene": "res://scenes/main.tscn",
   "outputDirectory": "res://evidence/automation/$REQUEST_ID",
   "artifactRoot": "res://evidence/automation/$REQUEST_ID",
@@ -11,10 +11,9 @@
     "failure": true
   },
   "stopPolicy": {
-    "stopAfterValidation": true,
-    "minRuntimeFrames": 30
+    "stopAfterValidation": true
   },
-  "requestedBy": "issue-47-repro",
+  "requestedBy": "issue-46-repro",
   "createdAt": "2026-05-02T00:00:00Z",
   "behaviorWatchRequest": {
     "targets": [

--- a/tools/tests/fixtures/issue-47/bogus-property-pong.json
+++ b/tools/tests/fixtures/issue-47/bogus-property-pong.json
@@ -11,7 +11,8 @@
     "failure": true
   },
   "stopPolicy": {
-    "stopAfterValidation": true
+    "stopAfterValidation": true,
+    "minRuntimeFrames": 5
   },
   "requestedBy": "issue-47-error-enrichment",
   "createdAt": "2026-05-02T00:00:00Z",

--- a/tools/tests/fixtures/issue-47/regression-original-props-pong.json
+++ b/tools/tests/fixtures/issue-47/regression-original-props-pong.json
@@ -11,7 +11,8 @@
     "failure": true
   },
   "stopPolicy": {
-    "stopAfterValidation": true
+    "stopAfterValidation": true,
+    "minRuntimeFrames": 30
   },
   "requestedBy": "issue-47-regression",
   "createdAt": "2026-05-02T00:00:00Z",

--- a/tools/tests/fixtures/issue-47/text-watch-pong.json
+++ b/tools/tests/fixtures/issue-47/text-watch-pong.json
@@ -11,7 +11,8 @@
     "failure": true
   },
   "stopPolicy": {
-    "stopAfterValidation": true
+    "stopAfterValidation": true,
+    "minRuntimeFrames": 30
   },
   "requestedBy": "issue-47-repro",
   "createdAt": "2026-05-02T00:00:00Z",

--- a/tools/tests/fixtures/pong-testbed/harness/automation/requests/behavior-watch-wall-bounce.every-frame.json
+++ b/tools/tests/fixtures/pong-testbed/harness/automation/requests/behavior-watch-wall-bounce.every-frame.json
@@ -14,7 +14,8 @@
     "failure": true
   },
   "stopPolicy": {
-    "stopAfterValidation": true
+    "stopAfterValidation": true,
+    "minRuntimeFrames": 16
   },
   "requestedBy": "behavior-watch-fixture",
   "createdAt": "2026-04-14T00:10:00Z",

--- a/tools/tests/fixtures/pong-testbed/harness/automation/requests/behavior-watch-wall-bounce.every-n.json
+++ b/tools/tests/fixtures/pong-testbed/harness/automation/requests/behavior-watch-wall-bounce.every-n.json
@@ -14,7 +14,8 @@
     "failure": true
   },
   "stopPolicy": {
-    "stopAfterValidation": true
+    "stopAfterValidation": true,
+    "minRuntimeFrames": 26
   },
   "requestedBy": "behavior-watch-fixture",
   "createdAt": "2026-04-14T00:11:00Z",

--- a/tools/tests/fixtures/runbook/behavior-watch/label-text-window.json
+++ b/tools/tests/fixtures/runbook/behavior-watch/label-text-window.json
@@ -11,7 +11,8 @@
     "failure": true
   },
   "stopPolicy": {
-    "stopAfterValidation": true
+    "stopAfterValidation": true,
+    "minRuntimeFrames": 10
   },
   "requestedBy": "runbook-fixture",
   "createdAt": "2026-05-02T00:00:00Z",

--- a/tools/tests/fixtures/runbook/behavior-watch/single-property-window.json
+++ b/tools/tests/fixtures/runbook/behavior-watch/single-property-window.json
@@ -11,7 +11,8 @@
     "failure": true
   },
   "stopPolicy": {
-    "stopAfterValidation": true
+    "stopAfterValidation": true,
+    "minRuntimeFrames": 10
   },
   "requestedBy": "runbook-fixture",
   "createdAt": "2026-04-22T00:00:00Z",


### PR DESCRIPTION
## Summary

Closes #46.

- Adds a cross-field check to `BehaviorWatchRequestValidator.normalize_request` that rejects when `stopPolicy.minRuntimeFrames < startFrameOffset + frameCount` whenever a `behaviorWatchRequest` is present.
- The diagnostic (`incompatible_stop_policy`) names the required value, the math (`startFrameOffset + frameCount`), the remediation (`set minRuntimeFrames>=N`), and the current setting — fixture authors don't need to leave the message to fix the request.
- Repairs every shipped/test behavior-watch fixture (8 files) by adding a correct `minRuntimeFrames`. Adds a new Pester test (`BehaviorWatchStopPolicyGate.Tests.ps1`) that scans every shipped fixture and fails if a future author reintroduces the silent-truncation shape.

## Why this matters

Pre-fix, the canonical `stopPolicy: { stopAfterValidation: true }` template combined with any `behaviorWatchRequest.frameCount > ~5` silently truncated the run: the playtest stopped at validation (~frame 5), but the orchestrator returned `status: success` with a manifest pointing at a 2-row trace. Same family of bug as #47 — the harness reports success on a request it didn't honor. The four shipped behavior-watch fixtures (`single-property-window`, both `wall-bounce` variants, `label-text-window`) were all silently truncated; the test that audits this catches any regression.

## Mid-implementation correction

Initial validator wording suggested two remediations: `stopAfterValidation: false` OR `minRuntimeFrames>=N`. The Phase C live-editor verification proved the first knob alone does **not** keep the playtest alive — the B18 fix in `scenegraph_run_coordinator.gd:295-304` made the post-validation stop unconditional regardless of `stopAfterValidation`. The validator + diagnostic + docs were tightened to recommend only `minRuntimeFrames`. This is exactly what the verification phase is for.

## Verified end-to-end against `D:/gameDev/pong`

- Bad combo (`frameCount: 30, minRuntimeFrames: 0`) → rejected with diagnostic naming required value + math + current setting.
- Repaired text-watch fixture (`frameCount: 30, minRuntimeFrames: 30`) → captures **30/30 rows** (was **2/30** pre-fix).
- Repaired wall-bounce fixture (`startFrameOffset: 12, frameCount: 4, minRuntimeFrames: 16`) → captures exactly the requested frames 12-15 (was 0 pre-fix because the playtest stopped before the watch window opened).

Before/after evidence checked in under [tools/tests/fixtures/issue-46/expected-before/](tools/tests/fixtures/issue-46/expected-before/) and [tools/tests/fixtures/issue-46/expected-after/](tools/tests/fixtures/issue-46/expected-after/).

## Test plan

- [x] `pwsh ./tools/check-addon-parse.ps1` — addon parses cleanly
- [x] `pwsh ./tools/tests/run-tool-tests.ps1` — 353/353 Pester tests pass (4 new in `BehaviorWatchStopPolicyGate.Tests.ps1` including the fixture-audit guard)
- [x] Live integration on `D:/gameDev/pong`: rejection diagnostic, full-window capture, wall-bounce regression, all repaired fixtures

🤖 Generated with [Claude Code](https://claude.com/claude-code)