### PR TITLE
docs: discourage speculative editor restarts (#49)

### DIFF
--- a/addons/agent_runtime_harness/templates/project_root/.github/copilot-instructions.runtime-harness.md
+++ b/addons/agent_runtime_harness/templates/project_root/.github/copilot-instructions.runtime-harness.md
@@ -31,6 +31,7 @@ Key identifiers in `inputDispatchScript` are bare Godot logical names (`ENTER`, 
 - **Do not read prior-run artifacts** (`lifecycle-status.json`, previous run artifacts, or files under `evidence/` not produced by the current run). They describe the past, not what you need to do now.
 - **Do not read addon source** (`addons/agent_runtime_harness/`) to understand the protocol. The prompt file has everything.
 - **Do not vary capture or stop policies speculatively.** Fixture defaults are correct for the common case.
+- **Do not stop and restart the editor speculatively.** `capability.json` reflects current state, and stale editor state is rarely the cause of failures. Read `harness/automation/results/capability.json`, `run-result.json`, or `lifecycle-status.json` first. Restart only when you've confirmed the issue is editor-cached, not config-driven (or when running a CLI tool that needs exclusive project access, e.g. `godot --headless --import`).
 
 ## Routing
 

--- a/addons/agent_runtime_harness/templates/project_root/CLAUDE.runtime-harness.md
+++ b/addons/agent_runtime_harness/templates/project_root/CLAUDE.runtime-harness.md
@@ -51,6 +51,7 @@ Use `{{HARNESS_REPO_ROOT}}/tools/automation/invoke-build-error-triage.ps1` as a 
 - **Do not read prior-run artifacts** to plan a new run — the transient zone is wiped before every invocation.
 - **Do not read addon source** (`addons/agent_runtime_harness/`).
 - **Do not vary capture or stop policies speculatively** — fixture defaults are correct.
+- **Do not stop and restart the editor speculatively.** `capability.json` reflects current state; stale editor state is rarely the cause of failures. Read `harness/automation/results/{capability,run-result,lifecycle-status}.json` first. Restart only when you've confirmed the issue is editor-cached, not config-driven (or when running a CLI tool that needs exclusive project access, e.g. `godot --headless --import`).
 
 ## Subagents
 

--- a/addons/agent_runtime_harness/templates/project_root/CLAUDE.runtime-harness.md
+++ b/addons/agent_runtime_harness/templates/project_root/CLAUDE.runtime-harness.md
@@ -51,7 +51,7 @@ Use `{{HARNESS_REPO_ROOT}}/tools/automation/invoke-build-error-triage.ps1` as a 
 - **Do not read prior-run artifacts** to plan a new run — the transient zone is wiped before every invocation.
 - **Do not read addon source** (`addons/agent_runtime_harness/`).
 - **Do not vary capture or stop policies speculatively** — fixture defaults are correct.
-- **Do not stop and restart the editor speculatively.** `capability.json` reflects current state; stale editor state is rarely the cause of failures. Read `harness/automation/results/{capability,run-result,lifecycle-status}.json` first. Restart only when you've confirmed the issue is editor-cached, not config-driven (or when running a CLI tool that needs exclusive project access, e.g. `godot --headless --import`).
+- **Do not stop and restart the editor speculatively** — `capability.json` reflects current state, and stale editor state is rarely the cause of failures. Read `harness/automation/results/capability.json`, `run-result.json`, or `lifecycle-status.json` first. Restart only when you've confirmed the issue is editor-cached, not config-driven (or when running a CLI tool that needs exclusive project access, e.g. `godot --headless --import`).
 
 ## Subagents
 


### PR DESCRIPTION
## Summary

- Adds a sixth bullet to the "Do not" list in `templates/project_root/CLAUDE.runtime-harness.md` discouraging speculative editor restarts. Points at the three live broker artifacts (`capability.json`, `run-result.json`, `lifecycle-status.json`) to read first, and carves out the legitimate restart cases.
- Closes #49.

## Why

In an early debugging session the maintainer stopped and restarted the editor four times in five minutes; only one restart was actually necessary (a CLI `--import` call needing exclusive access). The other three were reflexive "let me start fresh" moves while confused by a `target_scene_missing` diagnostic. The harness broker re-evaluates `capability.json` every ~0.5s and reflects current project state in real time, so editor-cached state is rarely the cause of failures — but the template didn't say so explicitly, leaving the universal dev reflex as the agent's fallback.

## Verification

The issue's load-bearing claims all check out against the implementation:
- `capability.json` is rewritten on a 0.5s poll ([scenegraph_automation_broker.gd:53, 65-72](https://github.com/RJAudas/godot-agent-harness/blob/master/addons/agent_runtime_harness/editor/scenegraph_automation_broker.gd#L53)) reading `application/run/main_scene` directly each time, with a 30s heartbeat fallback.
- All three named files exist at exactly `harness/automation/results/{capability,run-result,lifecycle-status}.json` ([scenegraph_automation_artifact_store.gd:81-91](https://github.com/RJAudas/godot-agent-harness/blob/master/addons/agent_runtime_harness/editor/scenegraph_automation_artifact_store.gd#L81-L91)).
- No duplicate guidance exists in the template tree.

## Test plan

- [x] Read modified file end-to-end; new bullet sits at the bottom of the `## Do not` list with the bold-lead + em-dash pattern of the surrounding bullets.
- [x] Pester suite green: `pwsh ./tools/tests/run-tool-tests.ps1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)