### PR TITLE
fix: split overloaded target_scene_missing into precise codes (#44)

### DIFF
--- a/addons/agent_runtime_harness/editor/scenegraph_automation_broker.gd
+++ b/addons/agent_runtime_harness/editor/scenegraph_automation_broker.gd
@@ -113,8 +113,21 @@ func evaluate_capability(config: Dictionary) -> Dictionary:
 	var validation_available := persistence_available
 	var shutdown_control_available := true
 
+	# Issue #44: split the overloaded `target_scene_missing` into two distinct
+	# codes so the diagnostic tells the agent which kind of misconfiguration
+	# to fix:
+	#   target_scene_unspecified — neither config.targetScene nor
+	#       application/run/main_scene was set
+	#   target_scene_file_not_found — a path is configured but the file does
+	#       not exist on disk (typo / project-rename / fixture error)
+	# Mode 3 from the issue (file exists but failed to load — e.g. attached
+	# script has a parse error) is already cleanly surfaced as
+	# `failureKind="build"` with the actual diagnostic in buildDiagnostics[],
+	# so it does NOT need a separate blocked-reason here.
 	if target_scene.is_empty():
-		blocked_reasons.append("target_scene_missing")
+		blocked_reasons.append("target_scene_unspecified")
+	elif not FileAccess.file_exists(target_scene):
+		blocked_reasons.append("target_scene_file_not_found")
 	if harness_autoload.is_empty():
 		blocked_reasons.append("harness_autoload_missing")
 	if _run_coordinator.is_active():

--- a/addons/agent_runtime_harness/editor/scenegraph_run_coordinator.gd
+++ b/addons/agent_runtime_harness/editor/scenegraph_run_coordinator.gd
@@ -881,8 +881,16 @@ func _collect_blocked_reasons(capability: Dictionary) -> Array:
 	# application/run/main_scene falls in when the request is empty. Without
 	# this, capability evaluation could pass (broker uses the fallback) while
 	# run-start re-fails on the same input — they must agree.
-	if ScenegraphAutomationBroker.resolve_target_scene(_active_request).is_empty():
-		blocked.append("target_scene_missing")
+	# Issue #44: split into target_scene_unspecified vs
+	# target_scene_file_not_found so the diagnostic identifies which kind of
+	# misconfiguration to fix. Must mirror the broker's evaluate_capability
+	# logic exactly so capability and run-start emit the same blocked-reason
+	# for the same input.
+	var resolved_target_scene := ScenegraphAutomationBroker.resolve_target_scene(_active_request)
+	if resolved_target_scene.is_empty():
+		blocked.append("target_scene_unspecified")
+	elif not FileAccess.file_exists(resolved_target_scene):
+		blocked.append("target_scene_file_not_found")
 	if _is_playing_scene():
 		# Per Copilot review on PR #42: do NOT reap-on-block here. An
 		# is_playing_scene() hit can also represent a manually-launched F5

--- a/addons/agent_runtime_harness/editor/scenegraph_run_coordinator.gd
+++ b/addons/agent_runtime_harness/editor/scenegraph_run_coordinator.gd
@@ -870,8 +870,17 @@ func _build_session_context() -> Dictionary:
 
 func _collect_blocked_reasons(capability: Dictionary) -> Array:
 	var blocked: Array = []
+	# Capability is computed from the *config* and may carry stale
+	# target_scene_* reasons (Copilot PR #59 review). Strip any
+	# scene-related reason from the capability-derived list so the
+	# request-side check below is the single source of truth — a request
+	# that overrides targetScene must not be blocked by a stale capability
+	# code computed before the override was applied.
 	for blocked_reason in capability.get("blockedReasons", []):
-		blocked.append(String(blocked_reason))
+		var reason_str := String(blocked_reason)
+		if reason_str == "target_scene_unspecified" or reason_str == "target_scene_file_not_found" or reason_str == "target_scene_missing":
+			continue
+		blocked.append(reason_str)
 
 	if String(_active_request.get("requestId", "")).is_empty():
 		blocked.append("request_id_missing")
@@ -885,7 +894,8 @@ func _collect_blocked_reasons(capability: Dictionary) -> Array:
 	# target_scene_file_not_found so the diagnostic identifies which kind of
 	# misconfiguration to fix. Must mirror the broker's evaluate_capability
 	# logic exactly so capability and run-start emit the same blocked-reason
-	# for the same input.
+	# for the same input. The capability-derived reasons above are filtered
+	# so this re-check on the resolved request is authoritative.
 	var resolved_target_scene := ScenegraphAutomationBroker.resolve_target_scene(_active_request)
 	if resolved_target_scene.is_empty():
 		blocked.append("target_scene_unspecified")

--- a/tools/automation/RunbookOrchestration.psm1
+++ b/tools/automation/RunbookOrchestration.psm1
@@ -730,7 +730,11 @@ function Get-BlockedReasonDiagnostics {
         Array of reason strings from run-result.json blockedReasons.
 
     .PARAMETER TargetScene
-        The targetScene value to interpolate into target_scene_missing hints.
+        The targetScene value to interpolate into target_scene_file_not_found
+        hints (the only code whose hint mentions the path directly). Issue
+        #44 split the older target_scene_missing into target_scene_unspecified
+        + target_scene_file_not_found; the latter is the one that needs the
+        path interpolation.
 
     .OUTPUTS
         [string[]] one hint per reason; falls back to generic text for unmapped reasons.
@@ -742,16 +746,20 @@ function Get-BlockedReasonDiagnostics {
         [string]$TargetScene = ''
     )
 
+    # Issue #44: split target_scene_missing into two precise codes; the old
+    # name remains as a backward-compat alias mapped to the SAME hint as
+    # target_scene_unspecified so out-of-tree emitters still receive identical
+    # remediation guidance (Copilot PR #59 review — keep the user message
+    # identical, not "deprecated alias…").
+    $unspecifiedHint = "No targetScene configured. Set ``targetScene`` in ``harness/inspection-run-config.json`` or ``application/run/main_scene`` in ``project.godot``."
+
     $hints = @{
-        'scene_already_running'      = "A previous playtest is still running. Restart the editor: invoke-stop-editor.ps1 then invoke-launch-editor.ps1."
-        # Issue #44: split target_scene_missing into two precise codes.
-        # The old name remains as a backward-compat alias so any out-of-tree
-        # consumer that still emits it gets a sensible hint.
-        'target_scene_unspecified'   = "No targetScene configured. Set ``targetScene`` in ``harness/inspection-run-config.json`` or ``application/run/main_scene`` in ``project.godot``."
+        'scene_already_running'       = "A previous playtest is still running. Restart the editor: invoke-stop-editor.ps1 then invoke-launch-editor.ps1."
+        'target_scene_unspecified'    = $unspecifiedHint
         'target_scene_file_not_found' = "The configured scene '$TargetScene' does not exist on disk. Check the path or correct any project rename."
-        'target_scene_missing'       = "Deprecated alias for target_scene_unspecified — set ``targetScene`` in ``harness/inspection-run-config.json`` or ``application/run/main_scene`` in ``project.godot``."
-        'harness_autoload_missing'   = "The agent_runtime_harness autoload is not registered. Enable the plugin in Project Settings → Plugins, or add the autoload manually."
-        'run_in_progress'            = "Another harness run is still in flight. Wait for it to complete, or restart the editor: invoke-stop-editor.ps1 then invoke-launch-editor.ps1."
+        'target_scene_missing'        = $unspecifiedHint
+        'harness_autoload_missing'    = "The agent_runtime_harness autoload is not registered. Enable the plugin in Project Settings → Plugins, or add the autoload manually."
+        'run_in_progress'             = "Another harness run is still in flight. Wait for it to complete, or restart the editor: invoke-stop-editor.ps1 then invoke-launch-editor.ps1."
     }
 
     $result = [System.Collections.Generic.List[string]]::new()
@@ -788,8 +796,9 @@ function Get-BlockedRunDiagnostics {
 
     .PARAMETER TargetScene
         Optional targetScene string forwarded to Get-BlockedReasonDiagnostics
-        for the target_scene_missing hint. Empty string is fine when the
-        invoke script does not bind TargetScene as a parameter.
+        for the target_scene_file_not_found hint (the one that interpolates
+        the path). Empty string is fine when the invoke script does not bind
+        TargetScene as a parameter.
     #>
     [CmdletBinding()]
     [OutputType([string])]

--- a/tools/automation/RunbookOrchestration.psm1
+++ b/tools/automation/RunbookOrchestration.psm1
@@ -743,10 +743,15 @@ function Get-BlockedReasonDiagnostics {
     )
 
     $hints = @{
-        'scene_already_running'    = "A previous playtest is still running. Restart the editor: invoke-stop-editor.ps1 then invoke-launch-editor.ps1."
-        'target_scene_missing'     = "Check that targetScene '$TargetScene' exists in the project."
-        'harness_autoload_missing' = "The agent_runtime_harness autoload is not registered. Enable the plugin in Project Settings → Plugins, or add the autoload manually."
-        'run_in_progress'          = "Another harness run is still in flight. Wait for it to complete, or restart the editor: invoke-stop-editor.ps1 then invoke-launch-editor.ps1."
+        'scene_already_running'      = "A previous playtest is still running. Restart the editor: invoke-stop-editor.ps1 then invoke-launch-editor.ps1."
+        # Issue #44: split target_scene_missing into two precise codes.
+        # The old name remains as a backward-compat alias so any out-of-tree
+        # consumer that still emits it gets a sensible hint.
+        'target_scene_unspecified'   = "No targetScene configured. Set ``targetScene`` in ``harness/inspection-run-config.json`` or ``application/run/main_scene`` in ``project.godot``."
+        'target_scene_file_not_found' = "The configured scene '$TargetScene' does not exist on disk. Check the path or correct any project rename."
+        'target_scene_missing'       = "Deprecated alias for target_scene_unspecified — set ``targetScene`` in ``harness/inspection-run-config.json`` or ``application/run/main_scene`` in ``project.godot``."
+        'harness_autoload_missing'   = "The agent_runtime_harness autoload is not registered. Enable the plugin in Project Settings → Plugins, or add the autoload manually."
+        'run_in_progress'            = "Another harness run is still in flight. Wait for it to complete, or restart the editor: invoke-stop-editor.ps1 then invoke-launch-editor.ps1."
     }
 
     $result = [System.Collections.Generic.List[string]]::new()

--- a/tools/tests/BrokerTargetSceneFallback.Tests.ps1
+++ b/tools/tests/BrokerTargetSceneFallback.Tests.ps1
@@ -85,3 +85,70 @@ Describe 'issue #43: targetScene falls back to project.godot application/run/mai
         $source | Should -Match 'func _collect_build_failure_payload\([^)]+\) -> Dictionary:[\s\S]{0,600}var target_scene := resolve_target_scene\(request\)' -Because 'issue #43: _collect_build_failure_payload must use the helper so build diagnostics are collected for fallback-resolved scenes'
     }
 }
+
+Describe 'issue #44: split target_scene_missing into target_scene_unspecified + target_scene_file_not_found' {
+    BeforeAll {
+        . (Join-Path $PSScriptRoot 'TestHelpers.ps1')
+    }
+
+    # Issue #44 root cause: target_scene_missing was overloaded across three
+    # failure modes (unspecified config, file not found, failed to load).
+    # The fix splits the diagnostic at the broker/coordinator layer:
+    #   target_scene_unspecified   — neither config.targetScene nor
+    #       application/run/main_scene was set.
+    #   target_scene_file_not_found — a path is configured but the file
+    #       does not exist on disk.
+    # Mode 3 (file exists but failed to load — e.g. parse error in an
+    # attached script) is already cleanly surfaced as failureKind="build"
+    # with the actual error in buildDiagnostics[], so no separate code
+    # is added at the capability layer for it.
+    #
+    # These tests statically verify the source emits the new codes and uses
+    # FileAccess.file_exists for the existence check. Functional behavior
+    # is verified live against D:/gameDev/pong.
+    It 'broker emits target_scene_unspecified when both sources are empty' {
+        $brokerPath = Get-RepoPath -Path 'addons/agent_runtime_harness/editor/scenegraph_automation_broker.gd'
+        $source = Get-Content -Raw -LiteralPath $brokerPath
+
+        # Two assertions: the new code string appears, and the old name
+        # is NOT used as a primary blocked-reason emission anywhere.
+        # (The old name remains as an alias hint in the PowerShell mapper.)
+        $source | Should -Match 'blocked_reasons\.append\("target_scene_unspecified"\)' -Because 'issue #44: empty-config case must emit the new precise code'
+        $source | Should -Not -Match 'blocked_reasons\.append\("target_scene_missing"\)' -Because 'issue #44: the overloaded code must not be emitted by the broker anymore'
+    }
+
+    It 'broker emits target_scene_file_not_found when the resolved path is missing on disk' {
+        $brokerPath = Get-RepoPath -Path 'addons/agent_runtime_harness/editor/scenegraph_automation_broker.gd'
+        $source = Get-Content -Raw -LiteralPath $brokerPath
+
+        $source | Should -Match 'blocked_reasons\.append\("target_scene_file_not_found"\)' -Because 'issue #44: the broker must surface bad paths via a distinct code'
+        $source | Should -Match 'FileAccess\.file_exists\(target_scene\)' -Because 'issue #44: the existence check must use Godot 4 FileAccess.file_exists'
+    }
+
+    It 'coordinator mirrors the same two-code split' {
+        $coordinatorPath = Get-RepoPath -Path 'addons/agent_runtime_harness/editor/scenegraph_run_coordinator.gd'
+        $source = Get-Content -Raw -LiteralPath $coordinatorPath
+
+        # Coordinator and broker must agree — capability and run-start
+        # checks must emit the same blocked-reason for the same input,
+        # otherwise capability could pass while run-start fails (or vice
+        # versa) on the same misconfiguration.
+        $source | Should -Match 'blocked\.append\("target_scene_unspecified"\)' -Because 'issue #44: coordinator must emit the new unspecified code'
+        $source | Should -Match 'blocked\.append\("target_scene_file_not_found"\)' -Because 'issue #44: coordinator must emit the new file-not-found code'
+        $source | Should -Match 'FileAccess\.file_exists\(resolved_target_scene\)' -Because 'issue #44: coordinator must check existence on the resolved path'
+        $source | Should -Not -Match 'blocked\.append\("target_scene_missing"\)' -Because 'issue #44: the overloaded code must not be emitted by the coordinator anymore'
+    }
+
+    It 'PowerShell hint mapper covers both new codes plus the deprecated alias' {
+        $modulePath = Get-RepoPath -Path 'tools/automation/RunbookOrchestration.psm1'
+        $source = Get-Content -Raw -LiteralPath $modulePath
+
+        # All three keys must be in the hint table so:
+        #  - new code consumers get precise hints
+        #  - any out-of-tree consumer still emitting the old name gets
+        #    a sensible (non-empty) hint via the alias
+        $source | Should -Match "'target_scene_unspecified'" -Because 'issue #44: hint mapper must cover the new unspecified code'
+        $source | Should -Match "'target_scene_file_not_found'" -Because 'issue #44: hint mapper must cover the new file-not-found code'
+        $source | Should -Match "'target_scene_missing'" -Because 'issue #44: keep the deprecated alias mapped so existing emissions still get a usable hint'
+    }
+}

--- a/tools/tests/InvokeRunbookScripts.Tests.ps1
+++ b/tools/tests/InvokeRunbookScripts.Tests.ps1
@@ -1187,9 +1187,25 @@ Describe 'Get-BlockedReasonDiagnostics (F2)' {
         ($hints -join ' ') | Should -Not -Match 'Check that targetScene'
     }
 
-    It 'target_scene_missing maps to targetScene hint with the supplied scene path' {
+    # Issue #44: target_scene_missing was overloaded across "no scene
+    # configured" and "scene file does not exist" — split into two codes.
+    # The old name remains as a backward-compat alias mapping to the
+    # unspecified hint.
+    It 'target_scene_unspecified maps to a hint pointing at the config field' {
+        $hints = Get-BlockedReasonDiagnostics -BlockedReasons @('target_scene_unspecified') -TargetScene ''
+        ($hints -join ' ') | Should -Match 'inspection-run-config'
+        ($hints -join ' ') | Should -Match 'application/run/main_scene'
+    }
+
+    It 'target_scene_file_not_found includes the offending scene path' {
+        $hints = Get-BlockedReasonDiagnostics -BlockedReasons @('target_scene_file_not_found') -TargetScene 'res://scenes/missing.tscn'
+        ($hints -join ' ') | Should -Match 'res://scenes/missing.tscn'
+        ($hints -join ' ') | Should -Match 'does not exist'
+    }
+
+    It 'target_scene_missing (deprecated alias) still maps to a usable hint' {
         $hints = Get-BlockedReasonDiagnostics -BlockedReasons @('target_scene_missing') -TargetScene 'res://scenes/main.tscn'
-        ($hints -join ' ') | Should -Match 'res://scenes/main.tscn'
+        ($hints -join ' ') | Should -Match 'inspection-run-config'
         ($hints -join ' ') | Should -Not -Match 'invoke-stop-editor'
     }
 
@@ -1220,7 +1236,7 @@ Describe 'Get-BlockedReasonDiagnostics (F2)' {
     }
 
     It 'multiple reasons produce one hint each' {
-        $hints = Get-BlockedReasonDiagnostics -BlockedReasons @('scene_already_running', 'target_scene_missing') -TargetScene 'res://x.tscn'
+        $hints = Get-BlockedReasonDiagnostics -BlockedReasons @('scene_already_running', 'target_scene_file_not_found') -TargetScene 'res://x.tscn'
         @($hints).Count | Should -Be 2
         ($hints[0]) | Should -Match 'invoke-stop-editor'
         ($hints[1]) | Should -Match 'res://x.tscn'
@@ -1273,12 +1289,16 @@ Describe 'Get-BlockedRunDiagnostics (B19)' {
 
     It 'returns the diagnostic string for blocked + multi-element blockedReasons' {
         Set-StrictMode -Version Latest
+        # Issue #44: target_scene_missing was split into two precise codes;
+        # use target_scene_file_not_found for the assertion that depends on
+        # the scene path appearing in the hint (the unspecified code points
+        # at the config field, not at the path).
         $rr = [pscustomobject]@{
             finalStatus    = 'blocked'
-            blockedReasons = @('scene_already_running', 'target_scene_missing')
+            blockedReasons = @('scene_already_running', 'target_scene_file_not_found')
         }
         $msg = Get-BlockedRunDiagnostics -RunResult $rr -TargetScene 'res://main.tscn'
-        $msg | Should -Match 'scene_already_running, target_scene_missing'
+        $msg | Should -Match 'scene_already_running, target_scene_file_not_found'
         $msg | Should -Match 'res://main.tscn'
     }
 


### PR DESCRIPTION
## Summary

Closes #44.

The `target_scene_missing` blocked-reason fired for three structurally distinct failures, making diagnosis confusing. This PR splits it into two precise codes at the broker / coordinator layer (mode 3 was already cleanly handled).

## Live verification on `D:/gameDev/pong` (Phase A baseline → Phase C post-fix)

| Mode | Symptom | Pre-fix | Post-fix |
|---|---|---|---|
| 1 — both sources empty | no scene configured anywhere | `target_scene_missing` | `target_scene_unspecified` |
| 2 — `targetScene: "res://scenes/does-not-exist.tscn"` | bad path / typo / project rename | `blockedReasons: []` (no existence check, silent — workflow fails inconsistently) | `target_scene_file_not_found` |
| 3 — script with `signal changed` parse error | scene exists but won't load | `failureKind: "build"` with parse error in `buildDiagnostics[]` | unchanged (already correct) |

Mode 3's existing behavior is intentional — it's already cleanly distinguished and includes the actual parse error. Adding a separate blocked-reason at capability-eval time would require the broker to load the resource on every heartbeat (heavy, no payoff). Documented in the implementation comment.

## What changed

- [`scenegraph_automation_broker.gd:116-128`](addons/agent_runtime_harness/editor/scenegraph_automation_broker.gd#L116-L128) — `evaluate_capability` now emits `target_scene_unspecified` (empty) or `target_scene_file_not_found` (`not FileAccess.file_exists`).
- [`scenegraph_run_coordinator.gd:884-895`](addons/agent_runtime_harness/editor/scenegraph_run_coordinator.gd#L884-L895) — `_collect_blocked_reasons` mirrors the same split. Capability and run-start must agree on the same input.
- [`RunbookOrchestration.psm1`](tools/automation/RunbookOrchestration.psm1) — hint mapper gets two precise hints. `target_scene_missing` stays as a deprecated alias mapping to the unspecified hint (backward compat for any out-of-tree emitter).
- Tests: 4 new `It` blocks in `BrokerTargetSceneFallback.Tests.ps1` (one per code, plus alias coverage); 3 updated tests in `InvokeRunbookScripts.Tests.ps1` that referenced the old name.

## What did NOT change

- The `blockedReasons` schema — confirmed open (no enum) during exploration. No schema migration.
- The build-failure path. Mode 3 stays as `failureKind: "build"`.
- The PowerShell-side fallback in `invoke-runtime-error-triage.ps1` that swaps to `main_scene` when the declared file is missing. Removing it is a separable UX change; out of scope.

## Test plan

- [x] `pwsh ./tools/check-addon-parse.ps1` — addon parses cleanly
- [x] `pwsh ./tools/tests/run-tool-tests.ps1` — 368/368 Pester tests pass (was 362; +4 new gate tests + 3 retargeted)
- [x] Live integration on `D:/gameDev/pong`: mode 1 emits `target_scene_unspecified`; mode 2 emits `target_scene_file_not_found`; mode 3 unchanged `failureKind: "build"` (re-verified)

🤖 Generated with [Claude Code](https://claude.com/claude-code)