### PR TITLE
docs: common-failure-modes crib sheet (#48)

### DIFF
--- a/addons/agent_runtime_harness/templates/project_root/.github/copilot-instructions.runtime-harness.md
+++ b/addons/agent_runtime_harness/templates/project_root/.github/copilot-instructions.runtime-harness.md
@@ -54,4 +54,17 @@ Key identifiers in `inputDispatchScript` are bare Godot logical names (`ENTER`, 
 | `runtime` | Runtime error captured | Read `outcome.latestErrorSummary` or `outcome.firstFailureSummary` |
 | `timeout` | Run did not complete | Broker only runs while game is in play mode |
 
+## Common failure modes
+
+The diagnostics are usually self-explanatory; this table is for recognising the recurring ones on sight.
+
+| Symptom | Root cause | Fix |
+|---|---|---|
+| `target_scene_unspecified` blocked-reason | Neither `targetScene` (in `inspection-run-config.json`) nor `application/run/main_scene` (in `project.godot`) is set | Set one of them to a `res://` path |
+| `target_scene_file_not_found` blocked-reason | The configured path doesn't exist on disk | Fix the path; the diagnostic names the offending file |
+| `failureKind: "build"` instead of a scene-load failure | The target scene exists but its scripts have parse errors | Report `diagnostics[0]` verbatim; the build phase didn't complete |
+| `incompatible_stop_policy` validation rejection | `behaviorWatchRequest` paired with `stopAfterValidation: true` — validation passes before the frame window fills | The diagnostic spells out the exact `stopPolicy.minRuntimeFrames` value to set |
+| Schema rejection: "Behavior watch property '…' is not in the supported allowlist" | Property name not in the watch allowlist | The diagnostic enumerates allowed values inline; pick one or expand the schema if you have a real need |
+| Invoke-script stdout warnings with `status: pass` in the manifest | Manifest's `outcomes` is the source of truth; the warnings flag a non-fatal disconnect (e.g., trace artifact missing) | Trust the manifest |
+
 Report harness bugs or automation-contract defects at <https://github.com/RJAudas/godot-agent-harness/issues>.

--- a/addons/agent_runtime_harness/templates/project_root/.github/copilot-instructions.runtime-harness.md
+++ b/addons/agent_runtime_harness/templates/project_root/.github/copilot-instructions.runtime-harness.md
@@ -63,8 +63,8 @@ The diagnostics are usually self-explanatory; this table is for recognising the 
 | `target_scene_unspecified` blocked-reason | Neither `targetScene` (in `inspection-run-config.json`) nor `application/run/main_scene` (in `project.godot`) is set | Set one of them to a `res://` path |
 | `target_scene_file_not_found` blocked-reason | The configured path doesn't exist on disk | Fix the path; the diagnostic names the offending file |
 | `failureKind: "build"` instead of a scene-load failure | The target scene exists but its scripts have parse errors | Report `diagnostics[0]` verbatim; the build phase didn't complete |
-| `incompatible_stop_policy` validation rejection | `behaviorWatchRequest` paired with `stopAfterValidation: true` — validation passes before the frame window fills | The diagnostic spells out the exact `stopPolicy.minRuntimeFrames` value to set |
-| Schema rejection: "Behavior watch property '…' is not in the supported allowlist" | Property name not in the watch allowlist | The diagnostic enumerates allowed values inline; pick one or expand the schema if you have a real need |
+| `incompatible_stop_policy` validation rejection | `behaviorWatchRequest`'s `frameCount` exceeds `stopPolicy.minRuntimeFrames` (the playtest would stop before the watch window fills) | The diagnostic spells out the exact `stopPolicy.minRuntimeFrames` value to set |
+| `unsupported_property` validation rejection: "Behavior watch property '…' is not in the supported allowlist" | Property name not in the watch allowlist (defined in both `automation-run-request.schema.json` and the runtime `BehaviorWatchRequestValidator`) | The diagnostic enumerates allowed values inline; pick one or expand the allowlist (schema + validator) if you have a real need |
 | Invoke-script stdout warnings with `status: pass` in the manifest | Manifest's `outcomes` is the source of truth; the warnings flag a non-fatal disconnect (e.g., trace artifact missing) | Trust the manifest |
 
 Report harness bugs or automation-contract defects at <https://github.com/RJAudas/godot-agent-harness/issues>.

--- a/addons/agent_runtime_harness/templates/project_root/CLAUDE.runtime-harness.md
+++ b/addons/agent_runtime_harness/templates/project_root/CLAUDE.runtime-harness.md
@@ -26,7 +26,7 @@ pwsh {{HARNESS_REPO_ROOT}}/tools/automation/invoke-stop-editor.ps1 `
   -ProjectRoot "<absolute path to this project>"
 ```
 
-Parse stdout JSON: `status`, `failureKind`, `manifestPath`, `diagnostics`, `outcome`. On success read `manifestPath`, then the one artifact the manifest references.
+Parse stdout JSON: `status`, `failureKind`, `manifestPath`, `diagnostics`, `outcome`. On success read `manifestPath`, then the one artifact the manifest references. On failure, read `diagnostics[0]` first; see **Common failure modes** below for symptom-to-fix mappings on the recurring ones.
 
 Key identifiers: bare Godot names (`ENTER`, `SPACE`, `LEFT`, `RIGHT`, `UP`, `DOWN`, `ESCAPE`) — not `KEY_ENTER`. InputMap actions: `{ "kind": "action", "identifier": "ui_accept", ... }`.
 
@@ -43,6 +43,19 @@ For build errors, try the CLI first (run from the project root, or pass `--path 
 - `godot --headless --quit-after 1` — autoload `_ready` failures
 
 Use `{{HARNESS_REPO_ROOT}}/tools/automation/invoke-build-error-triage.ps1` as a fallback when the CLI doesn't reproduce the error or doesn't surface enough detail (engine crashes, multi-file dependency error threading, structured JSON output for downstream consumption). If you find yourself reaching for it routinely, file an issue describing what the CLI missed.
+
+## Common failure modes
+
+The diagnostics are usually self-explanatory; this table is for recognising the recurring ones on sight.
+
+| Symptom | Root cause | Fix |
+|---|---|---|
+| `target_scene_unspecified` blocked-reason | Neither `targetScene` (in `inspection-run-config.json`) nor `application/run/main_scene` (in `project.godot`) is set | Set one of them to a `res://` path |
+| `target_scene_file_not_found` blocked-reason | The configured path doesn't exist on disk | Fix the path; the diagnostic names the offending file |
+| `failureKind: "build"` instead of a scene-load failure | The target scene exists but its scripts have parse errors | See **Build errors** above |
+| `incompatible_stop_policy` validation rejection | `behaviorWatchRequest` paired with `stopAfterValidation: true` — validation passes before the frame window fills | The diagnostic spells out the exact `stopPolicy.minRuntimeFrames` value to set |
+| Schema rejection: "Behavior watch property '…' is not in the supported allowlist" | Property name not in the watch allowlist | The diagnostic enumerates allowed values inline; pick one or expand the schema if you have a real need |
+| Invoke-script stdout warnings with `status: pass` in the manifest | Manifest's `outcomes` is the source of truth; the warnings flag a non-fatal disconnect (e.g., trace artifact missing) | Trust the manifest |
 
 ## Do not
 

--- a/addons/agent_runtime_harness/templates/project_root/CLAUDE.runtime-harness.md
+++ b/addons/agent_runtime_harness/templates/project_root/CLAUDE.runtime-harness.md
@@ -53,8 +53,8 @@ The diagnostics are usually self-explanatory; this table is for recognising the 
 | `target_scene_unspecified` blocked-reason | Neither `targetScene` (in `inspection-run-config.json`) nor `application/run/main_scene` (in `project.godot`) is set | Set one of them to a `res://` path |
 | `target_scene_file_not_found` blocked-reason | The configured path doesn't exist on disk | Fix the path; the diagnostic names the offending file |
 | `failureKind: "build"` instead of a scene-load failure | The target scene exists but its scripts have parse errors | See **Build errors** above |
-| `incompatible_stop_policy` validation rejection | `behaviorWatchRequest` paired with `stopAfterValidation: true` — validation passes before the frame window fills | The diagnostic spells out the exact `stopPolicy.minRuntimeFrames` value to set |
-| Schema rejection: "Behavior watch property '…' is not in the supported allowlist" | Property name not in the watch allowlist | The diagnostic enumerates allowed values inline; pick one or expand the schema if you have a real need |
+| `incompatible_stop_policy` validation rejection | `behaviorWatchRequest`'s `frameCount` exceeds `stopPolicy.minRuntimeFrames` (the playtest would stop before the watch window fills) | The diagnostic spells out the exact `stopPolicy.minRuntimeFrames` value to set |
+| `unsupported_property` validation rejection: "Behavior watch property '…' is not in the supported allowlist" | Property name not in the watch allowlist (defined in both `automation-run-request.schema.json` and the runtime `BehaviorWatchRequestValidator`) | The diagnostic enumerates allowed values inline; pick one or expand the allowlist (schema + validator) if you have a real need |
 | Invoke-script stdout warnings with `status: pass` in the manifest | Manifest's `outcomes` is the source of truth; the warnings flag a non-fatal disconnect (e.g., trace artifact missing) | Trust the manifest |
 
 ## Do not


### PR DESCRIPTION
## Summary

- Adds a new `## Common failure modes` section to both runtime-harness templates (`CLAUDE.runtime-harness.md` and `.github/copilot-instructions.runtime-harness.md`) mapping six recurring symptoms to root cause and one-line fix.
- Extends the existing "Parse stdout JSON..." line in the CLAUDE template to point at the new section on failure.
- Closes #48.

## Why

Issue #48 reports that when a harness call returns blocked, the natural reflex is to restart the editor instead of reading the diagnostic. The four bug-fixes referenced by the issue (#43-#47) have all shipped, so most diagnostics are now self-explanatory — but a quick symptom→cause→fix table accelerates recognition and cross-links into the existing workflow sections (`## Build errors` for the scripts-failed-to-compile case, etc.).

## Approach

The crib sheet describes **current behavior** (post-fix), not the historical bugs. Six rows covering the four families from the issue plus the disambiguation that the bug-fixes introduced:
- `target_scene_unspecified` and `target_scene_file_not_found` (the two codes #44 split into)
- `failureKind: "build"` for the third "scene file fails to compile" case (now routes to build error handling instead of being a blocked-reason)
- `incompatible_stop_policy` from the #46 fix (validator rejects with a self-explanatory diagnostic)
- Schema rejection for unsupported watch properties (#47's enumerated allowlist)
- The stdout-warnings-with-pass case from #45

Both templates get the new section. The "build failure" row reads slightly differently between them because the CLAUDE template has a `## Build errors` subsection to cross-reference; the Copilot template doesn't.

## Test plan

- [x] Read both modified files end-to-end; new section sits in a sensible spot in each (between `## Build errors` and `## Do not` in CLAUDE; after `## Failure handling` table in Copilot)
- [x] Pester suite green: `pwsh ./tools/tests/run-tool-tests.ps1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)