### PR TITLE
docs: CLI-first build-error guidance in runtime-harness template (#51)

### DIFF
--- a/addons/agent_runtime_harness/templates/project_root/CLAUDE.runtime-harness.md
+++ b/addons/agent_runtime_harness/templates/project_root/CLAUDE.runtime-harness.md
@@ -26,6 +26,16 @@ pwsh {{HARNESS_REPO_ROOT}}/tools/automation/invoke-stop-editor.ps1 `
   -ProjectRoot "<absolute path to this project>"
 ```
 
+## Build errors
+
+For build errors, try the CLI first:
+
+- `godot --check-only` — GDScript parse errors
+- `godot --import` — asset import / `.tres` / scene-load errors
+- `godot --headless --quit-after 1` — autoload `_ready` failures
+
+Use `{{HARNESS_REPO_ROOT}}/tools/automation/invoke-build-error-triage.ps1` as a fallback when the CLI doesn't reproduce the error or doesn't surface enough detail (engine crashes, multi-file dependency error threading, structured JSON output for downstream consumption). If you find yourself reaching for it routinely, file an issue describing what the CLI missed.
+
 Parse stdout JSON: `status`, `failureKind`, `manifestPath`, `diagnostics`, `outcome`. On success read `manifestPath`, then the one artifact the manifest references.
 
 Key identifiers: bare Godot names (`ENTER`, `SPACE`, `LEFT`, `RIGHT`, `UP`, `DOWN`, `ESCAPE`) — not `KEY_ENTER`. InputMap actions: `{ "kind": "action", "identifier": "ui_accept", ... }`.

--- a/addons/agent_runtime_harness/templates/project_root/CLAUDE.runtime-harness.md
+++ b/addons/agent_runtime_harness/templates/project_root/CLAUDE.runtime-harness.md
@@ -26,19 +26,19 @@ pwsh {{HARNESS_REPO_ROOT}}/tools/automation/invoke-stop-editor.ps1 `
   -ProjectRoot "<absolute path to this project>"
 ```
 
+Parse stdout JSON: `status`, `failureKind`, `manifestPath`, `diagnostics`, `outcome`. On success read `manifestPath`, then the one artifact the manifest references.
+
+Key identifiers: bare Godot names (`ENTER`, `SPACE`, `LEFT`, `RIGHT`, `UP`, `DOWN`, `ESCAPE`) — not `KEY_ENTER`. InputMap actions: `{ "kind": "action", "identifier": "ui_accept", ... }`.
+
 ## Build errors
 
-For build errors, try the CLI first:
+For build errors, try the CLI first (run from the project root, or pass `--path <project>`):
 
 - `godot --check-only` — GDScript parse errors
 - `godot --import` — asset import / `.tres` / scene-load errors
 - `godot --headless --quit-after 1` — autoload `_ready` failures
 
 Use `{{HARNESS_REPO_ROOT}}/tools/automation/invoke-build-error-triage.ps1` as a fallback when the CLI doesn't reproduce the error or doesn't surface enough detail (engine crashes, multi-file dependency error threading, structured JSON output for downstream consumption). If you find yourself reaching for it routinely, file an issue describing what the CLI missed.
-
-Parse stdout JSON: `status`, `failureKind`, `manifestPath`, `diagnostics`, `outcome`. On success read `manifestPath`, then the one artifact the manifest references.
-
-Key identifiers: bare Godot names (`ENTER`, `SPACE`, `LEFT`, `RIGHT`, `UP`, `DOWN`, `ESCAPE`) — not `KEY_ENTER`. InputMap actions: `{ "kind": "action", "identifier": "ui_accept", ... }`.
 
 ## Do not
 


### PR DESCRIPTION
## Summary

- Adds a new `## Build errors` section to `templates/project_root/CLAUDE.runtime-harness.md` (the file the harness drops into user projects) that recommends three Godot CLI flags first — `godot --check-only`, `godot --import`, `godot --headless --quit-after 1` — and reframes `invoke-build-error-triage.ps1` as a fallback for the narrow scenarios where the CLI falls short (engine crashes, multi-file dependency threading, structured JSON output).
- Closes #51.

## Why

In an end-to-end project session, the one build error encountered (a `signal changed` collision with `Resource.changed`) was diagnosed in seconds with `godot --check-only` from the CLI, and `invoke-build-error-triage.ps1` was never reached for. The template had no build-error guidance at all, so the agent default was "use the harness because that's what's documented" even when a CLI one-liner would be faster and clearer.

## Verification note

The issue describes adding to "the build-error section" — that section didn't exist yet. The template covered scene-inspection, input-dispatch, runtime-error-triage, and stop-editor in the Fast path, with no build-error guidance. This PR creates the section rather than amending one. Scope is intentionally limited to the template; the `godot-debug-build` skill template is left alone since it's a deliberate "user explicitly invoked the harness path" wrapper.

## Test plan

- [x] Pester suite green: `pwsh ./tools/tests/run-tool-tests.ps1` — 371 passed, 0 failed, 9 skipped (non-Windows-only)
- [x] Read modified file end-to-end; heading style matches surrounding `##` headings; `{{HARNESS_REPO_ROOT}}` macro consistent with Fast-path examples

🤖 Generated with [Claude Code](https://claude.com/claude-code)