### PR TITLE
fix: targetScene falls back to project main_scene (#43)

### DIFF
--- a/addons/agent_runtime_harness/editor/scenegraph_automation_broker.gd
+++ b/addons/agent_runtime_harness/editor/scenegraph_automation_broker.gd
@@ -304,7 +304,12 @@ func _publish_capability_if_needed(config: Dictionary, capability: Dictionary) -
 
 
 func _collect_build_failure_payload(request: Dictionary, build_failure_phase: String) -> Dictionary:
-	var target_scene := String(request.get("targetScene", ""))
+	# Issue #43: same fallback as evaluate_capability — when targetScene is
+	# empty, fall back to project.godot's main_scene. Without this, a request
+	# that omits targetScene would skip build-diagnostic collection on a
+	# compile/load failure even though we know which scene the harness will
+	# actually launch.
+	var target_scene := resolve_target_scene(request)
 	if target_scene.is_empty():
 		return {}
 

--- a/addons/agent_runtime_harness/editor/scenegraph_automation_broker.gd
+++ b/addons/agent_runtime_harness/editor/scenegraph_automation_broker.gd
@@ -87,9 +87,24 @@ func _on_poll_timer_timeout() -> void:
 	_run_coordinator.start_run(config, request, capability, _config_path)
 
 
+## Issue #43: resolve `targetScene` with fallback to the project's
+## `application/run/main_scene` setting when the source dictionary has an
+## empty `targetScene`. Matches Godot's own launch semantics — whatever scene
+## F5 would launch is what the harness uses by default. Both
+## `evaluate_capability` and the coordinator's run-start blocked-reasons
+## check call this so the fallback is applied uniformly. Only emit
+## `target_scene_missing` when BOTH sources are empty (which is a real
+## misconfiguration worth blocking on).
+static func resolve_target_scene(source: Dictionary) -> String:
+	var target := String(source.get("targetScene", "")).strip_edges()
+	if not target.is_empty():
+		return target
+	return String(ProjectSettings.get_setting("application/run/main_scene", "")).strip_edges()
+
+
 func evaluate_capability(config: Dictionary) -> Dictionary:
 	var blocked_reasons: Array = []
-	var target_scene := String(config.get("targetScene", ""))
+	var target_scene := resolve_target_scene(config)
 	var harness_autoload := String(ProjectSettings.get_setting("autoload/ScenegraphHarness", ""))
 	var launch_control_available := not target_scene.is_empty()
 	var runtime_bridge_available := _bridge != null and not harness_autoload.is_empty()

--- a/addons/agent_runtime_harness/editor/scenegraph_run_coordinator.gd
+++ b/addons/agent_runtime_harness/editor/scenegraph_run_coordinator.gd
@@ -877,7 +877,11 @@ func _collect_blocked_reasons(capability: Dictionary) -> Array:
 		blocked.append("request_id_missing")
 	if String(_active_request.get("runId", "")).is_empty():
 		blocked.append("run_id_missing")
-	if String(_active_request.get("targetScene", "")).is_empty():
+	# Issue #43: consult the broker's helper so the project's
+	# application/run/main_scene falls in when the request is empty. Without
+	# this, capability evaluation could pass (broker uses the fallback) while
+	# run-start re-fails on the same input — they must agree.
+	if ScenegraphAutomationBroker.resolve_target_scene(_active_request).is_empty():
 		blocked.append("target_scene_missing")
 	if _is_playing_scene():
 		# Per Copilot review on PR #42: do NOT reap-on-block here. An

--- a/addons/agent_runtime_harness/editor/scenegraph_run_coordinator.gd
+++ b/addons/agent_runtime_harness/editor/scenegraph_run_coordinator.gd
@@ -929,6 +929,12 @@ func _resolve_request(config: Dictionary, request: Dictionary, capability: Dicti
 		"stopPolicy": base_stop_policy,
 		"requestedBy": String(request.get("requestedBy", "scenegraph_automation_broker")),
 	}
+	# Issue #43: bake the project main_scene fallback into the resolved
+	# targetScene so every downstream consumer (play_custom_scene at line ~110,
+	# the blocked-reasons check, manifest fields) sees the same resolved path.
+	# Without this the capability check passed (broker uses the helper) but
+	# the launch silently passed an empty string to play_custom_scene.
+	resolved["targetScene"] = ScenegraphAutomationBroker.resolve_target_scene(resolved)
 
 	# Arrays and nested dicts still merge layer-by-layer (config -> default_overrides -> request -> overrides).
 	_apply_array_override(resolved, default_overrides, "expectationFiles")

--- a/tools/tests/BrokerTargetSceneFallback.Tests.ps1
+++ b/tools/tests/BrokerTargetSceneFallback.Tests.ps1
@@ -52,4 +52,36 @@ Describe 'issue #43: targetScene falls back to project.godot application/run/mai
         # run-start re-fails (raw check) on the same input.
         $source | Should -Match 'ScenegraphAutomationBroker\.resolve_target_scene\(_active_request\)' -Because 'issue #43: coordinator and broker must use the same fallback path'
     }
