### PR TITLE
docs: clarify scene-inspection's runtime-tree value (#50)

### DIFF
--- a/addons/agent_runtime_harness/templates/project_root/CLAUDE.runtime-harness.md
+++ b/addons/agent_runtime_harness/templates/project_root/CLAUDE.runtime-harness.md
@@ -32,7 +32,7 @@ Key identifiers: bare Godot names (`ENTER`, `SPACE`, `LEFT`, `RIGHT`, `UP`, `DOW
 
 ## Scene inspection
 
-`invoke-scene-inspection.ps1` captures the running tree, including nodes added at runtime and resolved post-`_ready` properties. For statically-authored scenes you can also read the `.tscn` directly, but only this call shows the live state — runtime-instantiated nodes (pooled enemies, spawned projectiles, runtime-loaded levels), resolved `script_class` on attached scripts, and tree state at a specific moment.
+`invoke-scene-inspection.ps1` captures the running tree, including nodes added at runtime and resolved post-`_ready` properties. For statically-authored scenes you can also read the `.tscn` directly, but only this call shows the live state — runtime-instantiated nodes (pooled enemies, spawned projectiles, runtime-loaded levels), live `processing_state` and group membership, and tree state at a specific moment.
 
 ## Build errors
 

--- a/addons/agent_runtime_harness/templates/project_root/CLAUDE.runtime-harness.md
+++ b/addons/agent_runtime_harness/templates/project_root/CLAUDE.runtime-harness.md
@@ -30,6 +30,10 @@ Parse stdout JSON: `status`, `failureKind`, `manifestPath`, `diagnostics`, `outc
 
 Key identifiers: bare Godot names (`ENTER`, `SPACE`, `LEFT`, `RIGHT`, `UP`, `DOWN`, `ESCAPE`) — not `KEY_ENTER`. InputMap actions: `{ "kind": "action", "identifier": "ui_accept", ... }`.
 
+## Scene inspection
+
+`invoke-scene-inspection.ps1` captures the running tree, including nodes added at runtime and resolved post-`_ready` properties. For statically-authored scenes you can also read the `.tscn` directly, but only this call shows the live state — runtime-instantiated nodes (pooled enemies, spawned projectiles, runtime-loaded levels), resolved `script_class` on attached scripts, and tree state at a specific moment.
+
 ## Build errors
 
 For build errors, try the CLI first (run from the project root, or pass `--path <project>`):


### PR DESCRIPTION
## Summary

- Adds a short `## Scene inspection` subsection to `templates/project_root/CLAUDE.runtime-harness.md` clarifying when scene-inspection adds value over reading `.tscn` directly: runtime-instantiated nodes, resolved `script_class`, and tree state at a specific moment.
- Closes #50.

## Why

In a project with a fully statically-authored scene tree (e.g., a Pong clone), the agent's reflex is "scene-inspection isn't adding much over reading the .tscn file." That's a project-specific accident — Pong has no runtime instantiation. The current template's scene-inspection blurb is just a one-line code comment (`# Scene inspection (no input). -EnsureEditor spawns the editor if needed.`) that doesn't draw the distinction, so an agent biased toward "I can read files" can skip the call and miss real value on projects that *do* instantiate at runtime.

## Approach

Adds a dedicated subsection rather than amending the inline comment, matching the `## Build errors` pattern from #51 — workflows that have a tempting "I can do this another way" alternative get a short subsection that frames when the harness call is the right call. Same scope discipline: only the ambient CLAUDE.md template changes; the `godot-inspect` skill is left alone since it's the explicit "user invoked the harness path" wrapper.

## Test plan

- [x] Read modified file end-to-end; new section sits between Fast-path trailing notes and `## Build errors`; heading style consistent with surrounding `##` headings
- [x] Pester suite green: `pwsh ./tools/tests/run-tool-tests.ps1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)