### PR TITLE
docs: static-first verification guidance for runtime-harness templates (#68)

### DIFF
--- a/addons/agent_runtime_harness/templates/project_root/AGENTS.runtime-harness.md
+++ b/addons/agent_runtime_harness/templates/project_root/AGENTS.runtime-harness.md
@@ -24,6 +24,8 @@ Match verification depth to how much of the fix's correctness is provable from t
 
 When runtime *is* the right tool, run the **smallest reproduction that yields the evidence you need** — a single scene inspection, one keypress, a short watch window. A full-level playthrough or a perfectly-timed input sequence is the wrong tool when a focused observation would settle the question.
 
+If the user explicitly asks to run the game, dispatch input, or verify at runtime, follow that — this default governs the agent's *own* verification choices after a fix, not user-directed runtime work.
+
 This default is calibrated for current model strength. As model capability and harness features evolve, the static/runtime threshold may move; keeping the rule visible here lets it be retuned without rewriting the template.
 
 ## Fast path — one invoke script call

--- a/addons/agent_runtime_harness/templates/project_root/AGENTS.runtime-harness.md
+++ b/addons/agent_runtime_harness/templates/project_root/AGENTS.runtime-harness.md
@@ -2,6 +2,30 @@
 
 This project has the `agent_runtime_harness` addon installed. When the user asks to run the game, press keys, verify at runtime, inspect the scene, or watch for errors, use the Scenegraph Harness. The full prompt is at [`.github/prompts/godot-runtime-verification.prompt.md`](.github/prompts/godot-runtime-verification.prompt.md); the matching subagent for Claude Code is at [`.claude/agents/godot-runtime-verification.md`](.claude/agents/godot-runtime-verification.md).
 
+## Static-first verification
+
+Match verification depth to how much of the fix's correctness is provable from the diff alone, not to the fact that it's a fix. Default to static; reach for runtime tools only when static is insufficient.
+
+**Static reading is sufficient when:**
+
+- Every claim the fix makes is visible in the change itself.
+- A **known-good sibling** in the same file shows what "right" looks like — e.g. four platforms with `collision_layer = 1` make the fifth's `0 → 1` self-evident. The working siblings *are* the verification.
+- The change is structural (rename, refactor) with no behavioral effect.
+- An experienced engineer would approve the PR without running it.
+
+**Runtime verification is appropriate when** the fix's correctness depends on emergent behavior the diff cannot prove:
+
+- **Timing** — frame ordering, signal cascades, race conditions.
+- **Async** — callback ordering, awaited operations, concurrent state.
+- **Physics tuning** — feel parameters whose right value can only be felt by playing.
+- **Integration glue** — cross-system behavior (pause + animation, save + state).
+- **Visual / performance** — anything where "does it look right" or "does it run fast enough" is the criterion.
+- The first fix attempt didn't land and observation is needed to redirect.
+
+When runtime *is* the right tool, run the **smallest reproduction that yields the evidence you need** — a single scene inspection, one keypress, a short watch window. A full-level playthrough or a perfectly-timed input sequence is the wrong tool when a focused observation would settle the question.
+
+This default is calibrated for current model strength. As model capability and harness features evolve, the static/runtime threshold may move; keeping the rule visible here lets it be retuned without rewriting the template.
+
 ## Fast path — one invoke script call
 
 Use a harness invoke script — it handles capability check, request authoring, polling, and manifest lookup automatically and emits a single JSON envelope to stdout. `-ProjectRoot` is the absolute path to this game project.
@@ -43,6 +67,8 @@ Key identifiers in `inputDispatchScript` are bare Godot logical names — `ENTER
 - **Do not read prior-run artifacts to plan a new run.** The transient zone is wiped before each invocation; any file you read there belongs to the current run or is stale.
 - **Do not read addon source** (`addons/agent_runtime_harness/`) to understand the protocol. Everything you need is in this file and the runtime-verification prompt.
 - **Do not vary `capturePolicy` or `stopPolicy` speculatively.** Fixture defaults are correct for the common case.
+- **Do not invoke runtime tools to confirm a fix you already have high static confidence in.** When the diff alone settles the question — or when a known-good sibling in the same file shows what "right" looks like — declare done. See **Static-first verification** above.
+- **Do not orchestrate elaborate runtime scenarios** (full-level playthroughs, perfectly-timed jump sequences) **when a focused observation would settle the question.** Run the smallest reproduction that yields the evidence you need.
 
 ## Routing
 

--- a/addons/agent_runtime_harness/templates/project_root/CLAUDE.runtime-harness.md
+++ b/addons/agent_runtime_harness/templates/project_root/CLAUDE.runtime-harness.md
@@ -24,6 +24,8 @@ Match verification depth to how much of the fix's correctness is provable from t
 
 When runtime *is* the right tool, run the **smallest reproduction that yields the evidence you need** — a single scene inspection, one keypress, a short watch window. A full-level playthrough or a perfectly-timed input sequence is the wrong tool when a focused observation would settle the question.
 
+If the user explicitly asks to run the game, dispatch input, or verify at runtime, follow that — this default governs the agent's *own* verification choices after a fix, not user-directed runtime work.
+
 This default is calibrated for current model strength. As model capability and harness features evolve, the static/runtime threshold may move; keeping the rule visible here lets it be retuned without rewriting the template.
 
 ## Fast path — one invoke script, one envelope

--- a/addons/agent_runtime_harness/templates/project_root/CLAUDE.runtime-harness.md
+++ b/addons/agent_runtime_harness/templates/project_root/CLAUDE.runtime-harness.md
@@ -2,6 +2,30 @@
 
 This project has the `agent_runtime_harness` addon installed. When the user asks to run the game, press keys, verify at runtime, inspect the scene, or watch for errors, delegate to the `godot-runtime-verification` subagent (`.claude/agents/godot-runtime-verification.md`) or follow the fast path below directly.
 
+## Static-first verification
+
+Match verification depth to how much of the fix's correctness is provable from the diff alone, not to the fact that it's a fix. Default to static; reach for runtime tools only when static is insufficient.
+
+**Static reading is sufficient when:**
+
+- Every claim the fix makes is visible in the change itself.
+- A **known-good sibling** in the same file shows what "right" looks like — e.g. four platforms with `collision_layer = 1` make the fifth's `0 → 1` self-evident. The working siblings *are* the verification.
+- The change is structural (rename, refactor) with no behavioral effect.
+- An experienced engineer would approve the PR without running it.
+
+**Runtime verification is appropriate when** the fix's correctness depends on emergent behavior the diff cannot prove:
+
+- **Timing** — frame ordering, signal cascades, race conditions.
+- **Async** — callback ordering, awaited operations, concurrent state.
+- **Physics tuning** — feel parameters whose right value can only be felt by playing.
+- **Integration glue** — cross-system behavior (pause + animation, save + state).
+- **Visual / performance** — anything where "does it look right" or "does it run fast enough" is the criterion.
+- The first fix attempt didn't land and observation is needed to redirect.
+
+When runtime *is* the right tool, run the **smallest reproduction that yields the evidence you need** — a single scene inspection, one keypress, a short watch window. A full-level playthrough or a perfectly-timed input sequence is the wrong tool when a focused observation would settle the question.
+
+This default is calibrated for current model strength. As model capability and harness features evolve, the static/runtime threshold may move; keeping the rule visible here lets it be retuned without rewriting the template.
+
 ## Fast path — one invoke script, one envelope
 
 The runtime invokers all assume a Godot editor is running against the project. Pass `-EnsureEditor` to have them auto-launch one (idempotent: reuses an existing editor when capability.json is fresh).
@@ -65,6 +89,8 @@ The diagnostics are usually self-explanatory; this table is for recognising the 
 - **Do not read addon source** (`addons/agent_runtime_harness/`).
 - **Do not vary capture or stop policies speculatively** — fixture defaults are correct.
 - **Do not stop and restart the editor speculatively** — `capability.json` reflects current state, and stale editor state is rarely the cause of failures. Read `harness/automation/results/capability.json`, `run-result.json`, or `lifecycle-status.json` first. Restart only when you've confirmed the issue is editor-cached, not config-driven (or when running a CLI tool that needs exclusive project access, e.g. `godot --headless --import`).
+- **Do not invoke runtime tools to confirm a fix you already have high static confidence in.** Re-reading the diff is the verification when every claim it makes is visible there or when a known-good sibling in the same file proves the target shape. See **Static-first verification** above.
+- **Do not orchestrate elaborate runtime scenarios** (full-level playthroughs, perfectly-timed jump sequences) **when a focused observation would settle the question.** Run the smallest reproduction that yields the evidence you need.
 
 ## Subagents
 


### PR DESCRIPTION
## Summary

- Adds a new **Static-first verification** section to both `CLAUDE.runtime-harness.md` and `AGENTS.runtime-harness.md` templates, immediately below the existing "verify at runtime → delegate to harness" routing line. Encodes the ambiguity axis from #68 (match verification depth to how much of the fix's correctness is provable from the diff alone, not to the fact that it's a fix), names the known-good-sibling pattern, and lists the five runtime-appropriate categories (timing, async, physics tuning, integration glue, visual / performance).
- Adds two new "Do not" bullets to each file: one against invoking runtime tools to confirm a fix that static reading already settled (the issue's primary failure mode), and one against orchestrating elaborate runtime scenarios — full-level playthroughs, perfectly-timed jump sequences — when a focused observation would do.
- Includes a one-paragraph rationale (the issue's nice-to-have AC #7) noting the static-first default is calibrated for current model strength; future maintainers can retune the threshold without rewriting the template.

No new capability; runtime tools remain available and recommended for cases that genuinely need them. Markdown-only change to the deployed templates — downstream projects pick up the new sections on next deploy via the editor dock's "Deploy Agent Assets" action or `tools/deploy-game-harness.ps1`. The repo's own root `CLAUDE.md` / `AGENTS.md` are intentionally left unchanged, matching the issue's stated scope.

Acceptance criteria from #68:
- AC1 (ambiguity-axis language) ✓ — line 7 of each file
- AC2 (known-good-sibling pattern named) ✓ — line 12 with the `collision_layer` example
- AC3 (five runtime categories named) ✓ — lines 18–22
- AC4 (agent will not over-verify trivial fixes) ✓ — gated by static-sufficient list + Do-not bullet; behavioral check noted in test plan
- AC5 (no capability lost) ✓ — runtime path preserved at lines 16–23
- AC6 (Do-not bullet for static-confidence case) ✓ — appended to each file's "Do not" list
- AC7 (rationale paragraph, nice-to-have) ✓ — line 27

Closes #68.

## Test plan

- [ ] Re-run the platformer experiment described in #68 (or a near equivalent: any one-line config-mismatch bug with a known-good sibling). Confirm the harness-equipped agent declares done after the static fix without invoking any `invoke-*.ps1` runtime script — wall-clock should match the vanilla-agent baseline.
- [ ] In the same sandbox, plant a bug whose symptom genuinely requires runtime observation (a feel/timing tuning, an animation playback issue, an integration glue bug). Confirm the agent still reaches for the runtime invoke scripts. The new guidance must not over-correct.
- [ ] Mechanical: deploy the updated templates into a fresh `integration-testing/` sandbox via `tools/deploy-game-harness.ps1` and confirm both new sections render correctly in the deployed copies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)