+
+    # Copilot PR #58 review caught two additional sites that the initial fix
+    # missed: play_custom_scene (which reads from _active_request and would
+    # have launched with an empty string), and _collect_build_failure_payload
+    # (which would have skipped diagnostic collection for fallback-resolved
+    # requests). The first is fixed by baking the resolution into
+    # _resolve_request so _active_request carries the resolved path; the
+    # second by calling resolve_target_scene directly. These tests guard
+    # against either site reverting to a raw String() extraction.
+    It 'coordinator._resolve_request bakes the fallback into the resolved targetScene' {
+        $coordinatorPath = Get-RepoPath -Path 'addons/agent_runtime_harness/editor/scenegraph_run_coordinator.gd'
+        $source = Get-Content -Raw -LiteralPath $coordinatorPath
+
+        # The resolved dict's targetScene must be normalized through the
+        # helper after the _pick_scalar merge, so play_custom_scene and any
+        # other consumer that reads _active_request.targetScene see the
+        # fallback-resolved value. Without this, capability passes (broker
+        # uses the helper) but the launch passes an empty string.
+        $source | Should -Match 'resolved\["targetScene"\]\s*=\s*ScenegraphAutomationBroker\.resolve_target_scene\(resolved\)' -Because 'issue #43: _resolve_request must bake the fallback into _active_request so play_custom_scene gets the resolved path'
+    }
+
+    It 'broker._collect_build_failure_payload calls resolve_target_scene' {
+        $brokerPath = Get-RepoPath -Path 'addons/agent_runtime_harness/editor/scenegraph_automation_broker.gd'
+        $source = Get-Content -Raw -LiteralPath $brokerPath
+
+        # The build-failure collector takes a request dict directly; without
+        # the fallback, a request that omits targetScene and relies on
+        # application/run/main_scene would skip diagnostic collection on a
+        # compile/load failure, degrading a real build error into a generic
+        # attachment timeout.
+        $source | Should -Match 'func _collect_build_failure_payload\([^)]+\) -> Dictionary:[\s\S]{0,600}var target_scene := resolve_target_scene\(request\)' -Because 'issue #43: _collect_build_failure_payload must use the helper so build diagnostics are collected for fallback-resolved scenes'
+    }
 }

--- a/tools/tests/BrokerTargetSceneFallback.Tests.ps1
+++ b/tools/tests/BrokerTargetSceneFallback.Tests.ps1
@@ -1,0 +1,55 @@
+Describe 'issue #43: targetScene falls back to project.godot application/run/main_scene' {
+    BeforeAll {
+        . (Join-Path $PSScriptRoot 'TestHelpers.ps1')
+    }
+
+    # Issue #43 root cause: harness/inspection-run-config.json shipped with
+    # `targetScene: ""`, and both the broker (capability evaluation) and the
+    # coordinator (run-start check) read that field directly without any
+    # fallback. Result: every harness call returned `target_scene_missing` in
+    # blockedReasons, even when application/run/main_scene was set in
+    # project.godot — costing real onboarding time before being diagnosed.
+    #
+    # The fix introduces `ScenegraphAutomationBroker.resolve_target_scene(source)`
+    # — a static helper that reads `targetScene` from a config or request dict
+    # and falls back to ProjectSettings.get_setting("application/run/main_scene")
+    # when empty. Both check sites consult the helper so the fallback is
+    # applied uniformly. The cryptic `target_scene_missing` diagnostic only
+    # fires when BOTH sources are empty (a real misconfiguration).
+    #
+    # This test statically verifies the source code defines the helper and
+    # both check sites use it. The functional behavior is verified live
+    # against D:/gameDev/pong (see plan and PR description).
+    It 'broker defines the resolve_target_scene helper that consults application/run/main_scene' {
+        $brokerPath = Get-RepoPath -Path 'addons/agent_runtime_harness/editor/scenegraph_automation_broker.gd'
+        Test-Path -LiteralPath $brokerPath | Should -BeTrue
+
+        $source = Get-Content -Raw -LiteralPath $brokerPath
+
+        $source | Should -Match 'static func resolve_target_scene\(' -Because 'issue #43: the broker must expose a static helper that other classes can reuse'
+        $source | Should -Match 'application/run/main_scene' -Because 'issue #43: the helper must consult Godot''s default-scene project setting'
+        $source | Should -Match 'ProjectSettings\.get_setting\(\s*"application/run/main_scene"' -Because 'issue #43: read the setting via ProjectSettings (no string-key typos)'
+    }
+
+    It 'broker.evaluate_capability calls resolve_target_scene (not raw config.get)' {
+        $brokerPath = Get-RepoPath -Path 'addons/agent_runtime_harness/editor/scenegraph_automation_broker.gd'
+        $source = Get-Content -Raw -LiteralPath $brokerPath
+
+        # The fallback is only useful if evaluate_capability actually calls
+        # the helper. A regression that re-introduces the raw String()
+        # extraction would silently re-introduce the bug.
+        $source | Should -Match 'var target_scene := resolve_target_scene\(config\)' -Because 'issue #43: evaluate_capability must use the fallback helper'
+    }
+
+    It 'coordinator.run-start blocked-reasons check calls the broker helper' {
+        $coordinatorPath = Get-RepoPath -Path 'addons/agent_runtime_harness/editor/scenegraph_run_coordinator.gd'
+        Test-Path -LiteralPath $coordinatorPath | Should -BeTrue
+
+        $source = Get-Content -Raw -LiteralPath $coordinatorPath
+
+        # The coordinator's _collect_blocked_reasons must agree with the
+        # broker — without this, capability could pass (fallback applied) but
+        # run-start re-fails (raw check) on the same input.
+        $source | Should -Match 'ScenegraphAutomationBroker\.resolve_target_scene\(_active_request\)' -Because 'issue #43: coordinator and broker must use the same fallback path'
+    }
+}


