### PR TITLE
fix: source behavior-watch envelope from manifest, not request payload (#45)

### DIFF
--- a/tools/automation/invoke-behavior-watch.ps1
+++ b/tools/automation/invoke-behavior-watch.ps1
@@ -234,7 +234,27 @@ if (-not $manifestCheck.Ok) {
     Exit-Failure $kind $manifestCheck.Diagnostic
 }
 
-# Step 9: Build outcome
+# Step 9: Build outcome from the manifest's appliedWatch.outcomes block.
+#
+# Issue #45: previously this script counted rows on disk and synthesized
+# warnings from the request payload's nodePath when the row count was zero.
+# Two compounding bugs made the envelope contradict the manifest:
+#  1. The artifact-kind filter used 'behavior-samples' / 'behavior-trace',
+#     but the runtime emits kind="trace" (per InspectionConstants.
+#     ARTIFACT_KIND_TRACE). The filter never matched, so the row-count
+#     read was skipped and sampleCount always stayed at 0.
+#  2. The zero-row fallback synthesized "target node not found or never
+#     sampled: <nodePath>" from the REQUEST payload — a string that's not
+#     informed by what actually happened at runtime. The watch could have
+#     succeeded fully (manifest's missingTargets: []) and still get a false
+#     missing-target warning.
+#
+# Fix: trust the manifest. appliedWatch.outcomes already has sampleCount,
+# missingTargets, missingProperties, and noSamples — populated by the
+# runtime in scenegraph_artifact_writer.gd:72-79. Source warnings from
+# THERE, not from the request payload. Use the trace file only for
+# frameRangeCovered (which the manifest doesn't carry) and for surfacing
+# the resolved samplesPath.
 $samplesPath       = $null
 $sampleCount       = 0
 $frameRangeCovered = $null
@@ -242,56 +262,75 @@ $warnings          = [System.Collections.Generic.List[string]]::new()
 
 try {
     $manifest = Get-Content -LiteralPath $absManifest -Raw | ConvertFrom-Json -Depth 20
-    $samplesRef = $manifest.artifactRefs | Where-Object { $_.kind -in @('behavior-samples', 'behavior-trace') } | Select-Object -First 1
+
+    # Source-of-truth: appliedWatch.outcomes block (issue #45).
+    $watchOutcomes = $null
+    if ($manifest.PSObject.Properties.Name -contains 'appliedWatch' -and $null -ne $manifest.appliedWatch) {
+        if ($manifest.appliedWatch.PSObject.Properties.Name -contains 'outcomes') {
+            $watchOutcomes = $manifest.appliedWatch.outcomes
+        }
+    }
+    if ($null -ne $watchOutcomes) {
+        if ($watchOutcomes.PSObject.Properties.Name -contains 'sampleCount') {
+            $sampleCount = [int]$watchOutcomes.sampleCount
+        }
+        if ($watchOutcomes.PSObject.Properties.Name -contains 'missingTargets') {
+            foreach ($mt in @($watchOutcomes.missingTargets)) {
+                if (-not [string]::IsNullOrWhiteSpace($mt)) {
+                    $warnings.Add("target node not found or never sampled: $mt")
+                }
+            }
+        }
+        if ($watchOutcomes.PSObject.Properties.Name -contains 'missingProperties') {
+            foreach ($mp in @($watchOutcomes.missingProperties)) {
+                if ($null -eq $mp) { continue }
+                $mpNode = if ($mp.PSObject.Properties.Name -contains 'nodePath') { [string]$mp.nodePath } else { '' }
+                if ([string]::IsNullOrWhiteSpace($mpNode)) { continue }
+                $mpProps = @()
+                if ($mp.PSObject.Properties.Name -contains 'properties') {
+                    $mpProps = @($mp.properties | ForEach-Object { [string]$_ } | Where-Object { -not [string]::IsNullOrWhiteSpace($_) })
+                }
+                $propsList = ($mpProps -join ', ')
+                $warnings.Add("target node '$mpNode' sampled but properties never observed: $propsList")
+            }
+        }
+        $noSamples = $false
+        if ($watchOutcomes.PSObject.Properties.Name -contains 'noSamples') {
+            $noSamples = [bool]$watchOutcomes.noSamples
+        }
+        if ($noSamples -and $warnings.Count -eq 0) {
+            $warnings.Add("no samples produced for the configured frame window")
+        }
+    }
+
+    # Trace artifact: surface samplesPath and derive frameRangeCovered.
+    # Issue #45 fix: filter on the actual emitted kind ('trace'), not the
+    # ghost names that never existed in the runtime.
+    $samplesRef = $manifest.artifactRefs | Where-Object { $_.kind -eq 'trace' } | Select-Object -First 1
     if ($null -ne $samplesRef) {
         $samplesPath = Resolve-RunbookEvidencePath -Path $samplesRef.path -ProjectRoot $resolvedRoot
         if (-not (Test-Path -LiteralPath $samplesPath)) {
-            Exit-Failure 'internal' "behavior samples artifact missing on disk at '$samplesPath'"
+            # Manifest references a trace that's not on disk. If the manifest
+            # also claimed samples, that's a real inconsistency worth surfacing
+            # — don't silently zero it out (which was the pre-fix failure mode).
+            if ($sampleCount -gt 0) {
+                $warnings.Add("manifest claims $sampleCount samples but trace file missing at '$samplesPath'")
+            }
+            $samplesPath = $null
         }
-        $rows = Get-Content -LiteralPath $samplesPath | Where-Object { -not [string]::IsNullOrWhiteSpace($_) } |
-                ForEach-Object { $_ | ConvertFrom-Json -Depth 10 -ErrorAction SilentlyContinue } |
-                Where-Object { $null -ne $_ }
-        $sampleCount = @($rows).Count
-        if ($sampleCount -gt 0) {
-            $frames = @($rows | ForEach-Object { [int]$_.frame } | Sort-Object)
-            $frameRangeCovered = @{ first = $frames[0]; last = $frames[-1] }
+        else {
+            $rows = Get-Content -LiteralPath $samplesPath | Where-Object { -not [string]::IsNullOrWhiteSpace($_) } |
+                    ForEach-Object { $_ | ConvertFrom-Json -Depth 10 -ErrorAction SilentlyContinue } |
+                    Where-Object { $null -ne $_ }
+            if (@($rows).Count -gt 0) {
+                $frames = @($rows | ForEach-Object { [int]$_.frame } | Sort-Object)
+                $frameRangeCovered = @{ first = $frames[0]; last = $frames[-1] }
+            }
         }
     }
 }
 catch {
     Exit-Failure 'internal' "Failed to assemble behavior-watch outcome from manifest: $($_.Exception.Message)"
-}
-
-# B3: zero samples almost always means the target node was not present in the
-# scene at sample time. Surface the watched nodePath(s) from the already-parsed
-# request payload so the user has something actionable to investigate.
-# Reuse $materialized.Payload (a hashtable produced by Resolve-RunbookPayload)
-# instead of re-reading the fixture file -- the file may already have been
-# consumed by the broker, and re-reading via $RequestFixturePath also skips
-# the repo-relative-to-absolute resolution that Resolve-RunbookPayload does.
-if ($sampleCount -eq 0) {
-    try {
-        $payload = $materialized.Payload
-        if ($null -ne $payload -and $payload.ContainsKey('behaviorWatchRequest')) {
-            $bwr = $payload['behaviorWatchRequest']
-            if ($null -ne $bwr -and $bwr -is [hashtable] -and $bwr.ContainsKey('targets')) {
-                foreach ($t in @($bwr['targets'])) {
-                    if ($null -ne $t -and $t -is [hashtable] -and $t.ContainsKey('nodePath')) {
-                        $np = [string]$t['nodePath']
-                        if (-not [string]::IsNullOrWhiteSpace($np)) {
-                            $warnings.Add("target node not found or never sampled: $np")
-                        }
-                    }
-                }
-            }
-        }
-        if ($warnings.Count -eq 0) {
-            $warnings.Add("zero samples captured; check that the watched node exists in the running scene at sample time")
-        }
-    }
-    catch {
-        $warnings.Add("zero samples captured; could not inspect request payload to identify target node ($($_.Exception.Message))")
-    }
 }
 
 # Steps 10-12

--- a/tools/automation/invoke-behavior-watch.ps1
+++ b/tools/automation/invoke-behavior-watch.ps1
@@ -290,6 +290,11 @@ try {
                 if ($mp.PSObject.Properties.Name -contains 'properties') {
                     $mpProps = @($mp.properties | ForEach-Object { [string]$_ } | Where-Object { -not [string]::IsNullOrWhiteSpace($_) })
                 }
+                # Skip the warning when the filtered properties list is empty
+                # (Copilot PR #60 review). An empty list would emit
+                # "... never observed: " with nothing actionable; the
+                # missingTargets warning above already covers that case.
+                if ($mpProps.Count -eq 0) { continue }
                 $propsList = ($mpProps -join ', ')
                 $warnings.Add("target node '$mpNode' sampled but properties never observed: $propsList")
             }
@@ -319,12 +324,28 @@ try {
             $samplesPath = $null
         }
         else {
-            $rows = Get-Content -LiteralPath $samplesPath | Where-Object { -not [string]::IsNullOrWhiteSpace($_) } |
-                    ForEach-Object { $_ | ConvertFrom-Json -Depth 10 -ErrorAction SilentlyContinue } |
-                    Where-Object { $null -ne $_ }
-            if (@($rows).Count -gt 0) {
-                $frames = @($rows | ForEach-Object { [int]$_.frame } | Sort-Object)
-                $frameRangeCovered = @{ first = $frames[0]; last = $frames[-1] }
+            # Stream once and track min/max — avoids materializing $rows and
+            # an O(N log N) sort just to pick first/last (Copilot PR #60).
+            # Note: use the `foreach` statement (parent scope) rather than the
+            # ForEach-Object cmdlet — the latter runs each iteration in a
+            # child scope, so the $minFrame / $maxFrame / $haveAny assignments
+            # would not propagate.
+            $minFrame = [int]::MaxValue
+            $maxFrame = [int]::MinValue
+            $haveAny  = $false
+            foreach ($line in [System.IO.File]::ReadLines($samplesPath)) {
+                if ([string]::IsNullOrWhiteSpace($line)) { continue }
+                $row = $null
+                try { $row = $line | ConvertFrom-Json -Depth 10 -ErrorAction Stop } catch { continue }
+                if ($null -eq $row) { continue }
+                if (-not ($row.PSObject.Properties.Name -contains 'frame')) { continue }
+                $frame = [int]$row.frame
+                if ($frame -lt $minFrame) { $minFrame = $frame }
+                if ($frame -gt $maxFrame) { $maxFrame = $frame }
+                $haveAny = $true
+            }
+            if ($haveAny) {
+                $frameRangeCovered = @{ first = $minFrame; last = $maxFrame }
             }
         }
     }

--- a/tools/tests/BehaviorWatchStopPolicyGate.Tests.ps1
+++ b/tools/tests/BehaviorWatchStopPolicyGate.Tests.ps1
@@ -102,6 +102,7 @@ Describe 'issue #46: behavior-watch lifetime cross-field gate' {
         $fixtureRoots = @(
             (Join-Path $repoRoot 'tools/tests/fixtures/runbook/behavior-watch'),
             (Join-Path $repoRoot 'tools/tests/fixtures/pong-testbed/harness/automation/requests'),
+            (Join-Path $repoRoot 'tools/tests/fixtures/issue-45'),
             (Join-Path $repoRoot 'tools/tests/fixtures/issue-46'),
             (Join-Path $repoRoot 'tools/tests/fixtures/issue-47')
         )

--- a/tools/tests/InvokeRunbookScripts.Tests.ps1
+++ b/tools/tests/InvokeRunbookScripts.Tests.ps1
@@ -1058,6 +1058,57 @@ Describe 'B15: invoke-behavior-watch.ps1 emits a flat warnings array' {
     }
 }
 
+Describe 'issue #45: invoke-behavior-watch envelope agrees with manifest appliedWatch.outcomes' {
+    # Issue #45 root cause: the orchestrator filtered manifest.artifactRefs
+    # for kind in ('behavior-samples', 'behavior-trace'), but the runtime
+    # emits kind='trace' (per InspectionConstants.ARTIFACT_KIND_TRACE). The
+    # filter never matched, sampleCount stayed at 0, and a misleading
+    # "target node not found or never sampled: <nodePath>" warning was
+    # synthesized from the REQUEST payload — making the envelope
+    # consistently contradict the manifest's appliedWatch.outcomes.
+    #
+    # Fix: source warnings + sampleCount from manifest.appliedWatch.outcomes
+    # (the runtime's source of truth) and use 'trace' as the artifact-kind
+    # filter for the samplesPath / frameRangeCovered derivation.
+    #
+    # These tests statically verify the orchestrator now consults the
+    # manifest outcomes block and uses the correct artifact kind. The full
+    # behavioral verification is via the live editor against D:/gameDev/pong
+    # (Phase C of the plan).
+    BeforeAll {
+        $script:WatchScriptText = Get-Content -Raw -LiteralPath (Join-Path $script:RepoRootPath 'tools/automation/invoke-behavior-watch.ps1')
+    }
+
+    It 'orchestrator filters artifactRefs on kind="trace" (the actual emitted kind)' {
+        $script:WatchScriptText | Should -Match "kind\s*-eq\s*'trace'" -Because 'issue #45: the runtime emits kind="trace" (InspectionConstants.ARTIFACT_KIND_TRACE); the filter must match that exact string'
+        # Make sure the dead aliases don't appear inside any active
+        # Where-Object filter expression. (They may still be referenced in a
+        # historical comment for context — that's fine; the regex only matches
+        # filter syntax, not free-form comment text.)
+        $script:WatchScriptText | Should -Not -Match "Where-Object[^|]*'behavior-samples'" -Because 'issue #45: behavior-samples never appeared in the runtime; do not re-introduce as a Where-Object filter'
+        $script:WatchScriptText | Should -Not -Match "Where-Object[^|]*'behavior-trace'" -Because 'issue #45: behavior-trace never appeared in the runtime; do not re-introduce as a Where-Object filter'
+    }
+
+    It 'orchestrator sources sampleCount + warnings from manifest.appliedWatch.outcomes' {
+        # The fix moves the truth from the request-payload-derived synthesis
+        # (which was wrong even when the run succeeded) to the manifest's
+        # outcomes block. These regex assertions catch a regression that
+        # re-introduces the request-payload synthesis path.
+        $script:WatchScriptText | Should -Match 'appliedWatch\.outcomes' -Because 'issue #45: outcome must be sourced from the manifest, not the request payload'
+        $script:WatchScriptText | Should -Match 'watchOutcomes\.missingTargets' -Because 'issue #45: warnings come from missingTargets in the manifest'
+        $script:WatchScriptText | Should -Match 'watchOutcomes\.sampleCount' -Because 'issue #45: sampleCount is the manifest field, not a disk row count'
+    }
+
+    It 'orchestrator no longer synthesizes warnings from the request payload nodePath' {
+        # The pre-fix code iterated $bwr['targets'] from $materialized.Payload
+        # to build warnings — that's what produced the false positives.
+        # Removing this path entirely is the actual fix; keeping it would
+        # silently re-introduce the bug even with the manifest-sourced
+        # warnings in place.
+        $script:WatchScriptText | Should -Not -Match '\$bwr\[''targets''\]' -Because 'issue #45: the request-payload warning synthesis is the source of the false positive; it must not exist'
+    }
+}
+
 Describe 'B16: Get-RunResultValidationDiagnostics surfaces validationResult.notes' {
     # When run-result reports failureKind=validation, validationResult.notes
     # carries the authoritative explanation. The helper extracts those notes

--- a/tools/tests/InvokeRunbookScripts.Tests.ps1
+++ b/tools/tests/InvokeRunbookScripts.Tests.ps1
@@ -1081,12 +1081,11 @@ Describe 'issue #45: invoke-behavior-watch envelope agrees with manifest applied
 
     It 'orchestrator filters artifactRefs on kind="trace" (the actual emitted kind)' {
         $script:WatchScriptText | Should -Match "kind\s*-eq\s*'trace'" -Because 'issue #45: the runtime emits kind="trace" (InspectionConstants.ARTIFACT_KIND_TRACE); the filter must match that exact string'
-        # Make sure the dead aliases don't appear inside any active
-        # Where-Object filter expression. (They may still be referenced in a
-        # historical comment for context — that's fine; the regex only matches
-        # filter syntax, not free-form comment text.)
-        $script:WatchScriptText | Should -Not -Match "Where-Object[^|]*'behavior-samples'" -Because 'issue #45: behavior-samples never appeared in the runtime; do not re-introduce as a Where-Object filter'
-        $script:WatchScriptText | Should -Not -Match "Where-Object[^|]*'behavior-trace'" -Because 'issue #45: behavior-trace never appeared in the runtime; do not re-introduce as a Where-Object filter'
+        # Anchor the dead-alias check on the actual pipeline expression
+        # (artifactRefs | Where-Object …) so commented-out examples in
+        # explanatory text don't make the test flaky. (Copilot PR #60 review.)
+        $script:WatchScriptText | Should -Not -Match "artifactRefs\s*\|\s*Where-Object[^\r\n]*'behavior-samples'" -Because 'issue #45: behavior-samples never appeared in the runtime; do not re-introduce as a Where-Object filter on artifactRefs'
+        $script:WatchScriptText | Should -Not -Match "artifactRefs\s*\|\s*Where-Object[^\r\n]*'behavior-trace'" -Because 'issue #45: behavior-trace never appeared in the runtime; do not re-introduce as a Where-Object filter on artifactRefs'
     }
 
     It 'orchestrator sources sampleCount + warnings from manifest.appliedWatch.outcomes' {

--- a/tools/tests/fixtures/issue-45/missing-target-pong.json
+++ b/tools/tests/fixtures/issue-45/missing-target-pong.json
@@ -1,0 +1,28 @@
+{
+  "requestId": "issue-45-missing-target-FIXTURE",
+  "scenarioId": "issue-45-missing-target",
+  "runId": "issue-45-missing-target-run",
+  "targetScene": "res://scenes/main.tscn",
+  "outputDirectory": "res://evidence/automation/$REQUEST_ID",
+  "artifactRoot": "res://evidence/automation/$REQUEST_ID",
+  "capturePolicy": {
+    "startup": true,
+    "manual": true,
+    "failure": true
+  },
+  "stopPolicy": {
+    "stopAfterValidation": true,
+    "minRuntimeFrames": 30
+  },
+  "requestedBy": "issue-45-negative",
+  "createdAt": "2026-05-02T00:00:00Z",
+  "behaviorWatchRequest": {
+    "targets": [
+      {
+        "nodePath": "/root/Main/DoesNotExist",
+        "properties": ["position"]
+      }
+    ],
+    "frameCount": 30
+  }
+}


### PR DESCRIPTION
## Summary

Closes #45.

`invoke-behavior-watch.ps1` printed `outcome.warnings: ["target node not found or never sampled: /root/Main/PaddleLeft"]` and `outcome.sampleCount: 0` even when the manifest's `appliedWatch.outcomes.missingTargets: []` and `outcomes.sampleCount: 11` (or 108) said the run succeeded. The envelope contradicted the manifest on every behavior-watch run — the same symptom I observed repeatedly during issue 47/52/53 verification work.

## Root cause

Two compounding bugs:

1. **Wrong artifact-kind filter.** The runtime emits trace artifacts with `kind: "trace"` (per [InspectionConstants.ARTIFACT_KIND_TRACE](addons/agent_runtime_harness/shared/inspection_constants.gd#L11) used at [scenegraph_artifact_writer.gd:64](addons/agent_runtime_harness/runtime/scenegraph_artifact_writer.gd#L64)). The orchestrator at line 245 filtered for `('behavior-samples', 'behavior-trace')` — strings that exist nowhere in the runtime. The filter never matched, the trace file was never opened, `sampleCount` stayed 0, and `samplesPath` stayed null.

2. **Request-payload-derived warning synthesis.** When `sampleCount == 0` (which it always was, per #1), lines 272-294 synthesized `"target node not found or never sampled: <nodePath>"` from the **request payload's** nodePath — a string with no relationship to what actually happened at runtime. The watch could have succeeded fully (manifest's `missingTargets: []`) and still get a false missing-target warning.

## Fix

- **Source `sampleCount` and `warnings` from `manifest.appliedWatch.outcomes`** (the runtime's source of truth, populated by [scenegraph_artifact_writer.gd:72-79](addons/agent_runtime_harness/runtime/scenegraph_artifact_writer.gd#L72-L79)). `warnings` now derives from `missingTargets[]`, `missingProperties[]`, and `noSamples` — never from the request payload.
- **Fix the artifact-kind filter to `'trace'`** so `samplesPath` and `frameRangeCovered` populate correctly. Drop the ghost aliases that never appeared in the runtime.
- **Add a real diagnostic for the genuine "manifest claims N samples but trace file missing" case** (was previously silently zeroed by the broken filter).

## Verified end-to-end against `D:/gameDev/pong`

| Scenario | Pre-fix envelope | Post-fix envelope |
|---|---|---|
| `Ball.linear_velocity`, 30-frame window | `sampleCount: 0`, `warnings: [false missing-target]`, `samplesPath: null` | `sampleCount: 10`, `warnings: []`, `samplesPath: <real>`, `frameRangeCovered: {9, 18}` |
| `/root/Main/DoesNotExist` (genuinely missing) | (would have shown the same false synthesis) | `warnings: ["target node not found or never sampled: /root/Main/DoesNotExist", "target node '...' sampled but properties never observed: position"]` — both manifest-sourced |

## Out of scope

- The other invoke scripts (`scene-inspection`, `input-dispatch`, `runtime-error-triage`) don't have this pattern per exploration — they don't synthesize warnings. No change needed there.
- The runtime's manifest writer is correct and unchanged.

## Test plan

- [x] `pwsh ./tools/tests/run-tool-tests.ps1` — 371/371 Pester tests pass (3 new source-grep tests in `InvokeRunbookScripts.Tests.ps1` fence the correct kind filter, the manifest-sourcing, and the absence of the request-payload synthesis path)
- [x] Live integration on `D:/gameDev/pong`: positive case (envelope agrees with manifest) and negative case (real missing target surfaces correct manifest-sourced warning)

🤖 Generated with [Claude Code](https://claude.com/claude-code)