### PR DESCRIPTION
## Summary

Closes #43.

The `harness/inspection-run-config.json` template ships with `targetScene: ""`. Pre-fix, both the broker (capability evaluation) and the coordinator (run-start check) read that field directly with no fallback, so every harness call returned `target_scene_missing` in `blockedReasons` — even when `application/run/main_scene` was set in `project.godot`. Diagnosing this cost ~5 minutes of editor-restart thrashing during initial setup; the cryptic blocked-reason string gives no hint that the run-config is the problem.

## Fix

Added `ScenegraphAutomationBroker.resolve_target_scene(source)` — a static helper that reads `targetScene` from a config or request dict and falls back to `ProjectSettings.get_setting("application/run/main_scene", "")` when empty. Both check sites consult the helper so the fallback is applied uniformly:

- [scenegraph_automation_broker.gd:107](addons/agent_runtime_harness/editor/scenegraph_automation_broker.gd#L107) (capability evaluation)
- [scenegraph_run_coordinator.gd:884](addons/agent_runtime_harness/editor/scenegraph_run_coordinator.gd#L884) (run-start blocked-reasons check)

The diagnostic string `target_scene_missing` is unchanged — its meaning just becomes "neither config nor project `main_scene` set" instead of "config not set." Matches Godot's own launch semantics: whatever scene F5 would launch is what the harness uses by default.

## Why not the other suggested fixes

- **Option 2** (loud-fail at config-load with hint text): doesn't fix the broken-by-default state, just changes the error wording. With option 1 in place, the only case where `target_scene_missing` should fire is when *both* sources are empty — which is a real misconfiguration worth blocking on.
- **Option 3** (template default `"res://scenes/main.tscn"`): would actively mislead projects whose main scene lives elsewhere. The fallback covers the common case automatically; hardcoding a default in the template trades a no-op for a possibly-wrong path.

## Verified end-to-end against `D:/gameDev/pong`

| Scenario | `targetScene` | `application/run/main_scene` | Pre-fix | Post-fix |
|---|---|---|---|---|
| Reproduction | `""` | set | `target_scene_missing` ❌ | unblocked, scene-inspection captures 28 nodes ✅ |
| Negative case | `""` | absent | `target_scene_missing` ✅ | `target_scene_missing` ✅ (correctly blocks) |

The negative case proves the fallback doesn't silently fabricate a scene — `target_scene_missing` still fires when there's truly nothing configured.

## Test plan

- [x] `pwsh ./tools/check-addon-parse.ps1` — addon parses cleanly
- [x] `pwsh ./tools/tests/run-tool-tests.ps1` — 360/360 Pester tests pass (3 new in `BrokerTargetSceneFallback.Tests.ps1`: helper exists + reads `application/run/main_scene`; broker uses it; coordinator uses it — belt-and-braces against future revert)
- [x] Live integration on `D:/gameDev/pong`: positive (fallback resolves) and negative (block still fires when both empty) verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)